### PR TITLE
Add LibraryDB update and remove methods

### DIFF
--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -16,6 +16,17 @@ public:
   bool initSchema();
   bool scanDirectory(const std::string &directory);
 
+  // Insert a media entry directly. Useful for tests or manual additions.
+  bool addMedia(const std::string &path, const std::string &title, const std::string &artist,
+                const std::string &album);
+
+  // Update metadata for an existing media entry identified by path.
+  bool updateMedia(const std::string &path, const std::string &title, const std::string &artist,
+                   const std::string &album);
+
+  // Remove a media item from the database by path.
+  bool removeMedia(const std::string &path);
+
 private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
                    const std::string &album);

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -82,4 +82,41 @@ bool LibraryDB::scanDirectory(const std::string &directory) {
   return true;
 }
 
+bool LibraryDB::addMedia(const std::string &path, const std::string &title,
+                         const std::string &artist, const std::string &album) {
+  if (!m_db)
+    return false;
+  return insertMedia(path, title, artist, album);
+}
+
+bool LibraryDB::updateMedia(const std::string &path, const std::string &title,
+                            const std::string &artist, const std::string &album) {
+  if (!m_db)
+    return false;
+  const char *sql = "UPDATE MediaItem SET title=?2, artist=?3, album=?4 WHERE path=?1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return false;
+  sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 2, title.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 3, artist.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 4, album.c_str(), -1, SQLITE_TRANSIENT);
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  return ok;
+}
+
+bool LibraryDB::removeMedia(const std::string &path) {
+  if (!m_db)
+    return false;
+  const char *sql = "DELETE FROM MediaItem WHERE path=?1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return false;
+  sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  return ok;
+}
+
 } // namespace mediaplayer

--- a/tests/library_db_update_test.cpp
+++ b/tests/library_db_update_test.cpp
@@ -1,0 +1,66 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+#include <sqlite3.h>
+#include <string>
+
+static int countRows(sqlite3 *db) {
+  sqlite3_stmt *stmt = nullptr;
+  sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM MediaItem;", -1, &stmt, nullptr);
+  int count = 0;
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    count = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+  return count;
+}
+
+static std::string titleFor(sqlite3 *db, const std::string &path) {
+  sqlite3_stmt *stmt = nullptr;
+  sqlite3_prepare_v2(db, "SELECT title FROM MediaItem WHERE path=?1;", -1, &stmt, nullptr);
+  sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
+  std::string title;
+  if (sqlite3_step(stmt) == SQLITE_ROW) {
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      title = reinterpret_cast<const char *>(txt);
+  }
+  sqlite3_finalize(stmt);
+  return title;
+}
+
+int main() {
+  const char *dbPath = "test_library.db";
+  {
+    mediaplayer::LibraryDB db(dbPath);
+    assert(db.open());
+    assert(db.addMedia("song.mp3", "Old", "Artist", "Album"));
+    db.close();
+  }
+  sqlite3 *conn = nullptr;
+  sqlite3_open(dbPath, &conn);
+  assert(countRows(conn) == 1);
+  assert(titleFor(conn, "song.mp3") == "Old");
+  sqlite3_close(conn);
+
+  {
+    mediaplayer::LibraryDB db(dbPath);
+    assert(db.open());
+    assert(db.updateMedia("song.mp3", "New", "Artist", "Album"));
+    db.close();
+  }
+  sqlite3_open(dbPath, &conn);
+  assert(titleFor(conn, "song.mp3") == "New");
+  sqlite3_close(conn);
+
+  {
+    mediaplayer::LibraryDB db(dbPath);
+    assert(db.open());
+    assert(db.removeMedia("song.mp3"));
+    db.close();
+  }
+  sqlite3_open(dbPath, &conn);
+  assert(countRows(conn) == 0);
+  sqlite3_close(conn);
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- extend `LibraryDB` with addMedia, updateMedia and removeMedia
- implement methods in the SQLite database implementation
- add unit test verifying update/remove logic

## Testing
- `g++ tests/library_db_update_test.cpp src/library/src/LibraryDB.cpp -std=c++17 -I./src/library/include -ltag -lsqlite3 -o library_db_update_test`
- `./library_db_update_test`

------
https://chatgpt.com/codex/tasks/task_e_685b3ade17788331bb17109c0cfaf4a5