### PR TITLE
Implement threading support for media playback

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -13,7 +13,7 @@
 | 7 | Implement Video Decoding (FFmpeg) | done | relevant |
 | 8 | Audio/Video Synchronization | done | relevant |
 | 9 | Buffering and Caching Logic | done | relevant |
-| 10 | Threading and Locking | open | relevant |
+| 10 | Threading and Locking | done | relevant |
 | 11 | Hardware Decoding Support (Optional) | open | relevant |
 | 12 | Abstract Audio Output Interface | done | relevant |
 | 13 | Audio Output – Windows (WASAPI) | open | relevant |

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -35,15 +35,19 @@ public:
   double position() const; // seconds
   int readAudio(uint8_t *buffer, int bufferSize);
   int readVideo(uint8_t *buffer, int bufferSize);
-  void fillQueues();
 
 private:
+  void demuxLoop();
+  void audioLoop();
+  void videoLoop();
   AVFormatContext *m_formatCtx{nullptr};
   AudioDecoder m_audioDecoder;
   VideoDecoder m_videoDecoder;
   std::unique_ptr<AudioOutput> m_output;
   std::unique_ptr<VideoOutput> m_videoOutput;
-  std::thread m_playThread;
+  std::thread m_demuxThread;
+  std::thread m_audioThread;
+  std::thread m_videoThread;
   mutable std::mutex m_mutex;
   std::condition_variable m_cv;
   std::atomic<bool> m_running{false};

--- a/src/core/include/mediaplayer/PacketQueue.h
+++ b/src/core/include/mediaplayer/PacketQueue.h
@@ -6,7 +6,10 @@ extern "C" {
 }
 
 #include <cstddef>
+#include <mutex>
 #include <queue>
+
+#include <condition_variable>
 
 namespace mediaplayer {
 
@@ -24,6 +27,8 @@ public:
 private:
   std::queue<AVPacket *> m_queue;
   size_t m_maxSize{0};
+  mutable std::mutex m_mutex;
+  std::condition_variable m_cv;
 };
 
 } // namespace mediaplayer

--- a/src/core/src/PacketQueue.cpp
+++ b/src/core/src/PacketQueue.cpp
@@ -7,17 +7,22 @@ PacketQueue::PacketQueue(size_t maxSize) : m_maxSize(maxSize) {}
 PacketQueue::~PacketQueue() { clear(); }
 
 bool PacketQueue::push(const AVPacket *pkt) {
-  if (!pkt || full())
+  if (!pkt)
+    return false;
+  std::unique_lock<std::mutex> lock(m_mutex);
+  if (full())
     return false;
   AVPacket *copy = av_packet_alloc();
   if (!copy)
     return false;
   av_packet_ref(copy, pkt);
   m_queue.push(copy);
+  m_cv.notify_one();
   return true;
 }
 
 bool PacketQueue::pop(AVPacket *&pkt) {
+  std::unique_lock<std::mutex> lock(m_mutex);
   if (m_queue.empty())
     return false;
   pkt = m_queue.front();
@@ -26,6 +31,7 @@ bool PacketQueue::pop(AVPacket *&pkt) {
 }
 
 void PacketQueue::clear() {
+  std::unique_lock<std::mutex> lock(m_mutex);
   while (!m_queue.empty()) {
     AVPacket *p = m_queue.front();
     av_packet_free(&p);
@@ -33,8 +39,14 @@ void PacketQueue::clear() {
   }
 }
 
-size_t PacketQueue::size() const { return m_queue.size(); }
+size_t PacketQueue::size() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_queue.size();
+}
 
-bool PacketQueue::full() const { return m_queue.size() >= m_maxSize; }
+bool PacketQueue::full() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_queue.size() >= m_maxSize;
+}
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add mutex-protected `PacketQueue`
- create demux, audio and video threads in `MediaPlayer`
- implement thread loops to handle decoding and playback
- mark "Threading and Locking" task as done

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6854bbca46f08331a8ecc379210013c0