### PR TITLE
library: close DB when schema init fails

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -16,7 +16,12 @@ bool LibraryDB::open() {
     std::cerr << "Failed to open DB: " << sqlite3_errmsg(m_db) << '\n';
     return false;
   }
-  return initSchema();
+  if (!initSchema()) {
+    sqlite3_close(m_db);
+    m_db = nullptr;
+    return false;
+  }
+  return true;
 }
 
 void LibraryDB::close() {


### PR DESCRIPTION
## Summary
- handle failure of `initSchema()` in `LibraryDB::open`

## Testing
- `cmake -S . -B build` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbe83feb48331ade7f7815f37a467