### PR TITLE
Add audio decoding skeleton and update task status

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -2,22 +2,22 @@
 
 ## Core Media Engine (C++17) ([Tasks.MD](../Tasks.MD#core-media-engine-c17))
 
-| # | Task | Status |
-|-:|------|--------|
-| 1 | Initialize Core Engine Project Structure | done |
-| 2 | Define Core Engine API (Header) | done |
-| 3 | Stub Implementation of Core Classes | done |
-| 4 | Build & Integration CI Setup | done |
-| 5 | Integrate FFmpeg for Demuxing | done |
-| 6 | Implement Audio Decoding (FFmpeg) | open |
-| 7 | Implement Video Decoding (FFmpeg) | open |
-| 8 | Audio/Video Synchronization | open |
-| 9 | Buffering and Caching Logic | open |
-| 10 | Threading and Locking | open |
-| 11 | Hardware Decoding Support (Optional) | open |
-| 12 | Abstract Audio Output Interface | open |
-| 13 | Audio Output – Windows (WASAPI) | open |
-| 14 | Audio Output – macOS (CoreAudio) | open |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 1 | Initialize Core Engine Project Structure | done | relevant |
+| 2 | Define Core Engine API (Header) | done | relevant |
+| 3 | Stub Implementation of Core Classes | done | relevant |
+| 4 | Build & Integration CI Setup | done | relevant |
+| 5 | Integrate FFmpeg for Demuxing | done | relevant |
+| 6 | Implement Audio Decoding (FFmpeg) | open | relevant |
+| 7 | Implement Video Decoding (FFmpeg) | open | relevant |
+| 8 | Audio/Video Synchronization | open | relevant |
+| 9 | Buffering and Caching Logic | open | relevant |
+| 10 | Threading and Locking | open | relevant |
+| 11 | Hardware Decoding Support (Optional) | open | relevant |
+| 12 | Abstract Audio Output Interface | open | relevant |
+| 13 | Audio Output – Windows (WASAPI) | open | relevant |
+| 14 | Audio Output – macOS (CoreAudio) | open | relevant |
 | 15 | Audio Output – Linux (PulseAudio/ALSA) | open |
 | 16 | Audio Output – Android (OpenSL ES or AAudio) | open |
 | 17 | Audio Output – iOS (AVAudio) | open |
@@ -55,8 +55,8 @@
 
 ## Media Library & Smart Playlists (C++17, SQLite) ([Tasks.MD](../Tasks.MD#media-library-smart-playlists-c17,-sqlite))
 
-| # | Task | Status |
-|-:|------|--------|
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
 | 49 | Integrate SQLite Database | open |
 | 50 | Define DB Schema | open |
 | 51 | Implement Library Scanning | open |
@@ -75,8 +75,8 @@
 
 ## Visualization Module (C++17 OpenGL) ([Tasks.MD](../Tasks.MD#visualization-module-c17-opengl))
 
-| # | Task | Status |
-|-:|------|--------|
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
 | 64 | Include projectM Library | open |
 | 65 | Initialize projectM Instance | open |
 | 66 | PCM Data Feeding | open |
@@ -218,30 +218,30 @@
 
 | # | Task | Status |
 |-:|------|--------|
-| 170 | Dockerfile for Core/C++ | open |
-| 171 | Dockerfile for Qt | open |
-| 172 | Android Build Environment | open |
-| 173 | iOS Build Setup | open |
-| 174 | GitHub Actions CI Workflow | done |
-| 175 | Automated Tests in CI | open |
-| 176 | Static Analysis & Lint | open |
-| 177 | Code Formatting | done |
-| 178 | Git Submodules for Libraries | open |
-| 179 | Issue Templates and Contribution Guide | open |
-| 180 | Merge Strategy for AI Agents | open |
+| 170 | Dockerfile for Core/C++ | open | relevant |
+| 171 | Dockerfile for Qt | open | relevant |
+| 172 | Android Build Environment | open | relevant |
+| 173 | iOS Build Setup | open | relevant |
+| 174 | GitHub Actions CI Workflow | done | relevant |
+| 175 | Automated Tests in CI | open | relevant |
+| 176 | Static Analysis & Lint | open | relevant |
+| 177 | Code Formatting | done | relevant |
+| 178 | Git Submodules for Libraries | open | relevant |
+| 179 | Issue Templates and Contribution Guide | open | relevant |
+| 180 | Merge Strategy for AI Agents | open | relevant |
 
 ## Testing & Quality Assurance ([Tasks.MD](../Tasks.MD#testing-quality-assurance))
 
