### PR TITLE
Implement CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-cmake@v3
+      - name: Configure
+        run: cmake -B build -S .
+      - name: Build
+        run: cmake --build build --config Release

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ make
 
 This will build the `mediaplayer_core` library defined in `src/core`.
 
+## Continuous Integration
+
+All pushes and pull requests are built using GitHub Actions. The workflow
+config in `.github/workflows/build.yml` compiles the project on Linux,
+Windows and macOS with CMake to ensure the code builds across platforms.
+
 ## Usage
 
 Run the resulting `mediaplayer` executable with a media file:

--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -7,7 +7,7 @@
 | 1 | Initialize Core Engine Project Structure | done |
 | 2 | Define Core Engine API (Header) | done |
 | 3 | Stub Implementation of Core Classes | done |
-| 4 | Build & Integration CI Setup | open |
+| 4 | Build & Integration CI Setup | done |
 | 5 | Integrate FFmpeg for Demuxing | open |
 | 6 | Implement Audio Decoding (FFmpeg) | open |
 | 7 | Implement Video Decoding (FFmpeg) | open |
@@ -222,7 +222,7 @@
 | 171 | Dockerfile for Qt | open |
 | 172 | Android Build Environment | open |
 | 173 | iOS Build Setup | open |
-| 174 | GitHub Actions CI Workflow | open |
+| 174 | GitHub Actions CI Workflow | done |
 | 175 | Automated Tests in CI | open |
 | 176 | Static Analysis & Lint | open |
 | 177 | Code Formatting | open |


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the project on Linux, macOS and Windows
- document CI setup in README
- mark CI tasks as done in documentation

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68548a4adcc0833194d41df521d8b41b