### PR TITLE
Introduce MediaDemuxer helper

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CORE_SOURCES
     src/VideoDecoder.cpp
     src/PlaylistManager.cpp
     src/PacketQueue.cpp
+    src/MediaDemuxer.cpp
     src/OpenGLVideoOutput.cpp
 )
 

--- a/src/core/include/mediaplayer/MediaDemuxer.h
+++ b/src/core/include/mediaplayer/MediaDemuxer.h
@@ -1,0 +1,36 @@
+#ifndef MEDIAPLAYER_MEDIADEMUXER_H
+#define MEDIAPLAYER_MEDIADEMUXER_H
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <string>
+
+namespace mediaplayer {
+
+class MediaDemuxer {
+public:
+  MediaDemuxer();
+  ~MediaDemuxer();
+
+  bool open(const std::string &path);
+  void close();
+  bool readPacket(AVPacket &pkt);
+  int audioStream() const { return m_audioStream; }
+  int videoStream() const { return m_videoStream; }
+  AVFormatContext *context() const { return m_ctx; }
+  bool eof() const { return m_eof; }
+
+private:
+  static bool isUrl(const std::string &path);
+
+  AVFormatContext *m_ctx{nullptr};
+  int m_audioStream{-1};
+  int m_videoStream{-1};
+  bool m_eof{false};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_MEDIADEMUXER_H

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -1,14 +1,13 @@
 #ifndef MEDIAPLAYER_MEDIAPLAYER_H
 #define MEDIAPLAYER_MEDIAPLAYER_H
 
-#include <libavformat/avformat.h>
 #include <string>
 
 #include "AudioDecoder.h"
 #include "AudioOutput.h"
 #include "LibraryDB.h"
+#include "MediaDemuxer.h"
 #include "MediaMetadata.h"
-#include "NetworkStream.h"
 #include "NullAudioOutput.h"
 #include "NullVideoOutput.h"
 #include "OpenGLVideoOutput.h"
@@ -55,7 +54,7 @@ private:
   void demuxLoop();
   void audioLoop();
   void videoLoop();
-  AVFormatContext *m_formatCtx{nullptr};
+  MediaDemuxer m_demuxer;
   AudioDecoder m_audioDecoder;
   VideoDecoder m_videoDecoder;
   std::unique_ptr<AudioOutput> m_output;
@@ -71,11 +70,8 @@ private:
   double m_videoClock{0.0};
   double m_startTime{0.0};
   bool m_stopRequested{false};
-  int m_audioStream{-1};
-  int m_videoStream{-1};
   PacketQueue m_audioPackets;
   PacketQueue m_videoPackets;
-  bool m_eof{false};
   PlaybackCallbacks m_callbacks;
   PlaylistManager m_playlist;
   LibraryDB *m_library{nullptr};

--- a/src/core/src/MediaDemuxer.cpp
+++ b/src/core/src/MediaDemuxer.cpp
@@ -1,0 +1,62 @@
+#include "mediaplayer/MediaDemuxer.h"
+#include "mediaplayer/NetworkStream.h"
+#include <iostream>
+
+namespace mediaplayer {
+
+MediaDemuxer::MediaDemuxer() = default;
+
+MediaDemuxer::~MediaDemuxer() { close(); }
+
+bool MediaDemuxer::isUrl(const std::string &path) {
+  return path.rfind("http://", 0) == 0 || path.rfind("https://", 0) == 0;
+}
+
+void MediaDemuxer::close() {
+  if (m_ctx) {
+    avformat_close_input(&m_ctx);
+  }
+  m_audioStream = -1;
+  m_videoStream = -1;
+  m_eof = false;
+}
+
+bool MediaDemuxer::open(const std::string &path) {
+  close();
+  if (isUrl(path)) {
+    NetworkStream stream;
+    if (!stream.open(path)) {
+      return false;
+    }
+    m_ctx = stream.release();
+  } else if (avformat_open_input(&m_ctx, path.c_str(), nullptr, nullptr) < 0) {
+    std::cerr << "Failed to open media: " << path << '\n';
+    return false;
+  }
+  if (avformat_find_stream_info(m_ctx, nullptr) < 0) {
+    std::cerr << "Failed to retrieve stream info\n";
+    avformat_close_input(&m_ctx);
+    return false;
+  }
+  for (unsigned i = 0; i < m_ctx->nb_streams; ++i) {
+    if (m_ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && m_audioStream < 0) {
+      m_audioStream = i;
+    } else if (m_ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && m_videoStream < 0) {
+      m_videoStream = i;
+    }
+  }
+  m_eof = false;
+  return true;
+}
+
+bool MediaDemuxer::readPacket(AVPacket &pkt) {
+  if (!m_ctx || m_eof)
+    return false;
+  if (av_read_frame(m_ctx, &pkt) < 0) {
+    m_eof = true;
+    return false;
+  }
+  return true;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add new MediaDemuxer component handling AVFormatContext lifecycle
- refactor MediaPlayer to use MediaDemuxer for opening and demuxing
- expose demuxer state in playback loops
- hook new source files into CMake

## Testing
- `cmake -S . -B build` *(fails: required packages not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f23350c108331a6ad3c38f1a1d128