### PR TITLE
Implement playlist management in LibraryDB

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -62,7 +62,7 @@
 | 51 | Implement Library Scanning | done | relevant |
 | 52 | Metadata Extraction | open | relevant |
 | 53 | Update/Remove Entries | open | relevant |
-| 54 | Basic Playlist Management | open | relevant |
+| 54 | Basic Playlist Management | done | relevant |
 | 55 | Smart Playlist Criteria | open | relevant |
 | 56 | Auto Playlists (Recent, Frequent) | open | relevant |
 | 57 | AI Recommendations Hook | open | relevant |

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -36,9 +36,17 @@ public:
   // Increment play count and update last played timestamp for a media item.
   bool recordPlayback(const std::string &path);
 
+  // Playlist management
+  bool createPlaylist(const std::string &name);
+  bool deletePlaylist(const std::string &name);
+  bool addToPlaylist(const std::string &name, const std::string &path);
+  bool removeFromPlaylist(const std::string &name, const std::string &path);
+  std::vector<MediaMetadata> playlistItems(const std::string &name);
+
 private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
                    const std::string &album, int duration = 0, int width = 0, int height = 0);
+  int playlistId(const std::string &name) const;
 
 private:
   std::string m_path;

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,4 +2,5 @@
 
 This directory contains simple test programs. `test_srtparser.cpp` verifies
 the SRT subtitle parser. `format_conversion_test.cpp` exercises the
-audio conversion utility.
+audio conversion utility. `library_playlist_test.cpp` checks basic
+playlist management in the SQLite library.

--- a/tests/library_playlist_test.cpp
+++ b/tests/library_playlist_test.cpp
@@ -1,0 +1,24 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "playlist_test.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("song1.mp3", "Song1", "Artist", "Album"));
+  assert(db.addMedia("song2.mp3", "Song2", "Artist", "Album"));
+
+  assert(db.createPlaylist("fav"));
+  assert(db.addToPlaylist("fav", "song1.mp3"));
+  assert(db.addToPlaylist("fav", "song2.mp3"));
+  auto items = db.playlistItems("fav");
+  assert(items.size() == 2 && items[0].path == "song1.mp3");
+  assert(db.removeFromPlaylist("fav", "song1.mp3"));
+  items = db.playlistItems("fav");
+  assert(items.size() == 1 && items[0].path == "song2.mp3");
+  assert(db.deletePlaylist("fav"));
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- support basic playlist tables in the SQLite library
- expose playlist CRUD methods in `LibraryDB`
- add tests for playlist functions
- document new test and mark task as done

## Testing
- `g++ -std=c++17 tests/library_playlist_test.cpp src/library/src/LibraryDB.cpp -I src/library/include -I src/core/include -lsqlite3 -ltag -lavformat -lavcodec -lavutil -o /tmp/test_bin` *(fails: libavformat/avformat.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685caba030b08331b18156d55feb6cca