-| # | Task | Status |
-|-:|------|--------|
-| 181 | Core Unit Tests Setup | open |
-| 182 | Library Module Tests | open |
-| 183 | Visualization Tests | open |
-| 184 | Playback Integration Test | open |
-| 185 | End-to-End Script | open |
-| 186 | Startup Time Test | open |
-| 187 | Memory/CPU Profiling | open |
-| 188 | Battery Test (Mobile) | open |
-| 189 | Formats Compatibility Test | open |
-| 190 | UI Responsiveness Test | open |
-| 191 | Automate Regression Suite | open |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 181 | Core Unit Tests Setup | open | relevant |
+| 182 | Library Module Tests | open | relevant |
+| 183 | Visualization Tests | open | relevant |
+| 184 | Playback Integration Test | open | relevant |
+| 185 | End-to-End Script | open | relevant |
+| 186 | Startup Time Test | open | relevant |
+| 187 | Memory/CPU Profiling | open | relevant |
+| 188 | Battery Test (Mobile) | open | relevant |
+| 189 | Formats Compatibility Test | open | relevant |
+| 190 | UI Responsiveness Test | open | relevant |
+| 191 | Automate Regression Suite | open | relevant |

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mediaplayer_core
     src/MediaPlayer.cpp
+    src/AudioDecoder.cpp
 )
 
 find_package(PkgConfig)

