### PR TITLE
Implement video transcoding utility

### DIFF
--- a/src/format_conversion/CMakeLists.txt
+++ b/src/format_conversion/CMakeLists.txt
@@ -1,19 +1,14 @@
-add_library(mediaplayer_conversion
-    src/AudioConverter.cpp
-)
+add_library(mediaplayer_conversion src / AudioConverter.cpp src / VideoConverter.cpp)
 
-find_package(PkgConfig)
-pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswresample)
+    find_package(PkgConfig) pkg_check_modules(
+        FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswresample libswscale)
 
-target_include_directories(mediaplayer_conversion PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${FFMPEG_INCLUDE_DIRS}
-)
+        target_include_directories(
+            mediaplayer_conversion PUBLIC $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
+                $<INSTALL_INTERFACE : include>
+                    ${FFMPEG_INCLUDE_DIRS})
 
-target_link_libraries(mediaplayer_conversion PkgConfig::FFMPEG)
+            target_link_libraries(mediaplayer_conversion PkgConfig::FFMPEG)
 
-set_target_properties(mediaplayer_conversion PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-)
+                set_target_properties(
+                    mediaplayer_conversion PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/format_conversion/README.md
+++ b/src/format_conversion/README.md
@@ -1,6 +1,9 @@
-# Format Conversion
+#Format Conversion
 
-This module provides utilities to convert audio files between common formats using FFmpeg libraries.
-The `AudioConverter` class exposes a simple `convert()` method which takes an
-input file path and an output file path. The output format is inferred from the
-extension of the output file.
+This module provides utilities to convert audio and video files using FFmpeg
+libraries. The `AudioConverter` class exposes a simple `convert()` method which
+takes an input file path and an output file path. The output format is inferred
+from the extension of the output file.
+
+The `VideoConverter` class offers similar functionality for video files. It can
+transcode between formats and optionally resize or set a target bitrate.

--- a/src/format_conversion/include/mediaplayer/VideoConverter.h
+++ b/src/format_conversion/include/mediaplayer/VideoConverter.h
@@ -1,0 +1,18 @@
+#ifndef MEDIAPLAYER_VIDEOCONVERTER_H
+#define MEDIAPLAYER_VIDEOCONVERTER_H
+
+#include <string>
+
+namespace mediaplayer {
+
+class VideoConverter {
+public:
+  // Convert input video to output path. If width/height are 0, keep input size.
+  // Bitrate is in bits per second.
+  bool convert(const std::string &inputPath, const std::string &outputPath, int width = 0,
+               int height = 0, int bitrate = 1000000);
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VIDEOCONVERTER_H

--- a/src/format_conversion/src/VideoConverter.cpp
+++ b/src/format_conversion/src/VideoConverter.cpp
@@ -1,0 +1,167 @@
+#include "mediaplayer/VideoConverter.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <libavutil/imgutils.h>
+#include <libswscale/swscale.h>
+}
+
+#include <iostream>
+
+namespace mediaplayer {
+
+bool VideoConverter::convert(const std::string &inputPath, const std::string &outputPath, int width,
+                             int height, int bitrate) {
+  AVFormatContext *inCtx = nullptr;
+  if (avformat_open_input(&inCtx, inputPath.c_str(), nullptr, nullptr) < 0) {
+    std::cerr << "Failed to open input" << std::endl;
+    return false;
+  }
+  if (avformat_find_stream_info(inCtx, nullptr) < 0) {
+    std::cerr << "Failed to find stream info" << std::endl;
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  int vStream = av_find_best_stream(inCtx, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
+  if (vStream < 0) {
+    std::cerr << "No video stream" << std::endl;
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  AVStream *inSt = inCtx->streams[vStream];
+  const AVCodec *dec = avcodec_find_decoder(inSt->codecpar->codec_id);
+  if (!dec) {
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  AVCodecContext *decCtx = avcodec_alloc_context3(dec);
+  avcodec_parameters_to_context(decCtx, inSt->codecpar);
+  if (avcodec_open2(decCtx, dec, nullptr) < 0) {
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  if (width == 0)
+    width = decCtx->width;
+  if (height == 0)
+    height = decCtx->height;
+
+  AVFormatContext *outCtx = nullptr;
+  if (avformat_alloc_output_context2(&outCtx, nullptr, nullptr, outputPath.c_str()) < 0) {
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  const AVCodec *enc = avcodec_find_encoder(outCtx->oformat->video_codec);
+  if (!enc) {
+    std::cerr << "No encoder" << std::endl;
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  AVStream *outSt = avformat_new_stream(outCtx, enc);
+  if (!outSt) {
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+
+  AVCodecContext *encCtx = avcodec_alloc_context3(enc);
+  encCtx->width = width;
+  encCtx->height = height;
+  encCtx->pix_fmt = enc->pix_fmts ? enc->pix_fmts[0] : AV_PIX_FMT_YUV420P;
+  encCtx->time_base = {1, 25};
+  encCtx->bit_rate = bitrate;
+  outSt->time_base = encCtx->time_base;
+  if (outCtx->oformat->flags & AVFMT_GLOBALHEADER)
+    encCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  if (avcodec_open2(encCtx, enc, nullptr) < 0) {
+    avcodec_free_context(&encCtx);
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+  avcodec_parameters_from_context(outSt->codecpar, encCtx);
+
+  if (!(outCtx->oformat->flags & AVFMT_NOFILE)) {
+    if (avio_open(&outCtx->pb, outputPath.c_str(), AVIO_FLAG_WRITE) < 0) {
+      avcodec_free_context(&encCtx);
+      avformat_free_context(outCtx);
+      avcodec_free_context(&decCtx);
+      avformat_close_input(&inCtx);
+      return false;
+    }
+  }
+  if (avformat_write_header(outCtx, nullptr) < 0) {
+    avio_closep(&outCtx->pb);
+    avcodec_free_context(&encCtx);
+    avformat_free_context(outCtx);
+    avcodec_free_context(&decCtx);
+    avformat_close_input(&inCtx);
+    return false;
+  }
+
+  SwsContext *sws = sws_getContext(decCtx->width, decCtx->height, decCtx->pix_fmt, width, height,
+                                   encCtx->pix_fmt, SWS_BILINEAR, nullptr, nullptr, nullptr);
+  AVFrame *frame = av_frame_alloc();
+  AVFrame *scaled = av_frame_alloc();
+  scaled->format = encCtx->pix_fmt;
+  scaled->width = width;
+  scaled->height = height;
+  av_frame_get_buffer(scaled, 0);
+  AVPacket pkt{};
+
+  while (av_read_frame(inCtx, &pkt) >= 0) {
+    if (pkt.stream_index != vStream) {
+      av_packet_unref(&pkt);
+      continue;
+    }
+    avcodec_send_packet(decCtx, &pkt);
+    av_packet_unref(&pkt);
+    while (avcodec_receive_frame(decCtx, frame) == 0) {
+      sws_scale(sws, frame->data, frame->linesize, 0, decCtx->height, scaled->data,
+                scaled->linesize);
+      scaled->pts = frame->pts;
+      avcodec_send_frame(encCtx, scaled);
+      AVPacket outPkt{};
+      while (avcodec_receive_packet(encCtx, &outPkt) == 0) {
+        outPkt.stream_index = outSt->index;
+        outPkt.pts = av_rescale_q(outPkt.pts, encCtx->time_base, outSt->time_base);
+        outPkt.dts = av_rescale_q(outPkt.dts, encCtx->time_base, outSt->time_base);
+        outPkt.duration = av_rescale_q(outPkt.duration, encCtx->time_base, outSt->time_base);
+        av_interleaved_write_frame(outCtx, &outPkt);
+        av_packet_unref(&outPkt);
+      }
+    }
+  }
+
+  avcodec_send_frame(encCtx, nullptr);
+  AVPacket outPkt{};
+  while (avcodec_receive_packet(encCtx, &outPkt) == 0) {
+    outPkt.stream_index = outSt->index;
+    outPkt.pts = av_rescale_q(outPkt.pts, encCtx->time_base, outSt->time_base);
+    outPkt.dts = av_rescale_q(outPkt.dts, encCtx->time_base, outSt->time_base);
+    outPkt.duration = av_rescale_q(outPkt.duration, encCtx->time_base, outSt->time_base);
+    av_interleaved_write_frame(outCtx, &outPkt);
+    av_packet_unref(&outPkt);
+  }
+
+  av_write_trailer(outCtx);
+  av_frame_free(&frame);
+  av_frame_free(&scaled);
+  sws_freeContext(sws);
+  if (!(outCtx->oformat->flags & AVFMT_NOFILE))
+    avio_closep(&outCtx->pb);
+  avcodec_free_context(&encCtx);
+  avformat_free_context(outCtx);
+  avcodec_free_context(&decCtx);
+  avformat_close_input(&inCtx);
+  return true;
+}
+
+} // namespace mediaplayer

--- a/tests/video_conversion_test.cpp
+++ b/tests/video_conversion_test.cpp
@@ -1,0 +1,75 @@
+#include "mediaplayer/VideoConverter.h"
+#include <cassert>
+#include <cstring>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+}
+
+// Helper to create a small MP4 video for testing
+static void createTestMp4(const std::string &path) {
+  AVFormatContext *ctx = nullptr;
+  avformat_alloc_output_context2(&ctx, nullptr, nullptr, path.c_str());
+  const AVCodec *codec = avcodec_find_encoder(ctx->oformat->video_codec);
+  AVStream *st = avformat_new_stream(ctx, codec);
+  AVCodecContext *c = avcodec_alloc_context3(codec);
+  c->width = 32;
+  c->height = 32;
+  c->pix_fmt = codec->pix_fmts ? codec->pix_fmts[0] : AV_PIX_FMT_YUV420P;
+  c->time_base = {1, 25};
+  if (ctx->oformat->flags & AVFMT_GLOBALHEADER)
+    c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  avcodec_open2(c, codec, nullptr);
+  avcodec_parameters_from_context(st->codecpar, c);
+  st->time_base = c->time_base;
+  if (!(ctx->oformat->flags & AVFMT_NOFILE))
+    avio_open(&ctx->pb, path.c_str(), AVIO_FLAG_WRITE);
+  avformat_write_header(ctx, nullptr);
+  AVFrame *frame = av_frame_alloc();
+  frame->format = c->pix_fmt;
+  frame->width = c->width;
+  frame->height = c->height;
+  av_frame_get_buffer(frame, 0);
+  for (int i = 0; i < 25; ++i) {
+    av_frame_make_writable(frame);
+    memset(frame->data[0], i, c->width * c->height);
+    memset(frame->data[1], 128, c->width * c->height / 4);
+    memset(frame->data[2], 128, c->width * c->height / 4);
+    frame->pts = i;
+    avcodec_send_frame(c, frame);
+    AVPacket pkt{};
+    while (avcodec_receive_packet(c, &pkt) == 0) {
+      pkt.stream_index = st->index;
+      av_interleaved_write_frame(ctx, &pkt);
+      av_packet_unref(&pkt);
+    }
+  }
+  avcodec_send_frame(c, nullptr);
+  AVPacket pkt{};
+  while (avcodec_receive_packet(c, &pkt) == 0) {
+    pkt.stream_index = st->index;
+    av_interleaved_write_frame(ctx, &pkt);
+    av_packet_unref(&pkt);
+  }
+  av_write_trailer(ctx);
+  av_frame_free(&frame);
+  if (!(ctx->oformat->flags & AVFMT_NOFILE))
+    avio_closep(&ctx->pb);
+  avcodec_free_context(&c);
+  avformat_free_context(ctx);
+}
+
+int main() {
+  const std::string in = "test_in.mp4";
+  const std::string out = "test_out.mp4";
+  createTestMp4(in);
+  mediaplayer::VideoConverter conv;
+  bool ok = conv.convert(in, out, 16, 16, 500000);
+  assert(ok && "conversion failed");
+  AVFormatContext *ctx = nullptr;
+  assert(avformat_open_input(&ctx, out.c_str(), nullptr, nullptr) == 0);
+  avformat_close_input(&ctx);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `VideoConverter` with FFmpeg-based transcoding
- build VideoConverter in the format_conversion module
- document video conversion capability
- add simple test program creating and transcoding a short video

## Testing
- `clang-format -i src/format_conversion/include/mediaplayer/VideoConverter.h src/format_conversion/src/VideoConverter.cpp src/format_conversion/CMakeLists.txt tests/video_conversion_test.cpp src/format_conversion/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6858a9bf240883318872a84a0d4191d4