### PR TITLE
Implement PulseAudio output

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -10,15 +10,15 @@
 | 4 | Build & Integration CI Setup | done | relevant |
 | 5 | Integrate FFmpeg for Demuxing | done | relevant |
 | 6 | Implement Audio Decoding (FFmpeg) | done | relevant |
-| 7 | Implement Video Decoding (FFmpeg) | open | relevant |
+| 7 | Implement Video Decoding (FFmpeg) | done | relevant |
 | 8 | Audio/Video Synchronization | open | relevant |
 | 9 | Buffering and Caching Logic | open | relevant |
 | 10 | Threading and Locking | open | relevant |
 | 11 | Hardware Decoding Support (Optional) | open | relevant |
-| 12 | Abstract Audio Output Interface | open | relevant |
+| 12 | Abstract Audio Output Interface | done | relevant |
 | 13 | Audio Output – Windows (WASAPI) | open | relevant |
 | 14 | Audio Output – macOS (CoreAudio) | open | relevant |
-| 15 | Audio Output – Linux (PulseAudio/ALSA) | open | relevant |
+| 15 | Audio Output – Linux (PulseAudio/ALSA) | done | relevant |
 | 16 | Audio Output – Android (OpenSL ES or AAudio) | open | relevant |
 | 17 | Audio Output – iOS (AVAudio) | open | relevant |
 | 18 | Audio Buffering & Mixing | open | relevant |

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(mediaplayer_core
     src/AudioDecoder.cpp
     src/VideoDecoder.cpp
     src/PlaylistManager.cpp
+    src/AudioOutputPulse.cpp
 )
 
 find_package(PkgConfig)
@@ -15,8 +16,13 @@ target_include_directories(mediaplayer_core PUBLIC
     ${FFMPEG_INCLUDE_DIRS}
 )
 
+find_library(PULSE_SIMPLE_LIB pulse-simple)
+find_library(PULSE_LIB pulse)
+
 target_link_libraries(mediaplayer_core
     PkgConfig::FFMPEG
+    ${PULSE_SIMPLE_LIB}
+    ${PULSE_LIB}
 )
 
 set_target_properties(mediaplayer_core PROPERTIES

--- a/src/core/include/mediaplayer/AudioOutputPulse.h
+++ b/src/core/include/mediaplayer/AudioOutputPulse.h
@@ -1,0 +1,30 @@
+#ifndef MEDIAPLAYER_AUDIOOUTPUTPULSE_H
+#define MEDIAPLAYER_AUDIOOUTPUTPULSE_H
+
+#include "AudioOutput.h"
+#include <pulse/error.h>
+#include <pulse/simple.h>
+#include <string>
+
+namespace mediaplayer {
+
+class AudioOutputPulse : public AudioOutput {
+public:
+  AudioOutputPulse();
+  ~AudioOutputPulse() override;
+
+  bool init(int sampleRate, int channels) override;
+  void shutdown() override;
+  int write(const uint8_t *data, int len) override;
+  void pause() override;
+  void resume() override;
+
+private:
+  pa_simple *m_pa = nullptr;
+  pa_sample_spec m_spec{};
+  bool m_paused = false;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOOUTPUTPULSE_H

--- a/src/core/src/AudioOutputPulse.cpp
+++ b/src/core/src/AudioOutputPulse.cpp
@@ -1,0 +1,49 @@
+#include "mediaplayer/AudioOutputPulse.h"
+
+#include <iostream>
+
+namespace mediaplayer {
+
+AudioOutputPulse::AudioOutputPulse() = default;
+
+AudioOutputPulse::~AudioOutputPulse() { shutdown(); }
+
+bool AudioOutputPulse::init(int sampleRate, int channels) {
+  m_spec.format = PA_SAMPLE_S16LE;
+  m_spec.rate = sampleRate;
+  m_spec.channels = static_cast<uint8_t>(channels);
+
+  int error = 0;
+  m_pa = pa_simple_new(nullptr, "MediaPlayer", PA_STREAM_PLAYBACK, nullptr, "playback", &m_spec,
+                       nullptr, nullptr, &error);
+  if (!m_pa) {
+    std::cerr << "PulseAudio init failed: " << pa_strerror(error) << "\n";
+    return false;
+  }
+  return true;
+}
+
+void AudioOutputPulse::shutdown() {
+  if (m_pa) {
+    pa_simple_drain(m_pa, nullptr);
+    pa_simple_free(m_pa);
+    m_pa = nullptr;
+  }
+}
+
+int AudioOutputPulse::write(const uint8_t *data, int len) {
+  if (!m_pa || m_paused)
+    return 0;
+  int error = pa_simple_write(m_pa, data, static_cast<size_t>(len), nullptr);
+  if (error < 0) {
+    std::cerr << "PulseAudio write failed: " << pa_strerror(error) << "\n";
+    return -1;
+  }
+  return len;
+}
+
+void AudioOutputPulse::pause() { m_paused = true; }
+
+void AudioOutputPulse::resume() { m_paused = false; }
+
+} // namespace mediaplayer

--- a/src/core/src/VideoDecoder.cpp
+++ b/src/core/src/VideoDecoder.cpp
@@ -1,5 +1,6 @@
 #include "mediaplayer/VideoDecoder.h"
 #include <iostream>
+#include <libavutil/imgutils.h>
 
 namespace mediaplayer {
 


### PR DESCRIPTION
## Summary
- implement PulseAudio `AudioOutputPulse`
- link PulseAudio in core CMake
- include missing imgutils header in video decoder
- update task status table

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6854ab40c5088331873b22ddc866ce28