### PR TITLE
Add Windows WASAPI audio output class

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(mediaplayer_core
     src/AudioDecoder.cpp
     src/VideoDecoder.cpp
     src/PlaylistManager.cpp
-    src/AudioOutputPulse.cpp
     src/PacketQueue.cpp
     src/OpenGLVideoOutput.cpp
 )
@@ -26,18 +25,24 @@ target_include_directories(mediaplayer_core PUBLIC
     ${FFMPEG_INCLUDE_DIRS}
     ${TAGLIB_INCLUDE_DIRS}
 )
-
-find_library(PULSE_SIMPLE_LIB pulse-simple)
-find_library(PULSE_LIB pulse)
-
 target_link_libraries(mediaplayer_core
     PkgConfig::FFMPEG
     PkgConfig::TAGLIB
     OpenGL::GL
     glfw
-    ${PULSE_SIMPLE_LIB}
-    ${PULSE_LIB}
 )
+
+if (WIN32)
+  target_sources(mediaplayer_core PRIVATE src/AudioOutputWASAPI.cpp)
+  target_link_libraries(mediaplayer_core ole32)
+else()
+  target_sources(mediaplayer_core PRIVATE src/AudioOutputPulse.cpp)
+  find_library(PULSE_SIMPLE_LIB pulse-simple)
+  find_library(PULSE_LIB pulse)
+  target_link_libraries(mediaplayer_core ${PULSE_SIMPLE_LIB} ${PULSE_LIB})
+endif()
+
+
 
 set_target_properties(mediaplayer_core PROPERTIES
     CXX_STANDARD 17

--- a/src/core/include/mediaplayer/AudioOutputWASAPI.h
+++ b/src/core/include/mediaplayer/AudioOutputWASAPI.h
@@ -1,0 +1,36 @@
+#ifndef MEDIAPLAYER_AUDIOOUTPUTWASAPI_H
+#define MEDIAPLAYER_AUDIOOUTPUTWASAPI_H
+
+#include "AudioOutput.h"
+#ifdef _WIN32
+#include <Audioclient.h>
+#include <Mmdeviceapi.h>
+#endif
+
+namespace mediaplayer {
+
+#ifdef _WIN32
+class AudioOutputWASAPI : public AudioOutput {
+public:
+  AudioOutputWASAPI();
+  ~AudioOutputWASAPI() override;
+
+  bool init(int sampleRate, int channels) override;
+  void shutdown() override;
+  int write(const uint8_t *data, int len) override;
+  void pause() override;
+  void resume() override;
+
+private:
+  IMMDevice *m_device{nullptr};
+  IAudioClient *m_client{nullptr};
+  IAudioRenderClient *m_render{nullptr};
+  WAVEFORMATEX *m_format{nullptr};
+  UINT32 m_bufferFrames{0};
+  bool m_paused{false};
+};
+#endif
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOOUTPUTWASAPI_H

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -9,6 +9,9 @@
 #include "LibraryDB.h"
 #include "MediaMetadata.h"
 #include "NullAudioOutput.h"
+#ifdef _WIN32
+#include "AudioOutputWASAPI.h"
+#endif
 #include "NullVideoOutput.h"
 #include "OpenGLVideoOutput.h"
 #include "PacketQueue.h"

--- a/src/core/src/AudioOutputWASAPI.cpp
+++ b/src/core/src/AudioOutputWASAPI.cpp
@@ -1,0 +1,128 @@
+#ifdef _WIN32
+#include "mediaplayer/AudioOutputWASAPI.h"
+#include <algorithm>
+#include <cstring>
+
+namespace mediaplayer {
+
+AudioOutputWASAPI::AudioOutputWASAPI() = default;
+
+AudioOutputWASAPI::~AudioOutputWASAPI() { shutdown(); }
+
+bool AudioOutputWASAPI::init(int sampleRate, int channels) {
+  HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  if (FAILED(hr) && hr != RPC_E_CHANGED_MODE)
+    return false;
+
+  IMMDeviceEnumerator *enumerator = nullptr;
+  hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                        IID_PPV_ARGS(&enumerator));
+  if (FAILED(hr))
+    return false;
+
+  hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &m_device);
+  enumerator->Release();
+  if (FAILED(hr))
+    return false;
+
+  hr = m_device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                          reinterpret_cast<void **>(&m_client));
+  if (FAILED(hr))
+    return false;
+
+  WAVEFORMATEX waveFmt{};
+  waveFmt.wFormatTag = WAVE_FORMAT_PCM;
+  waveFmt.nChannels = static_cast<WORD>(channels);
+  waveFmt.nSamplesPerSec = sampleRate;
+  waveFmt.wBitsPerSample = 16;
+  waveFmt.nBlockAlign = waveFmt.nChannels * waveFmt.wBitsPerSample / 8;
+  waveFmt.nAvgBytesPerSec = waveFmt.nSamplesPerSec * waveFmt.nBlockAlign;
+  waveFmt.cbSize = 0;
+
+  REFERENCE_TIME bufferDuration = 1000000;
+  hr = m_client->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, bufferDuration, 0, &waveFmt, nullptr);
+  if (FAILED(hr))
+    return false;
+
+  hr = m_client->GetBufferSize(&m_bufferFrames);
+  if (FAILED(hr))
+    return false;
+
+  hr = m_client->GetService(__uuidof(IAudioRenderClient), reinterpret_cast<void **>(&m_render));
+  if (FAILED(hr))
+    return false;
+
+  m_format = reinterpret_cast<WAVEFORMATEX *>(CoTaskMemAlloc(sizeof(WAVEFORMATEX)));
+  if (!m_format)
+    return false;
+  *m_format = waveFmt;
+
+  hr = m_client->Start();
+  if (FAILED(hr))
+    return false;
+  m_paused = false;
+  return true;
+}
+
+void AudioOutputWASAPI::shutdown() {
+  if (m_client) {
+    m_client->Stop();
+  }
+  if (m_render) {
+    m_render->Release();
+    m_render = nullptr;
+  }
+  if (m_client) {
+    m_client->Release();
+    m_client = nullptr;
+  }
+  if (m_device) {
+    m_device->Release();
+    m_device = nullptr;
+  }
+  if (m_format) {
+    CoTaskMemFree(m_format);
+    m_format = nullptr;
+  }
+  CoUninitialize();
+}
+
+int AudioOutputWASAPI::write(const uint8_t *data, int len) {
+  if (!m_render || m_paused)
+    return 0;
+
+  UINT32 padding = 0;
+  if (FAILED(m_client->GetCurrentPadding(&padding)))
+    return 0;
+
+  UINT32 frameSize = m_format->nBlockAlign;
+  UINT32 framesAvailable = m_bufferFrames - padding;
+  UINT32 framesToWrite = std::min(framesAvailable, static_cast<UINT32>(len / frameSize));
+  if (framesToWrite == 0)
+    return 0;
+
+  BYTE *buffer = nullptr;
+  if (FAILED(m_render->GetBuffer(framesToWrite, &buffer)))
+    return 0;
+
+  std::memcpy(buffer, data, framesToWrite * frameSize);
+  m_render->ReleaseBuffer(framesToWrite, 0);
+  return static_cast<int>(framesToWrite * frameSize);
+}
+
+void AudioOutputWASAPI::pause() {
+  if (m_client && !m_paused) {
+    m_client->Stop();
+    m_paused = true;
+  }
+}
+
+void AudioOutputWASAPI::resume() {
+  if (m_client && m_paused) {
+    m_client->Start();
+    m_paused = false;
+  }
+}
+
+} // namespace mediaplayer
+#endif

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -12,9 +12,16 @@
 
 namespace mediaplayer {
 
+#ifdef _WIN32
+#define DEFAULT_AUDIO_OUTPUT std::make_unique<AudioOutputWASAPI>()
+#else
+#define DEFAULT_AUDIO_OUTPUT std::make_unique<NullAudioOutput>()
+#endif
+
 MediaPlayer::MediaPlayer() {
   avformat_network_init();
-  m_output = std::make_unique<NullAudioOutput>();
+  m_output = DEFAULT_AUDIO_OUTPUT;
+#undef DEFAULT_AUDIO_OUTPUT
 #ifdef MEDIAPLAYER_DESKTOP
   m_videoOutput = std::make_unique<OpenGLVideoOutput>();
 #else


### PR DESCRIPTION
## Summary
- implement `AudioOutputWASAPI` for Windows using WASAPI APIs
- hook WASAPI output into `MediaPlayer` when building on Windows
- update build to compile the new source on Windows only

## Testing
- `clang-format -i src/core/include/mediaplayer/AudioOutputWASAPI.h src/core/src/AudioOutputWASAPI.cpp src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_685f13c49f448331a403e119fda5365d