### PR TITLE
Fix PulseAudio write error handling

### DIFF
--- a/src/core/src/AudioOutputPulse.cpp
+++ b/src/core/src/AudioOutputPulse.cpp
@@ -34,8 +34,8 @@ void AudioOutputPulse::shutdown() {
 int AudioOutputPulse::write(const uint8_t *data, int len) {
   if (!m_pa || m_paused)
     return 0;
-  int error = pa_simple_write(m_pa, data, static_cast<size_t>(len), nullptr);
-  if (error < 0) {
+  int error = 0;
+  if (pa_simple_write(m_pa, data, static_cast<size_t>(len), &error) < 0) {
     std::cerr << "PulseAudio write failed: " << pa_strerror(error) << "\n";
     return -1;
   }


### PR DESCRIPTION
## Summary
- correctly pass error pointer to `pa_simple_write`
- log PulseAudio errors using the provided error code

## Testing
- `clang-format -i src/core/src/AudioOutputPulse.cpp`

------
https://chatgpt.com/codex/tasks/task_e_685efa13f0588331a6e44f81712632b1