### PR TITLE
Add macOS CoreAudio audio backend

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,12 +1,19 @@
-add_library(mediaplayer_core
+set(CORE_SOURCES
     src/MediaPlayer.cpp
     src/AudioDecoder.cpp
     src/VideoDecoder.cpp
     src/PlaylistManager.cpp
-    src/AudioOutputPulse.cpp
     src/PacketQueue.cpp
     src/OpenGLVideoOutput.cpp
 )
+
+if(APPLE)
+    list(APPEND CORE_SOURCES src/AudioOutputCoreAudio.mm)
+elseif(UNIX)
+    list(APPEND CORE_SOURCES src/AudioOutputPulse.cpp)
+endif()
+
+add_library(mediaplayer_core ${CORE_SOURCES})
 
 find_package(PkgConfig)
 pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
@@ -27,17 +34,24 @@ target_include_directories(mediaplayer_core PUBLIC
     ${TAGLIB_INCLUDE_DIRS}
 )
 
-find_library(PULSE_SIMPLE_LIB pulse-simple)
-find_library(PULSE_LIB pulse)
-
 target_link_libraries(mediaplayer_core
     PkgConfig::FFMPEG
     PkgConfig::TAGLIB
     OpenGL::GL
     glfw
-    ${PULSE_SIMPLE_LIB}
-    ${PULSE_LIB}
 )
+
+if(APPLE)
+    target_link_libraries(mediaplayer_core
+        "-framework AudioToolbox"
+        "-framework CoreAudio")
+else()
+    find_library(PULSE_SIMPLE_LIB pulse-simple)
+    find_library(PULSE_LIB pulse)
+    target_link_libraries(mediaplayer_core
+        ${PULSE_SIMPLE_LIB}
+        ${PULSE_LIB})
+endif()
 
 set_target_properties(mediaplayer_core PROPERTIES
     CXX_STANDARD 17

--- a/src/core/include/mediaplayer/AudioOutputCoreAudio.h
+++ b/src/core/include/mediaplayer/AudioOutputCoreAudio.h
@@ -1,0 +1,29 @@
+#ifndef MEDIAPLAYER_AUDIOOUTPUTCOREAUDIO_H
+#define MEDIAPLAYER_AUDIOOUTPUTCOREAUDIO_H
+
+#include "AudioOutput.h"
+#include <AudioToolbox/AudioToolbox.h>
+
+namespace mediaplayer {
+
+class AudioOutputCoreAudio : public AudioOutput {
+public:
+  AudioOutputCoreAudio();
+  ~AudioOutputCoreAudio() override;
+
+  bool init(int sampleRate, int channels) override;
+  void shutdown() override;
+  int write(const uint8_t *data, int len) override;
+  void pause() override;
+  void resume() override;
+
+private:
+  AudioQueueRef m_queue{nullptr};
+  AudioStreamBasicDescription m_format{};
+  bool m_started{false};
+  bool m_paused{false};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOOUTPUTCOREAUDIO_H

--- a/src/core/src/AudioOutputCoreAudio.mm
+++ b/src/core/src/AudioOutputCoreAudio.mm
@@ -1,0 +1,78 @@
+#include "mediaplayer/AudioOutputCoreAudio.h"
+
+#include <cstring>
+
+namespace mediaplayer {
+
+static void BufferCallback(void *userData, AudioQueueRef inAQ, AudioQueueBufferRef inBuffer) {
+  AudioQueueFreeBuffer(inAQ, inBuffer);
+}
+
+AudioOutputCoreAudio::AudioOutputCoreAudio() = default;
+
+AudioOutputCoreAudio::~AudioOutputCoreAudio() { shutdown(); }
+
+bool AudioOutputCoreAudio::init(int sampleRate, int channels) {
+  m_format.mSampleRate = sampleRate;
+  m_format.mFormatID = kAudioFormatLinearPCM;
+  m_format.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
+  m_format.mBitsPerChannel = 16;
+  m_format.mChannelsPerFrame = static_cast<UInt32>(channels);
+  m_format.mBytesPerFrame = m_format.mChannelsPerFrame * m_format.mBitsPerChannel / 8;
+  m_format.mFramesPerPacket = 1;
+  m_format.mBytesPerPacket = m_format.mBytesPerFrame;
+  m_format.mReserved = 0;
+
+  OSStatus status =
+      AudioQueueNewOutput(&m_format, BufferCallback, this, nullptr, nullptr, 0, &m_queue);
+  if (status != noErr)
+    return false;
+  status = AudioQueueStart(m_queue, nullptr);
+  if (status != noErr) {
+    AudioQueueDispose(m_queue, true);
+    m_queue = nullptr;
+    return false;
+  }
+  m_started = true;
+  return true;
+}
+
+void AudioOutputCoreAudio::shutdown() {
+  if (m_queue) {
+    AudioQueueStop(m_queue, true);
+    AudioQueueDispose(m_queue, true);
+    m_queue = nullptr;
+  }
+  m_started = false;
+}
+
+int AudioOutputCoreAudio::write(const uint8_t *data, int len) {
+  if (!m_queue || m_paused)
+    return 0;
+  AudioQueueBufferRef buffer;
+  if (AudioQueueAllocateBuffer(m_queue, len, &buffer) != noErr)
+    return -1;
+  std::memcpy(buffer->mAudioData, data, len);
+  buffer->mAudioDataByteSize = static_cast<UInt32>(len);
+  if (AudioQueueEnqueueBuffer(m_queue, buffer, 0, nullptr) != noErr) {
+    AudioQueueFreeBuffer(m_queue, buffer);
+    return -1;
+  }
+  return len;
+}
+
+void AudioOutputCoreAudio::pause() {
+  if (m_queue && !m_paused) {
+    AudioQueuePause(m_queue);
+    m_paused = true;
+  }
+}
+
+void AudioOutputCoreAudio::resume() {
+  if (m_queue && m_paused) {
+    AudioQueueStart(m_queue, nullptr);
+    m_paused = false;
+  }
+}
+
+} // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -1,4 +1,9 @@
 #include "mediaplayer/MediaPlayer.h"
+#ifdef __APPLE__
+#include "mediaplayer/AudioOutputCoreAudio.h"
+#elif defined(__linux__)
+#include "mediaplayer/AudioOutputPulse.h"
+#endif
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -14,7 +19,13 @@ namespace mediaplayer {
 
 MediaPlayer::MediaPlayer() {
   avformat_network_init();
+#ifdef __APPLE__
+  m_output = std::make_unique<AudioOutputCoreAudio>();
+#elif defined(__linux__)
+  m_output = std::make_unique<AudioOutputPulse>();
+#else
   m_output = std::make_unique<NullAudioOutput>();
+#endif
 #ifdef MEDIAPLAYER_DESKTOP
   m_videoOutput = std::make_unique<OpenGLVideoOutput>();
 #else


### PR DESCRIPTION
## Summary
- add `AudioOutputCoreAudio` Objective‑C++ implementation for macOS
- hook CoreAudio backend into `MediaPlayer` on Apple platforms
- update core CMake to build Objective‑C++ file and link AudioToolbox/CoreAudio frameworks
- fix formatting of CMake file

## Testing
- `clang-format -i src/core/CMakeLists.txt src/core/src/MediaPlayer.cpp src/core/include/mediaplayer/AudioOutputCoreAudio.h src/core/src/AudioOutputCoreAudio.mm`

------
https://chatgpt.com/codex/tasks/task_e_685f13c63e1083319e22158ec769a623