### PR TITLE
Add basic library scanning

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -57,9 +57,9 @@
 
 | # | Task | Status | Notes |
 |-:|------|--------|-------|
-| 49 | Integrate SQLite Database | open | relevant |
-| 50 | Define DB Schema | open | relevant |
-| 51 | Implement Library Scanning | open | relevant |
+| 49 | Integrate SQLite Database | done | relevant |
+| 50 | Define DB Schema | done | relevant |
+| 51 | Implement Library Scanning | done | relevant |
 | 52 | Metadata Extraction | open | relevant |
 | 53 | Update/Remove Entries | open | relevant |
 | 54 | Basic Playlist Management | open | relevant |

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -4,15 +4,18 @@ add_library(mediaplayer_library
 
 find_package(PkgConfig)
 pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
+pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
 
 target_include_directories(mediaplayer_library PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${SQLITE3_INCLUDE_DIRS}
+    ${TAGLIB_INCLUDE_DIRS}
 )
 
 target_link_libraries(mediaplayer_library
     PkgConfig::SQLITE3
+    PkgConfig::TAGLIB
 )
 
 set_target_properties(mediaplayer_library PROPERTIES

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -14,6 +14,11 @@ public:
   bool open();
   void close();
   bool initSchema();
+  bool scanDirectory(const std::string &directory);
+
+private:
+  bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
+                   const std::string &album);
 
 private:
   std::string m_path;

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -1,5 +1,8 @@
 #include "mediaplayer/LibraryDB.h"
+#include <filesystem>
 #include <iostream>
+#include <taglib/fileref.h>
+#include <taglib/tag.h>
 
 namespace mediaplayer {
 
@@ -37,6 +40,44 @@ bool LibraryDB::initSchema() {
     std::cerr << "Failed to init schema: " << err << '\n';
     sqlite3_free(err);
     return false;
+  }
+  return true;
+}
+
+bool LibraryDB::insertMedia(const std::string &path, const std::string &title,
+                            const std::string &artist, const std::string &album) {
+  const char *sql = "INSERT OR IGNORE INTO MediaItem (path, title, artist, album)"
+                    " VALUES (?1, ?2, ?3, ?4);";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    return false;
+  }
+  sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 2, title.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 3, artist.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 4, album.c_str(), -1, SQLITE_TRANSIENT);
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  return ok;
+}
+
+bool LibraryDB::scanDirectory(const std::string &directory) {
+  namespace fs = std::filesystem;
+  if (!m_db)
+    return false;
+  for (auto const &entry : fs::recursive_directory_iterator(directory)) {
+    if (!entry.is_regular_file())
+      continue;
+    auto pathStr = entry.path().string();
+    TagLib::FileRef f(pathStr.c_str());
+    if (!f.isNull() && f.tag()) {
+      std::string title = f.tag()->title().to8Bit(true);
+      std::string artist = f.tag()->artist().to8Bit(true);
+      std::string album = f.tag()->album().to8Bit(true);
+      if (title.empty())
+        title = entry.path().filename().string();
+      insertMedia(pathStr, title, artist, album);
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- link TagLib in the library module
- implement `LibraryDB::scanDirectory` to populate the database
- mark initial library tasks as done in the task table

## Testing
- `cmake ..`
- `cmake --build . --config Release`


------
https://chatgpt.com/codex/tasks/task_e_6854a0153c1483318fa5acb31f51d416