### PR TITLE
Add env var to skip offline tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+    env:
+      SKIP_OFFLINE_TESTS: 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-cmake@v3

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ SRT files.
 All pushes and pull requests are built using GitHub Actions. The workflow
 config in `.github/workflows/build.yml` compiles the project on Linux,
 Windows and macOS with CMake to ensure the code builds across platforms.
+The CI defines `SKIP_OFFLINE_TESTS=true` so optional tests that require
+network access won't run in restricted environments.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- disable optional tests in workflow when network isn't available
- document the `SKIP_OFFLINE_TESTS` variable in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859f4617320833184ee8bfbaed21dfe