### PR TITLE
Improve PacketQueue pop and update loops

### DIFF
--- a/src/core/include/mediaplayer/PacketQueue.h
+++ b/src/core/include/mediaplayer/PacketQueue.h
@@ -5,11 +5,11 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 }
 
+#include <condition_variable>
 #include <cstddef>
+#include <functional>
 #include <mutex>
 #include <queue>
-
-#include <condition_variable>
 
 namespace mediaplayer {
 
@@ -19,7 +19,7 @@ public:
   ~PacketQueue();
 
   bool push(const AVPacket *pkt);
-  bool pop(AVPacket *&pkt);
+  bool pop(AVPacket *&pkt, const std::function<bool()> &waitPredicate = [] { return false; });
   void clear();
   size_t size() const;
   bool full() const;

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -356,7 +356,7 @@ void MediaPlayer::audioLoop() {
         break;
     }
     AVPacket *pkt = nullptr;
-    if (m_audioPackets.pop(pkt)) {
+    if (m_audioPackets.pop(pkt, [this]() { return m_stopRequested || m_eof; })) {
       int bytes = m_audioDecoder.decode(pkt, audioBuffer, sizeof(audioBuffer));
       av_packet_free(&pkt);
       if (bytes > 0 && m_output) {
@@ -382,10 +382,8 @@ void MediaPlayer::audioLoop() {
         if (m_callbacks.onPosition)
           m_callbacks.onPosition(m_audioClock);
       }
-    } else if (m_eof) {
-      break;
     } else {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      break;
     }
   }
 }
@@ -402,7 +400,7 @@ void MediaPlayer::videoLoop() {
         break;
     }
     AVPacket *pkt = nullptr;
-    if (m_videoPackets.pop(pkt)) {
+    if (m_videoPackets.pop(pkt, [this]() { return m_stopRequested || m_eof; })) {
       int bytes = m_videoDecoder.decode(pkt, videoBuffer.data(), videoBufferSize);
       av_packet_free(&pkt);
       if (bytes > 0 && m_videoOutput) {
@@ -416,10 +414,8 @@ void MediaPlayer::videoLoop() {
         if (m_callbacks.onPosition)
           m_callbacks.onPosition(m_videoClock);
       }
-    } else if (m_eof) {
-      break;
     } else {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      break;
     }
   }
 }

--- a/src/core/src/PacketQueue.cpp
+++ b/src/core/src/PacketQueue.cpp
@@ -21,8 +21,9 @@ bool PacketQueue::push(const AVPacket *pkt) {
   return true;
 }
 
-bool PacketQueue::pop(AVPacket *&pkt) {
+bool PacketQueue::pop(AVPacket *&pkt, const std::function<bool()> &waitPredicate) {
   std::unique_lock<std::mutex> lock(m_mutex);
+  m_cv.wait(lock, [this, &waitPredicate]() { return !m_queue.empty() || waitPredicate(); });
   if (m_queue.empty())
     return false;
   pkt = m_queue.front();


### PR DESCRIPTION
## Summary
- add wait-based pop method for PacketQueue
- update MediaPlayer's audio and video loops to use the blocking pop

## Testing
- `cmake ..` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f234128188331bd192d1de8d492ac