### PR TITLE
Implement basic video decoding

### DIFF
--- a/src/core/include/mediaplayer/MediaDecoder.h
+++ b/src/core/include/mediaplayer/MediaDecoder.h
@@ -12,7 +12,7 @@ class MediaDecoder {
 public:
   virtual ~MediaDecoder() = default;
   virtual bool open(AVFormatContext *fmtCtx, int streamIndex) = 0;
-  virtual int decode(AVPacket *pkt) = 0;
+  virtual int decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) = 0;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "AudioDecoder.h"
+#include "VideoDecoder.h"
 
 namespace mediaplayer {
 
@@ -19,11 +20,14 @@ public:
   void stop();
   double position() const; // seconds
   int readAudio(uint8_t *buffer, int bufferSize);
+  int readVideo(uint8_t *buffer, int bufferSize);
 
 private:
   AVFormatContext *m_formatCtx{nullptr};
   AudioDecoder m_audioDecoder;
+  VideoDecoder m_videoDecoder;
   int m_audioStream{-1};
+  int m_videoStream{-1};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/VideoDecoder.h
+++ b/src/core/include/mediaplayer/VideoDecoder.h
@@ -15,7 +15,8 @@ public:
   ~VideoDecoder() override;
 
   bool open(AVFormatContext *fmtCtx, int streamIndex) override;
-  int decode(AVPacket *pkt) override; // returns number of bytes of RGB data
+  // Decode packet and write RGBA data into outBuffer. Returns bytes written.
+  int decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) override;
 
 private:
   AVCodecContext *m_codecCtx{nullptr};


### PR DESCRIPTION
## Summary
- implement `VideoDecoder::decode` using libswscale
- open video streams and decode frames in `MediaPlayer`
- add video decoding interfaces

## Testing
- `clang-format -i src/core/src/VideoDecoder.cpp src/core/include/mediaplayer/VideoDecoder.h src/core/include/mediaplayer/MediaDecoder.h src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6854a81cb234833185de5083ced428a3