### PR TITLE
Add basic OpenGL video output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A detailed breakdown of planned modules and tasks can be found in [Tasks.MD](Tas
 - Compiler with C++17 support
 - FFmpeg development libraries
 - Qt 6 development files
+- OpenGL headers and GLFW 3
 
 ```
 # Example build steps

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,20 +1,41 @@
-add_library(mediaplayer_core src / MediaPlayer.cpp src / AudioDecoder.cpp src /
-            VideoDecoder.cpp src / PlaylistManager.cpp src / AudioOutputPulse.cpp src /
-            PacketQueue.cpp)
+add_library(mediaplayer_core
+    src/MediaPlayer.cpp
+    src/AudioDecoder.cpp
+    src/VideoDecoder.cpp
+    src/PlaylistManager.cpp
+    src/AudioOutputPulse.cpp
+    src/PacketQueue.cpp
+    src/OpenGLVideoOutput.cpp
+)
 
-    find_package(PkgConfig) pkg_check_modules(
-        FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswresample libswscale)
-        pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
+find_package(PkgConfig)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswresample libswscale)
+pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
+find_package(OpenGL REQUIRED)
+find_package(glfw3 REQUIRED)
 
-            target_include_directories(
-                mediaplayer_core PUBLIC $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
-                    $<INSTALL_INTERFACE : include>
-                        ${FFMPEG_INCLUDE_DIRS} ${TAGLIB_INCLUDE_DIRS})
+target_include_directories(mediaplayer_core PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${FFMPEG_INCLUDE_DIRS}
+    ${TAGLIB_INCLUDE_DIRS}
+)
 
-                find_library(PULSE_SIMPLE_LIB pulse - simple) find_library(PULSE_LIB pulse)
+find_library(PULSE_SIMPLE_LIB pulse-simple)
+find_library(PULSE_LIB pulse)
 
-                    target_link_libraries(mediaplayer_core PkgConfig::FFMPEG PkgConfig::TAGLIB ${
-                        PULSE_SIMPLE_LIB} ${PULSE_LIB})
+target_link_libraries(mediaplayer_core
+    PkgConfig::FFMPEG
+    PkgConfig::TAGLIB
+    OpenGL::GL
+    glfw
+    ${PULSE_SIMPLE_LIB}
+    ${PULSE_LIB}
+)
 
-                        set_target_properties(
-                            mediaplayer_core PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaplayer_core PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+target_compile_definitions(mediaplayer_core PUBLIC MEDIAPLAYER_DESKTOP)

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -9,6 +9,7 @@
 #include "MediaMetadata.h"
 #include "NullAudioOutput.h"
 #include "NullVideoOutput.h"
+#include "OpenGLVideoOutput.h"
 #include "PacketQueue.h"
 #include "PlaybackCallbacks.h"
 #include "PlaylistManager.h"

--- a/src/core/include/mediaplayer/OpenGLVideoOutput.h
+++ b/src/core/include/mediaplayer/OpenGLVideoOutput.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_OPENGLVIDEOOUTPUT_H
+#define MEDIAPLAYER_OPENGLVIDEOOUTPUT_H
+
+#include "VideoOutput.h"
+#include <GLFW/glfw3.h>
+
+namespace mediaplayer {
+
+class OpenGLVideoOutput : public VideoOutput {
+public:
+  OpenGLVideoOutput();
+  ~OpenGLVideoOutput() override;
+
+  bool init(int width, int height) override;
+  void shutdown() override;
+  void displayFrame(const uint8_t *rgba, int linesize) override;
+
+private:
+  GLFWwindow *m_window{nullptr};
+  unsigned int m_texture{0};
+  int m_width{0};
+  int m_height{0};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_OPENGLVIDEOOUTPUT_H

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -15,7 +15,11 @@ namespace mediaplayer {
 MediaPlayer::MediaPlayer() {
   avformat_network_init();
   m_output = std::make_unique<NullAudioOutput>();
+#ifdef MEDIAPLAYER_DESKTOP
+  m_videoOutput = std::make_unique<OpenGLVideoOutput>();
+#else
   m_videoOutput = std::make_unique<NullVideoOutput>();
+#endif
   m_eof = false;
 }
 

--- a/src/core/src/OpenGLVideoOutput.cpp
+++ b/src/core/src/OpenGLVideoOutput.cpp
@@ -1,0 +1,70 @@
+#include "mediaplayer/OpenGLVideoOutput.h"
+
+#include <GL/gl.h>
+#include <iostream>
+
+namespace mediaplayer {
+
+OpenGLVideoOutput::OpenGLVideoOutput() = default;
+
+OpenGLVideoOutput::~OpenGLVideoOutput() { shutdown(); }
+
+bool OpenGLVideoOutput::init(int width, int height) {
+  if (!glfwInit()) {
+    std::cerr << "Failed to init GLFW\n";
+    return false;
+  }
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+  m_window = glfwCreateWindow(width, height, "MediaPlayer", nullptr, nullptr);
+  if (!m_window) {
+    std::cerr << "Failed to create GLFW window\n";
+    glfwTerminate();
+    return false;
+  }
+  glfwMakeContextCurrent(m_window);
+  glGenTextures(1, &m_texture);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  m_width = width;
+  m_height = height;
+  return true;
+}
+
+void OpenGLVideoOutput::shutdown() {
+  if (m_texture) {
+    glDeleteTextures(1, &m_texture);
+    m_texture = 0;
+  }
+  if (m_window) {
+    glfwDestroyWindow(m_window);
+    m_window = nullptr;
+    glfwTerminate();
+  }
+}
+
+void OpenGLVideoOutput::displayFrame(const uint8_t *rgba, int linesize) {
+  if (!m_window)
+    return;
+  glfwMakeContextCurrent(m_window);
+  glClear(GL_COLOR_BUFFER_BIT);
+  glBindTexture(GL_TEXTURE_2D, m_texture);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, linesize / 4);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
+  glEnable(GL_TEXTURE_2D);
+  glBegin(GL_QUADS);
+  glTexCoord2f(0.f, 1.f);
+  glVertex2f(-1.f, -1.f);
+  glTexCoord2f(1.f, 1.f);
+  glVertex2f(1.f, -1.f);
+  glTexCoord2f(1.f, 0.f);
+  glVertex2f(1.f, 1.f);
+  glTexCoord2f(0.f, 0.f);
+  glVertex2f(-1.f, 1.f);
+  glEnd();
+  glfwSwapBuffers(m_window);
+  glfwPollEvents();
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `OpenGLVideoOutput` implementation using GLFW
- compile `OpenGLVideoOutput` on desktop builds and use by default
- link OpenGL and glfw in `mediaplayer_core`
- note new OpenGL/GLFW prerequisite in README

## Testing
- `cmake ..` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b45221d888331983464589435a5f8