### PR TITLE
Fix queue clearing on seek

### DIFF
--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -288,6 +288,11 @@ void MediaPlayer::seek(double seconds) {
   av_seek_frame(m_formatCtx, -1, ts, AVSEEK_FLAG_BACKWARD);
   m_audioDecoder.flush();
   m_videoDecoder.flush();
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_audioPackets.clear();
+    m_videoPackets.clear();
+  }
   m_audioClock = seconds;
   m_videoClock = seconds;
 }


### PR DESCRIPTION
## Summary
- clear queued packets when seeking
- protect queue clearing with the media player mutex

## Testing
- `clang-format -i src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_685f234209dc8331854e92decdd8c845