### PR TITLE
Implement core stubs

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(mediaplayer_core
     src/MediaPlayer.cpp
     src/AudioDecoder.cpp
+    src/VideoDecoder.cpp
+    src/PlaylistManager.cpp
 )
 
 find_package(PkgConfig)

--- a/src/core/include/mediaplayer/AudioOutput.h
+++ b/src/core/include/mediaplayer/AudioOutput.h
@@ -1,0 +1,20 @@
+#ifndef MEDIAPLAYER_AUDIOOUTPUT_H
+#define MEDIAPLAYER_AUDIOOUTPUT_H
+
+#include <cstdint>
+
+namespace mediaplayer {
+
+class AudioOutput {
+public:
+  virtual ~AudioOutput() = default;
+  virtual bool init(int sampleRate, int channels) = 0;
+  virtual void shutdown() = 0;
+  virtual int write(const uint8_t *data, int len) = 0;
+  virtual void pause() = 0;
+  virtual void resume() = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOOUTPUT_H

--- a/src/core/include/mediaplayer/MediaDecoder.h
+++ b/src/core/include/mediaplayer/MediaDecoder.h
@@ -1,0 +1,20 @@
+#ifndef MEDIAPLAYER_MEDIADECODER_H
+#define MEDIAPLAYER_MEDIADECODER_H
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
+namespace mediaplayer {
+
+class MediaDecoder {
+public:
+  virtual ~MediaDecoder() = default;
+  virtual bool open(AVFormatContext *fmtCtx, int streamIndex) = 0;
+  virtual int decode(AVPacket *pkt) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_MEDIADECODER_H

--- a/src/core/include/mediaplayer/NullAudioOutput.h
+++ b/src/core/include/mediaplayer/NullAudioOutput.h
@@ -1,0 +1,25 @@
+#ifndef MEDIAPLAYER_NULLAUDIOOUTPUT_H
+#define MEDIAPLAYER_NULLAUDIOOUTPUT_H
+
+#include "AudioOutput.h"
+#include <iostream>
+
+namespace mediaplayer {
+
+class NullAudioOutput : public AudioOutput {
+public:
+  bool init(int sampleRate, int channels) override {
+    std::cout << "NullAudioOutput init\n";
+    return true;
+  }
+  void shutdown() override { std::cout << "NullAudioOutput shutdown\n"; }
+  int write(const uint8_t *, int len) override {
+    return len; // discard
+  }
+  void pause() override {}
+  void resume() override {}
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_NULLAUDIOOUTPUT_H

--- a/src/core/include/mediaplayer/NullVideoOutput.h
+++ b/src/core/include/mediaplayer/NullVideoOutput.h
@@ -1,0 +1,21 @@
+#ifndef MEDIAPLAYER_NULLVIDEOOUTPUT_H
+#define MEDIAPLAYER_NULLVIDEOOUTPUT_H
+
+#include "VideoOutput.h"
+#include <iostream>
+
+namespace mediaplayer {
+
+class NullVideoOutput : public VideoOutput {
+public:
+  bool init(int width, int height) override {
+    std::cout << "NullVideoOutput init " << width << "x" << height << "\n";
+    return true;
+  }
+  void shutdown() override { std::cout << "NullVideoOutput shutdown\n"; }
+  void displayFrame(const uint8_t *, int) override {}
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_NULLVIDEOOUTPUT_H

--- a/src/core/include/mediaplayer/PlaylistManager.h
+++ b/src/core/include/mediaplayer/PlaylistManager.h
@@ -1,0 +1,23 @@
+#ifndef MEDIAPLAYER_PLAYLISTMANAGER_H
+#define MEDIAPLAYER_PLAYLISTMANAGER_H
+
+#include <string>
+#include <vector>
+
+namespace mediaplayer {
+
+class PlaylistManager {
+public:
+  void add(const std::string &path);
+  void clear();
+  std::string next();
+  bool empty() const;
+
+private:
+  std::vector<std::string> m_items;
+  size_t m_index{0};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_PLAYLISTMANAGER_H

--- a/src/core/include/mediaplayer/VideoDecoder.h
+++ b/src/core/include/mediaplayer/VideoDecoder.h
@@ -1,0 +1,28 @@
+#ifndef MEDIAPLAYER_VIDEODECODER_H
+#define MEDIAPLAYER_VIDEODECODER_H
+
+#include "MediaDecoder.h"
+
+extern "C" {
+#include <libswscale/swscale.h>
+}
+
+namespace mediaplayer {
+
+class VideoDecoder : public MediaDecoder {
+public:
+  VideoDecoder();
+  ~VideoDecoder() override;
+
+  bool open(AVFormatContext *fmtCtx, int streamIndex) override;
+  int decode(AVPacket *pkt) override; // returns number of bytes of RGB data
+
+private:
+  AVCodecContext *m_codecCtx{nullptr};
+  SwsContext *m_swsCtx{nullptr};
+  AVFrame *m_frame{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VIDEODECODER_H

--- a/src/core/include/mediaplayer/VideoOutput.h
+++ b/src/core/include/mediaplayer/VideoOutput.h
@@ -1,0 +1,18 @@
+#ifndef MEDIAPLAYER_VIDEOOUTPUT_H
+#define MEDIAPLAYER_VIDEOOUTPUT_H
+
+#include <cstdint>
+
+namespace mediaplayer {
+
+class VideoOutput {
+public:
+  virtual ~VideoOutput() = default;
+  virtual bool init(int width, int height) = 0;
+  virtual void shutdown() = 0;
+  virtual void displayFrame(const uint8_t *rgba, int linesize) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VIDEOOUTPUT_H

--- a/src/core/src/PlaylistManager.cpp
+++ b/src/core/src/PlaylistManager.cpp
@@ -1,0 +1,21 @@
+#include "mediaplayer/PlaylistManager.h"
+
+namespace mediaplayer {
+
+void PlaylistManager::add(const std::string &path) { m_items.push_back(path); }
+
+void PlaylistManager::clear() {
+  m_items.clear();
+  m_index = 0;
+}
+
+std::string PlaylistManager::next() {
+  if (m_index < m_items.size()) {
+    return m_items[m_index++];
+  }
+  return {};
+}
+
+bool PlaylistManager::empty() const { return m_index >= m_items.size(); }
+
+} // namespace mediaplayer

--- a/src/core/src/VideoDecoder.cpp
+++ b/src/core/src/VideoDecoder.cpp
@@ -1,0 +1,58 @@
+#include "mediaplayer/VideoDecoder.h"
+#include <iostream>
+
+namespace mediaplayer {
+
+VideoDecoder::VideoDecoder() { m_frame = av_frame_alloc(); }
+
+VideoDecoder::~VideoDecoder() {
+  if (m_codecCtx) {
+    avcodec_free_context(&m_codecCtx);
+  }
+  if (m_swsCtx) {
+    sws_freeContext(m_swsCtx);
+  }
+  if (m_frame) {
+    av_frame_free(&m_frame);
+  }
+}
+
+bool VideoDecoder::open(AVFormatContext *fmtCtx, int streamIndex) {
+  if (streamIndex < 0 || streamIndex >= static_cast<int>(fmtCtx->nb_streams)) {
+    return false;
+  }
+  AVStream *stream = fmtCtx->streams[streamIndex];
+  const AVCodec *dec = avcodec_find_decoder(stream->codecpar->codec_id);
+  if (!dec) {
+    std::cerr << "No video decoder" << std::endl;
+    return false;
+  }
+  m_codecCtx = avcodec_alloc_context3(dec);
+  if (!m_codecCtx) {
+    return false;
+  }
+  if (avcodec_parameters_to_context(m_codecCtx, stream->codecpar) < 0) {
+    return false;
+  }
+  if (avcodec_open2(m_codecCtx, dec, nullptr) < 0) {
+    return false;
+  }
+  m_swsCtx =
+      sws_getContext(m_codecCtx->width, m_codecCtx->height, m_codecCtx->pix_fmt, m_codecCtx->width,
+                     m_codecCtx->height, AV_PIX_FMT_RGBA, SWS_BILINEAR, nullptr, nullptr, nullptr);
+  return m_swsCtx != nullptr;
+}
+
+int VideoDecoder::decode(AVPacket *pkt) {
+  if (avcodec_send_packet(m_codecCtx, pkt) < 0) {
+    return -1;
+  }
+  int got = 0;
+  while (avcodec_receive_frame(m_codecCtx, m_frame) == 0) {
+    // For stub, just pretend we converted frame to RGBA
+    got += m_codecCtx->width * m_codecCtx->height * 4;
+  }
+  return got;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add stub interfaces for media decoder and audio/video outputs
- create video decoder and playlist manager placeholders
- update core build to compile new stubs

## Testing
- `cmake .. && make -j2`

------
https://chatgpt.com/codex/tasks/task_e_6854a09ed428833193f1208ba4f724ad