--- a/src/core/include/mediaplayer/AudioDecoder.h
+++ b/src/core/include/mediaplayer/AudioDecoder.h
@@ -1,0 +1,28 @@
+#ifndef MEDIAPLAYER_AUDIODECODER_H
+#define MEDIAPLAYER_AUDIODECODER_H
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswresample/swresample.h>
+}
+
+namespace mediaplayer {
+
+class AudioDecoder {
+public:
+  AudioDecoder();
+  ~AudioDecoder();
+
+  bool open(AVFormatContext *fmtCtx, int streamIndex);
+  int decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize);
+
+private:
+  AVCodecContext *m_codecCtx{nullptr};
+  SwrContext *m_swrCtx{nullptr};
+  AVFrame *m_frame{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIODECODER_H

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -4,6 +4,8 @@
 #include <libavformat/avformat.h>
 #include <string>
 
+#include "AudioDecoder.h"
+
 namespace mediaplayer {
 
 class MediaPlayer {
@@ -16,9 +18,12 @@ public:
   void pause();
   void stop();
   double position() const; // seconds
+  int readAudio(uint8_t *buffer, int bufferSize);
 
 private:
   AVFormatContext *m_formatCtx{nullptr};
+  AudioDecoder m_audioDecoder;
+  int m_audioStream{-1};
 };
 
 } // namespace mediaplayer

--- a/src/core/src/AudioDecoder.cpp
+++ b/src/core/src/AudioDecoder.cpp
@@ -1,0 +1,74 @@
+#include "mediaplayer/AudioDecoder.h"
+#include <iostream>
+
+namespace mediaplayer {
+
+AudioDecoder::AudioDecoder() { m_frame = av_frame_alloc(); }
+
+AudioDecoder::~AudioDecoder() {
+  if (m_codecCtx) {
+    avcodec_free_context(&m_codecCtx);
+  }
+  if (m_swrCtx) {
+    swr_free(&m_swrCtx);
+  }
+  if (m_frame) {
+    av_frame_free(&m_frame);
+  }
+}
+
+bool AudioDecoder::open(AVFormatContext *fmtCtx, int streamIndex) {
+  if (streamIndex < 0 || streamIndex >= static_cast<int>(fmtCtx->nb_streams)) {
+    return false;
+  }
+  AVStream *stream = fmtCtx->streams[streamIndex];
+  const AVCodec *dec = avcodec_find_decoder(stream->codecpar->codec_id);
+  if (!dec) {
+    std::cerr << "No decoder for stream" << std::endl;
+    return false;
+  }
+  m_codecCtx = avcodec_alloc_context3(dec);
+  if (!m_codecCtx) {
+    return false;
+  }
+  if (avcodec_parameters_to_context(m_codecCtx, stream->codecpar) < 0) {
+    return false;
+  }
+  if (avcodec_open2(m_codecCtx, dec, nullptr) < 0) {
+    return false;
+  }
+  m_swrCtx = swr_alloc_set_opts(nullptr, AV_CH_LAYOUT_STEREO, AV_SAMPLE_FMT_S16,
+                                m_codecCtx->sample_rate, m_codecCtx->channel_layout,
+                                m_codecCtx->sample_fmt, m_codecCtx->sample_rate, 0, nullptr);
+  if (!m_swrCtx || swr_init(m_swrCtx) < 0) {
+    std::cerr << "Failed to init resampler" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+int AudioDecoder::decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) {
+  if (avcodec_send_packet(m_codecCtx, pkt) < 0) {
+    return -1;
+  }
+  int total = 0;
+  while (avcodec_receive_frame(m_codecCtx, m_frame) == 0) {
+    int dst_nb_samples =
+        av_rescale_rnd(swr_get_delay(m_swrCtx, m_codecCtx->sample_rate) + m_frame->nb_samples,
+                       m_codecCtx->sample_rate, m_codecCtx->sample_rate, AV_ROUND_UP);
+    int needed = av_samples_get_buffer_size(nullptr, 2, dst_nb_samples, AV_SAMPLE_FMT_S16, 1);
+    if (total + needed > outBufferSize) {
+      break;
+    }
+    uint8_t *dst = outBuffer + total;
+    int len = swr_convert(m_swrCtx, &dst, dst_nb_samples, (const uint8_t **)m_frame->extended_data,
+                          m_frame->nb_samples);
+    if (len < 0) {
+      return -1;
+    }
+    total += len * 2 * av_get_bytes_per_sample(AV_SAMPLE_FMT_S16);
+  }
+  return total;
+}
+
+} // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -23,6 +23,18 @@ bool MediaPlayer::open(const std::string &path) {
     avformat_close_input(&m_formatCtx);
     return false;
   }
+  for (unsigned i = 0; i < m_formatCtx->nb_streams; ++i) {
+    if (m_formatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+      m_audioStream = i;
+      break;
+    }
+  }
+  if (m_audioStream >= 0) {
+    if (!m_audioDecoder.open(m_formatCtx, m_audioStream)) {
+      std::cerr << "Failed to open audio decoder\n";
+      return false;
+    }
+  }
   std::cout << "Opened " << path << '\n';
   return true;
 }
@@ -34,5 +46,22 @@ void MediaPlayer::pause() { std::cout << "pause not implemented\n"; }
 void MediaPlayer::stop() { std::cout << "stop not implemented\n"; }
 
 double MediaPlayer::position() const { return 0.0; }
+
+int MediaPlayer::readAudio(uint8_t *buffer, int bufferSize) {
+  if (!m_formatCtx || m_audioStream < 0) {
+    return 0;
+  }
+  AVPacket pkt;
+  av_init_packet(&pkt);
+  while (av_read_frame(m_formatCtx, &pkt) >= 0) {
+    if (pkt.stream_index == m_audioStream) {
+      int ret = m_audioDecoder.decode(&pkt, buffer, bufferSize);
+      av_packet_unref(&pkt);
+      return ret;
+    }
+    av_packet_unref(&pkt);
+  }
+  return 0;
+}
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- implement an `AudioDecoder` class and hook it into `MediaPlayer`
- update CMake build to compile new files
- mark tasks as relevant in `docs/parallel_tasks.md`

## Testing
- `clang-format -i src/core/include/mediaplayer/AudioDecoder.h src/core/include/mediaplayer/MediaPlayer.h src/core/src/AudioDecoder.cpp src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_685493f826dc8331a816eafeea0f1e84