### PR TITLE
Fix decoder context cleanup on open failures

### DIFF
--- a/src/core/src/VideoDecoder.cpp
+++ b/src/core/src/VideoDecoder.cpp
@@ -35,15 +35,21 @@ bool VideoDecoder::open(AVFormatContext *fmtCtx, int streamIndex) {
     return false;
   }
   if (avcodec_parameters_to_context(m_codecCtx, stream->codecpar) < 0) {
+    avcodec_free_context(&m_codecCtx);
     return false;
   }
   if (avcodec_open2(m_codecCtx, dec, nullptr) < 0) {
+    avcodec_free_context(&m_codecCtx);
     return false;
   }
   m_swsCtx =
       sws_getContext(m_codecCtx->width, m_codecCtx->height, m_codecCtx->pix_fmt, m_codecCtx->width,
                      m_codecCtx->height, AV_PIX_FMT_RGBA, SWS_BILINEAR, nullptr, nullptr, nullptr);
-  return m_swsCtx != nullptr;
+  if (!m_swsCtx) {
+    avcodec_free_context(&m_codecCtx);
+    return false;
+  }
+  return true;
 }
 
 int VideoDecoder::decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) {


### PR DESCRIPTION
## Summary
- ensure `AudioDecoder::open` frees allocated contexts when initialization fails
- ensure `VideoDecoder::open` frees allocated contexts when initialization fails

## Testing
- `clang-format -i src/core/src/AudioDecoder.cpp src/core/src/VideoDecoder.cpp`
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efa13b8948331ad2bfa4d7b91b19a