### PR TITLE
Implement library search feature

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -66,7 +66,7 @@
 | 55 | Smart Playlist Criteria | open | relevant |
 | 56 | Auto Playlists (Recent, Frequent) | open | relevant |
 | 57 | AI Recommendations Hook | open | relevant |
-| 58 | Search Functionality | open | relevant |
+| 58 | Search Functionality | done | relevant |
 | 59 | Rating System | open | relevant |
 | 60 | Library-Core Integration | open | relevant |
 | 61 | Expose Library API to UI | open | relevant |

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(mediaplayer_library PUBLIC
     ${SQLITE3_INCLUDE_DIRS}
     ${TAGLIB_INCLUDE_DIRS}
     ${FFMPEG_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/src/core/include
 )
 
 target_link_libraries(mediaplayer_library

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -1,8 +1,10 @@
 #ifndef MEDIAPLAYER_LIBRARYDB_H
 #define MEDIAPLAYER_LIBRARYDB_H
 
+#include "mediaplayer/MediaMetadata.h"
 #include <sqlite3.h>
 #include <string>
+#include <vector>
 
 namespace mediaplayer {
 
@@ -26,6 +28,10 @@ public:
 
   // Remove a media item from the database by path.
   bool removeMedia(const std::string &path);
+
+  // Search library for items where title, artist or album contain the query
+  // string. Case-insensitive according to SQLite's LIKE operator.
+  std::vector<MediaMetadata> search(const std::string &query);
 
 private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,

--- a/tests/library_search_test.cpp
+++ b/tests/library_search_test.cpp
@@ -1,0 +1,21 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "search_test.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("song1.mp3", "Hello World", "Artist1", "Album1"));
+  assert(db.addMedia("song2.mp3", "Goodbye", "Artist2", "Album2"));
+  assert(db.addMedia("song3.mp3", "Hello Again", "Artist3", "Album3"));
+
+  auto resHello = db.search("Hello");
+  assert(resHello.size() == 2);
+  auto resArtist = db.search("Artist2");
+  assert(resArtist.size() == 1 && resArtist[0].path == "song2.mp3");
+
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add search method to `LibraryDB`
- expose `MediaMetadata` in library headers
- update CMake include directories for library
- mark `Search Functionality` task as done
- add unit test for library search

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp tests/library_search_test.cpp`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c9fcbb4948331b0f1b821b6a9592f