### PR TITLE
Make stop request atomic

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -70,7 +70,7 @@ private:
   double m_audioClock{0.0};
   double m_videoClock{0.0};
   double m_startTime{0.0};
-  bool m_stopRequested{false};
+  std::atomic<bool> m_stopRequested{false};
   int m_audioStream{-1};
   int m_videoStream{-1};
   PacketQueue m_audioPackets;


### PR DESCRIPTION
## Summary
- make `m_stopRequested` an `std::atomic<bool>` to avoid race conditions
- update reads/writes using `.load()` and `.store()`
- clang-format the modified code

## Testing
- `cmake ..` *(fails: libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f233f9b2083318e0e844a34948325