### PR TITLE
Integrate missing logic from open PRs

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -69,7 +69,7 @@ private:
   double m_audioClock{0.0};
   double m_videoClock{0.0};
   double m_startTime{0.0};
-  bool m_stopRequested{false};
+  std::atomic<bool> m_stopRequested{false};
   PacketQueue m_audioPackets;
   PacketQueue m_videoPackets;
   PlaybackCallbacks m_callbacks;

--- a/src/core/include/mediaplayer/PacketQueue.h
+++ b/src/core/include/mediaplayer/PacketQueue.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <queue>
 
 #include <condition_variable>
+#include <functional>
 
 namespace mediaplayer {
 
@@ -19,7 +20,7 @@ public:
   ~PacketQueue();
 
   bool push(const AVPacket *pkt);
-  bool pop(AVPacket *&pkt);
+  bool pop(AVPacket *&pkt, const std::function<bool()> &waitPredicate = nullptr);
   void clear();
   size_t size() const;
   bool full() const;

--- a/src/core/src/PacketQueue.cpp
+++ b/src/core/src/PacketQueue.cpp
@@ -21,8 +21,11 @@ bool PacketQueue::push(const AVPacket *pkt) {
   return true;
 }
 
-bool PacketQueue::pop(AVPacket *&pkt) {
+bool PacketQueue::pop(AVPacket *&pkt, const std::function<bool()> &waitPredicate) {
   std::unique_lock<std::mutex> lock(m_mutex);
+  if (waitPredicate) {
+    m_cv.wait(lock, [this, &waitPredicate]() { return !m_queue.empty() || waitPredicate(); });
+  }
   if (m_queue.empty())
     return false;
   pkt = m_queue.front();


### PR DESCRIPTION
## Summary
- incorporate `m_stopRequested` as an atomic boolean
- add optional wait predicate to `PacketQueue::pop`
- use blocking pop in audio/video loops
- adjust loop conditions to check atomic flag

## Testing
- `clang++ -std=c++17 -I src/core/include -I src/network/include -c src/core/src/PacketQueue.cpp -o /tmp/PacketQueue.o`
- `clang++ -std=c++17 -I src/core/include -I src/network/include -c src/core/src/MediaPlayer.cpp -o /tmp/MediaPlayer.o` *(fails: 'LibraryDB.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2e62a5e083319b6cc294c1afd3f8