### PR TITLE
Implement SRT subtitle parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,4 +5,6 @@ add_subdirectory(src/core)
 
 add_subdirectory(src/library)
 
+add_subdirectory(src/subtitles)
+
 # Optionally add other modules later

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ make
 
 This will build the `mediaplayer_core` library defined in `src/core`.
 The core library now links with FFmpeg and can open media files using
-`avformat_open_input`.
+`avformat_open_input`. It also builds `mediaplayer_subtitles`, a small
+library providing SRT subtitle parsing.
 
 ## Continuous Integration
 

--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -42,7 +42,7 @@
 | 36 | YouTube Integration (Optional) | open | relevant |
 | 37 | Streaming Protocols (HLS/DASH) | open | relevant |
 | 38 | Internet Radio Streams | open | relevant |
-| 39 | Subtitle Parser (SRT) | open | relevant |
+| 39 | Subtitle Parser (SRT) | done | relevant |
 | 40 | Subtitle Renderer/Provider | open | relevant |
 | 41 | Subtitle Sync Adjustment | open | relevant |
 | 42 | Subtitle Track Selection | open | relevant |

--- a/src/subtitles/CMakeLists.txt
+++ b/src/subtitles/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(mediaplayer_subtitles
+    src/SrtParser.cpp
+)
+
+target_include_directories(mediaplayer_subtitles PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+set_target_properties(mediaplayer_subtitles PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/subtitles/include/mediaplayer/SrtParser.h
+++ b/src/subtitles/include/mediaplayer/SrtParser.h
@@ -1,0 +1,28 @@
+#ifndef MEDIAPLAYER_SRTPARSER_H
+#define MEDIAPLAYER_SRTPARSER_H
+
+#include <string>
+#include <vector>
+
+namespace mediaplayer {
+
+struct SubtitleCue {
+  double start{0.0};
+  double end{0.0};
+  std::string text;
+};
+
+class SrtParser {
+public:
+  bool load(const std::string &path);
+  const std::vector<SubtitleCue> &cues() const { return m_cues; }
+  const SubtitleCue *cueAt(double time) const;
+
+private:
+  static double parseTimestamp(const std::string &ts);
+  std::vector<SubtitleCue> m_cues;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_SRTPARSER_H

--- a/src/subtitles/src/SrtParser.cpp
+++ b/src/subtitles/src/SrtParser.cpp
@@ -1,0 +1,62 @@
+#include "mediaplayer/SrtParser.h"
+
+#include <fstream>
+#include <sstream>
+
+namespace mediaplayer {
+
+static bool parseLine(std::istream &is, std::string &line) {
+  std::getline(is, line);
+  if (!line.empty() && line.back() == '\r')
+    line.pop_back();
+  return !is.fail();
+}
+
+double SrtParser::parseTimestamp(const std::string &ts) {
+  int h = 0, m = 0, s = 0, ms = 0;
+  char sep1, sep2, comma;
+  std::stringstream ss(ts);
+  ss >> h >> sep1 >> m >> sep2 >> s >> comma >> ms;
+  return h * 3600.0 + m * 60.0 + s + ms / 1000.0;
+}
+
+bool SrtParser::load(const std::string &path) {
+  std::ifstream file(path);
+  if (!file.is_open())
+    return false;
+  m_cues.clear();
+  std::string line;
+  while (parseLine(file, line)) {
+    if (line.empty())
+      continue; // skip blank lines
+    // skip index number
+    if (!parseLine(file, line))
+      break;
+    auto arrow = line.find("-->");
+    if (arrow == std::string::npos)
+      break;
+    std::string startStr = line.substr(0, arrow - 1);
+    std::string endStr = line.substr(arrow + 3);
+    SubtitleCue cue{};
+    cue.start = parseTimestamp(startStr);
+    cue.end = parseTimestamp(endStr);
+    cue.text.clear();
+    while (parseLine(file, line) && !line.empty()) {
+      if (!cue.text.empty())
+        cue.text += "\n";
+      cue.text += line;
+    }
+    m_cues.push_back(std::move(cue));
+  }
+  return !m_cues.empty();
+}
+
+const SubtitleCue *SrtParser::cueAt(double time) const {
+  for (const auto &cue : m_cues) {
+    if (time >= cue.start && time <= cue.end)
+      return &cue;
+  }
+  return nullptr;
+}
+
+} // namespace mediaplayer

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,4 @@
 # Tests
+
+This directory contains simple test programs. `test_srtparser.cpp` verifies
+the SRT subtitle parser.

--- a/tests/test_srtparser.cpp
+++ b/tests/test_srtparser.cpp
@@ -1,0 +1,23 @@
+#include "mediaplayer/SrtParser.h"
+#include <cassert>
+#include <fstream>
+#include <iostream>
+
+int main() {
+  const char *srt =
+      "1\n00:00:01,000 --> 00:00:02,000\nHello\n\n2\n00:00:02,500 --> 00:00:04,000\nWorld\n";
+  const char *path = "sample.srt";
+  std::ofstream out(path);
+  out << srt;
+  out.close();
+
+  mediaplayer::SrtParser parser;
+  assert(parser.load(path));
+  assert(parser.cues().size() == 2);
+  assert(parser.cueAt(1.5) != nullptr);
+  assert(parser.cueAt(1.5)->text == "Hello");
+  assert(parser.cueAt(3.0)->text == "World");
+  std::remove(path);
+  std::cout << "SrtParser test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement a new `mediaplayer_subtitles` library
- provide `SrtParser` for reading `.srt` files
- include a tiny test program demonstrating the parser
- document the new module in README and mark task 39 as complete

## Testing
- `clang-format -i src/subtitles/include/mediaplayer/SrtParser.h src/subtitles/src/SrtParser.cpp tests/test_srtparser.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6854d6ab11888331abb32ff0ef97dbf2