### PR TITLE
Implement subtitle provider with offset

### DIFF
--- a/src/subtitles/CMakeLists.txt
+++ b/src/subtitles/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mediaplayer_subtitles
     src/SrtParser.cpp
+    src/SubtitleProvider.cpp
 )
 
 target_include_directories(mediaplayer_subtitles PUBLIC

--- a/src/subtitles/include/mediaplayer/SubtitleProvider.h
+++ b/src/subtitles/include/mediaplayer/SubtitleProvider.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_SUBTITLEPROVIDER_H
+#define MEDIAPLAYER_SUBTITLEPROVIDER_H
+
+#include "SrtParser.h"
+
+namespace mediaplayer {
+
+class SubtitleProvider {
+public:
+  // Load subtitles from file (currently only SRT supported)
+  bool load(const std::string &path);
+
+  // Adjust subtitle timing by offset (in seconds). Positive values delay.
+  void setOffset(double offset) { m_offset = offset; }
+  double offset() const { return m_offset; }
+
+  // Retrieve subtitle cue for given playback time (seconds).
+  const SubtitleCue *subtitleAt(double time) const;
+
+private:
+  SrtParser m_parser;
+  double m_offset{0.0};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_SUBTITLEPROVIDER_H

--- a/src/subtitles/src/SubtitleProvider.cpp
+++ b/src/subtitles/src/SubtitleProvider.cpp
@@ -1,0 +1,11 @@
+#include "mediaplayer/SubtitleProvider.h"
+
+namespace mediaplayer {
+
+bool SubtitleProvider::load(const std::string &path) { return m_parser.load(path); }
+
+const SubtitleCue *SubtitleProvider::subtitleAt(double time) const {
+  return m_parser.cueAt(time + m_offset);
+}
+
+} // namespace mediaplayer

--- a/tests/subtitle_provider_test.cpp
+++ b/tests/subtitle_provider_test.cpp
@@ -1,0 +1,21 @@
+#include "mediaplayer/SubtitleProvider.h"
+#include <cassert>
+#include <fstream>
+
+int main() {
+  const char *srt =
+      "1\n00:00:01,000 --> 00:00:02,000\nHello\n\n2\n00:00:03,000 --> 00:00:04,000\nWorld\n";
+  const char *path = "provider.srt";
+  std::ofstream out(path);
+  out << srt;
+  out.close();
+
+  mediaplayer::SubtitleProvider provider;
+  assert(provider.load(path));
+  assert(provider.subtitleAt(1.5)->text == "Hello");
+  assert(provider.subtitleAt(3.5)->text == "World");
+  provider.setOffset(-1.0);
+  assert(provider.subtitleAt(2.5)->text == "World");
+  std::remove(path);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `SubtitleProvider` for retrieving subtitles with timing offset
- compile subtitle provider in `mediaplayer_subtitles`
- include simple test for provider

## Testing
- `clang-format -i src/subtitles/include/mediaplayer/SubtitleProvider.h src/subtitles/src/SubtitleProvider.cpp tests/subtitle_provider_test.cpp`


------
https://chatgpt.com/codex/tasks/task_e_685b2c872b748331a4da95709b0baa1e