### PR TITLE
Implement rating system in LibraryDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ The core library links with FFmpeg and can open media files using
 `avformat_open_input`. The conversion module provides a simple API to
 convert audio files between formats while the subtitles module parses
 SRT files.
-The SQLite-based library tracks media metadata and updates play counts when
-items are played through the core engine.
+The SQLite-based library tracks media metadata, including an optional rating
+field, and updates play counts when items are played through the core engine.
 
 ## Continuous Integration
 

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -36,6 +36,10 @@ public:
   // Increment play count and update last played timestamp for a media item.
   bool recordPlayback(const std::string &path);
 
+  // Rating management (0-5). Values outside range will be clamped.
+  bool setRating(const std::string &path, int rating);
+  int rating(const std::string &path) const;
+
   // Playlist management
   bool createPlaylist(const std::string &name);
   bool deletePlaylist(const std::string &name);
@@ -45,7 +49,8 @@ public:
 
 private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
-                   const std::string &album, int duration = 0, int width = 0, int height = 0);
+                   const std::string &album, int duration = 0, int width = 0, int height = 0,
+                   int rating = 0);
   int playlistId(const std::string &name) const;
 
 private:

--- a/tests/library_rating_test.cpp
+++ b/tests/library_rating_test.cpp
@@ -1,0 +1,19 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "rating.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("song.mp3", "Title", "Artist", "Album"));
+  assert(db.setRating("song.mp3", 4));
+  assert(db.rating("song.mp3") == 4);
+  assert(db.setRating("song.mp3", 6));
+  assert(db.rating("song.mp3") == 5);
+  assert(db.setRating("song.mp3", -1));
+  assert(db.rating("song.mp3") == 0);
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- extend `MediaItem` table with `rating`
- add `setRating` and `rating` functions in `LibraryDB`
- expose new API in header and update README
- provide a small test for rating support

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp tests/library_rating_test.cpp`


------
https://chatgpt.com/codex/tasks/task_e_685cb1f7605c833187c23927e51eeb93