### PR TITLE
Implement audio format conversion utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
-cmake_minimum_required(VERSION 3.15)
-project(MediaPlayer LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.15) project(MediaPlayer LANGUAGES CXX)
 
-add_subdirectory(src/core)
+    add_subdirectory(src / core)
 
-add_subdirectory(src/library)
+        add_subdirectory(src / library)
 
-# Optionally add other modules later
+#Format conversion utilities
+            add_subdirectory(src / format_conversion)
+#Optionally add other modules later

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MediaPlayer
+#MediaPlayer
 
 MediaPlayer is an open-source, cross-platform AI-enabled media player focused on speed and a polished user experience.
 High level design is described in [Masterplan.MD](Masterplan.MD) and a breakdown of work items is in [Tasks.MD](Tasks.MD).
@@ -23,15 +23,17 @@ A detailed breakdown of planned modules and tasks can be found in [Tasks.MD](Tas
 - Qt 6 development files
 
 ```
-# Example build steps
+#Example build steps
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make
 ```
 
-This will build the `mediaplayer_core` library defined in `src/core`.
-The core library now links with FFmpeg and can open media files using
-`avformat_open_input`.
+This will build the `mediaplayer_core` library defined in `src/core` and the
+`mediaplayer_conversion` library in `src/format_conversion`.
+The core library links with FFmpeg and can open media files using
+`avformat_open_input`. The conversion module provides a simple API to convert
+audio files between formats.
 
 ## Continuous Integration
 

--- a/src/format_conversion/CMakeLists.txt
+++ b/src/format_conversion/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(mediaplayer_conversion src / AudioConverter.cpp)
+
+    find_package(PkgConfig) pkg_check_modules(
+        FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswresample)
+
+        target_include_directories(
+            mediaplayer_conversion PUBLIC $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
+                $<INSTALL_INTERFACE : include>
+                    ${FFMPEG_INCLUDE_DIRS})
+
+            target_link_libraries(mediaplayer_conversion PkgConfig::FFMPEG)
+
+                set_target_properties(
+                    mediaplayer_conversion PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/format_conversion/README.md
+++ b/src/format_conversion/README.md
@@ -1,1 +1,7 @@
-# Format Conversion
+#Format Conversion
+
+This module provides utilities to convert audio files between common formats using FFmpeg libraries
+    .
+
+    The `AudioConverter` class exposes a simple `convert()` method which takes an input file path
+        and an output file path.The output format is inferred from the extension of the output file.

--- a/src/format_conversion/include/mediaplayer/AudioConverter.h
+++ b/src/format_conversion/include/mediaplayer/AudioConverter.h
@@ -1,0 +1,17 @@
+#ifndef MEDIAPLAYER_AUDIOCONVERTER_H
+#define MEDIAPLAYER_AUDIOCONVERTER_H
+
+#include <string>
+
+namespace mediaplayer {
+
+class AudioConverter {
+public:
+  // Convert input audio file to the format implied by outputPath extension.
+  // Returns true on success.
+  bool convert(const std::string &inputPath, const std::string &outputPath);
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOCONVERTER_H

--- a/src/format_conversion/src/AudioConverter.cpp
+++ b/src/format_conversion/src/AudioConverter.cpp
@@ -1,0 +1,160 @@
+#include "mediaplayer/AudioConverter.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/opt.h>
+#include <libswresample/swresample.h>
+}
+
+#include <iostream>
+
+namespace mediaplayer {
+
+bool AudioConverter::convert(const std::string &inputPath, const std::string &outputPath) {
+  AVFormatContext *inCtx = nullptr;
+  if (avformat_open_input(&inCtx, inputPath.c_str(), nullptr, nullptr) < 0) {
+    std::cerr << "Failed to open input" << std::endl;
+    return false;
+  }
+  if (avformat_find_stream_info(inCtx, nullptr) < 0) {
+    std::cerr << "Failed to find stream info" << std::endl;
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  int audioStream = av_find_best_stream(inCtx, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
+  if (audioStream < 0) {
+    std::cerr << "No audio stream" << std::endl;
+    avformat_close_input(&inCtx);
+    return false;
+  }
+
+  AVStream *inSt = inCtx->streams[audioStream];
+  const AVCodec *dec = avcodec_find_decoder(inSt->codecpar->codec_id);
+  if (!dec) {
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  AVCodecContext *decCtx = avcodec_alloc_context3(dec);
+  avcodec_parameters_to_context(decCtx, inSt->codecpar);
+  if (avcodec_open2(decCtx, dec, nullptr) < 0) {
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+
+  AVFormatContext *outCtx = nullptr;
+  if (avformat_alloc_output_context2(&outCtx, nullptr, nullptr, outputPath.c_str()) < 0) {
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  const AVCodec *enc = avcodec_find_encoder(outCtx->oformat->audio_codec);
+  if (!enc) {
+    std::cerr << "No encoder" << std::endl;
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  AVStream *outSt = avformat_new_stream(outCtx, enc);
+  if (!outSt) {
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+
+  AVCodecContext *encCtx = avcodec_alloc_context3(enc);
+  encCtx->channels = decCtx->channels;
+  encCtx->channel_layout = av_get_default_channel_layout(encCtx->channels);
+  encCtx->sample_rate = decCtx->sample_rate;
+  encCtx->sample_fmt = enc->sample_fmts ? enc->sample_fmts[0] : decCtx->sample_fmt;
+  encCtx->bit_rate = 192000;
+  outSt->time_base = {1, encCtx->sample_rate};
+  if (outCtx->oformat->flags & AVFMT_GLOBALHEADER)
+    encCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  if (avcodec_open2(encCtx, enc, nullptr) < 0) {
+    avcodec_free_context(&encCtx);
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  avcodec_parameters_from_context(outSt->codecpar, encCtx);
+
+  if (!(outCtx->oformat->flags & AVFMT_NOFILE)) {
+    if (avio_open(&outCtx->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+      avcodec_free_context(&encCtx);
+      avformat_free_context(outCtx);
+      avcodec_free_context(&decCtx);
+      avformat_close_input(&inCtx);
+      return false;
+    }
+  }
+  if (avformat_write_header(outCtx, nullptr) < 0) {
+    avio_closep(&outCtx->pb);
+    avcodec_free_context(&encCtx);
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+
+  SwrContext *swr = swr_alloc_set_opts(nullptr, encCtx->channel_layout, encCtx->sample_fmt,
+                                       encCtx->sample_rate, decCtx->channel_layout,
+                                       decCtx->sample_fmt, decCtx->sample_rate, 0, nullptr);
+  swr_init(swr);
+  AVPacket pkt{};
+  AVFrame *frame = av_frame_alloc();
+  AVFrame *resampled = av_frame_alloc();
+  resampled->channel_layout = encCtx->channel_layout;
+  resampled->format = encCtx->sample_fmt;
+  resampled->sample_rate = encCtx->sample_rate;
+  int outSamples = encCtx->frame_size > 0 ? encCtx->frame_size : 1024;
+  av_frame_set_nb_samples(resampled, outSamples);
+  av_frame_get_buffer(resampled, 0);
+
+  while (av_read_frame(inCtx, &pkt) >= 0) {
+    if (pkt.stream_index != audioStream) {
+      av_packet_unref(&pkt);
+      continue;
+    }
+    avcodec_send_packet(decCtx, &pkt);
+    av_packet_unref(&pkt);
+    while (avcodec_receive_frame(decCtx, frame) == 0) {
+      swr_convert(swr, resampled->data, resampled->nb_samples, (const uint8_t **)frame->data,
+                  frame->nb_samples);
+      resampled->pts = frame->pts;
+      avcodec_send_frame(encCtx, resampled);
+      AVPacket outPkt{};
+      while (avcodec_receive_packet(encCtx, &outPkt) == 0) {
+        outPkt.stream_index = outSt->index;
+        av_interleaved_write_frame(outCtx, &outPkt);
+        av_packet_unref(&outPkt);
+      }
+    }
+  }
+  // flush encoder
+  avcodec_send_frame(encCtx, nullptr);
+  AVPacket outPkt{};
+  while (avcodec_receive_packet(encCtx, &outPkt) == 0) {
+    outPkt.stream_index = outSt->index;
+    av_interleaved_write_frame(outCtx, &outPkt);
+    av_packet_unref(&outPkt);
+  }
+
+  av_write_trailer(outCtx);
+  av_frame_free(&frame);
+  av_frame_free(&resampled);
+  swr_free(&swr);
+  if (!(outCtx->oformat->flags & AVFMT_NOFILE))
+    avio_closep(&outCtx->pb);
+  avcodec_free_context(&encCtx);
+  avformat_free_context(outCtx);
+  avcodec_free_context(&decCtx);
+  avformat_close_input(&inCtx);
+  return true;
+}
+
+} // namespace mediaplayer

--- a/tests/format_conversion_test.cpp
+++ b/tests/format_conversion_test.cpp
@@ -1,0 +1,49 @@
+#include "mediaplayer/AudioConverter.h"
+#include <cassert>
+#include <fstream>
+#include <vector>
+
+// Simple helper to create a small PCM wav file for tests
+static void createTestWav(const std::string &path) {
+  const int sampleRate = 44100;
+  const int seconds = 1;
+  const int16_t amplitude = 1000;
+  std::vector<int16_t> samples(sampleRate * seconds);
+  for (int i = 0; i < sampleRate * seconds; ++i) {
+    samples[i] = (i % 100 < 50 ? amplitude : -amplitude);
+  }
+  std::ofstream f(path, std::ios::binary);
+  int32_t chunkSize = 36 + samples.size() * sizeof(int16_t);
+  f.write("RIFF", 4);
+  f.write(reinterpret_cast<const char *>(&chunkSize), 4);
+  f.write("WAVEfmt ", 8);
+  int32_t subChunk1 = 16;
+  int16_t audioFormat = 1;
+  int16_t numChannels = 1;
+  int32_t byteRate = sampleRate * numChannels * sizeof(int16_t);
+  int16_t blockAlign = numChannels * sizeof(int16_t);
+  int16_t bitsPerSample = 16;
+  f.write(reinterpret_cast<const char *>(&subChunk1), 4);
+  f.write(reinterpret_cast<const char *>(&audioFormat), 2);
+  f.write(reinterpret_cast<const char *>(&numChannels), 2);
+  f.write(reinterpret_cast<const char *>(&sampleRate), 4);
+  f.write(reinterpret_cast<const char *>(&byteRate), 4);
+  f.write(reinterpret_cast<const char *>(&blockAlign), 2);
+  f.write(reinterpret_cast<const char *>(&bitsPerSample), 2);
+  f.write("data", 4);
+  int32_t dataSize = samples.size() * sizeof(int16_t);
+  f.write(reinterpret_cast<const char *>(&dataSize), 4);
+  f.write(reinterpret_cast<const char *>(samples.data()), dataSize);
+}
+
+int main() {
+  const std::string wav = "test_input.wav";
+  const std::string mp3 = "test_output.mp3";
+  createTestWav(wav);
+  mediaplayer::AudioConverter conv;
+  bool ok = conv.convert(wav, mp3);
+  assert(ok && "conversion failed");
+  std::ifstream f(mp3, std::ios::binary);
+  assert(f.good() && "output file missing");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `AudioConverter` class for transcoding between audio formats
- build new `mediaplayer_conversion` library
- add unit test that converts a generated WAV file to MP3
- update project build instructions

## Testing
- `clang-format -i src/format_conversion/include/mediaplayer/AudioConverter.h src/format_conversion/src/AudioConverter.cpp tests/format_conversion_test.cpp README.md CMakeLists.txt src/format_conversion/CMakeLists.txt src/format_conversion/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6854d6a646b88331b3ef6d48d28a0ca0