### PR TITLE
Initialize CMake build and stub core engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+project(MediaPlayer VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(src/core)
+
+add_executable(mediaplayer src/main.cpp)
+
+target_link_libraries(mediaplayer PRIVATE mediaplayer_core)
+
+target_compile_features(mediaplayer PRIVATE cxx_std_17)

--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -4,9 +4,9 @@
 
 | # | Task | Status |
 |-:|------|--------|
-| 1 | Initialize Core Engine Project Structure | open |
-| 2 | Define Core Engine API (Header) | open |
-| 3 | Stub Implementation of Core Classes | open |
+| 1 | Initialize Core Engine Project Structure | done |
+| 2 | Define Core Engine API (Header) | done |
+| 3 | Stub Implementation of Core Classes | done |
 | 4 | Build & Integration CI Setup | open |
 | 5 | Integrate FFmpeg for Demuxing | open |
 | 6 | Implement Audio Decoding (FFmpeg) | open |

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(mediaplayer_core
+    src/MediaPlayer.cpp
+)
+
+target_include_directories(mediaplayer_core PUBLIC include)
+
+target_compile_features(mediaplayer_core PUBLIC cxx_std_17)

--- a/src/core/include/MediaPlayer.h
+++ b/src/core/include/MediaPlayer.h
@@ -1,0 +1,23 @@
+#ifndef MEDIA_PLAYER_H
+#define MEDIA_PLAYER_H
+
+#include <string>
+
+namespace mediaplayer {
+
+class MediaPlayer {
+public:
+  MediaPlayer();
+  ~MediaPlayer();
+
+  bool open(const std::string &path);
+  void play();
+  void pause();
+  void stop();
+
+  double duration() const; // seconds
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIA_PLAYER_H

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -1,0 +1,22 @@
+#include "MediaPlayer.h"
+#include <iostream>
+
+namespace mediaplayer {
+
+MediaPlayer::MediaPlayer() = default;
+MediaPlayer::~MediaPlayer() = default;
+
+bool MediaPlayer::open(const std::string &path) {
+  std::cout << "Opening media: " << path << std::endl;
+  return true;
+}
+
+void MediaPlayer::play() { std::cout << "Play" << std::endl; }
+
+void MediaPlayer::pause() { std::cout << "Pause" << std::endl; }
+
+void MediaPlayer::stop() { std::cout << "Stop" << std::endl; }
+
+double MediaPlayer::duration() const { return 0.0; }
+
+} // namespace mediaplayer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,11 @@
+#include "core/include/MediaPlayer.h"
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    return 0;
+  }
+  mediaplayer::MediaPlayer player;
+  player.open(argv[1]);
+  player.play();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add CMake build files
- stub out MediaPlayer API and implementation
- add simple main executable
- update parallel task list to mark initial tasks done

## Testing
- `cmake ..`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685488678a088331ab43e7b11b557e49