### PR TITLE
Add optional hardware video decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ SRT files.
 The SQLite-based library tracks media metadata, including an optional rating
 field, and updates play counts when items are played through the core engine.
 
+## Hardware Decoding
+
+Hardware accelerated video decoding is supported on major desktop platforms when
+FFmpeg is built with the appropriate backends. The default device used can be
+overridden at runtime via `MediaPlayer::setPreferredHardwareDevice()`.
+
+- **Windows**: DXVA2
+- **macOS**: VideoToolbox
+- **Linux**: VAAPI
+
 ## Continuous Integration
 
 All pushes and pull requests are built using GitHub Actions. The workflow

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,8 @@ elseif(UNIX)
     list(APPEND CORE_SOURCES src/AudioOutputPulse.cpp)
 endif()
 
+option(ENABLE_HW_DECODING "Enable hardware accelerated video decoding" ON)
+
 add_library(mediaplayer_core ${CORE_SOURCES})
 
 find_package(PkgConfig)
@@ -64,4 +66,6 @@ set_target_properties(mediaplayer_core PROPERTIES
     CXX_STANDARD_REQUIRED ON
 )
 
-target_compile_definitions(mediaplayer_core PUBLIC MEDIAPLAYER_DESKTOP)
+target_compile_definitions(mediaplayer_core PUBLIC MEDIAPLAYER_DESKTOP
+    $<$<BOOL:${ENABLE_HW_DECODING}>:MEDIAPLAYER_HW_DECODING>)
+

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -41,6 +41,7 @@ public:
   bool nextTrack();
   void setAudioOutput(std::unique_ptr<AudioOutput> output);
   void setVideoOutput(std::unique_ptr<VideoOutput> output);
+  void setPreferredHardwareDevice(const std::string &device);
   void setCallbacks(PlaybackCallbacks callbacks);
   void setLibrary(LibraryDB *db);
   void setVolume(double volume); // 0.0 - 1.0
@@ -78,6 +79,7 @@ private:
   bool m_playRecorded{false};
   double m_volume{1.0};
   MediaMetadata m_metadata;
+  std::string m_hwDevice;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/VideoDecoder.h
+++ b/src/core/include/mediaplayer/VideoDecoder.h
@@ -2,6 +2,10 @@
 #define MEDIAPLAYER_VIDEODECODER_H
 
 #include "MediaDecoder.h"
+#include <string>
+#ifdef MEDIAPLAYER_HW_DECODING
+#include <libavutil/hwcontext.h>
+#endif
 
 extern "C" {
 #include <libavutil/avutil.h>
@@ -15,7 +19,10 @@ public:
   VideoDecoder();
   ~VideoDecoder() override;
 
-  bool open(AVFormatContext *fmtCtx, int streamIndex) override;
+  bool open(AVFormatContext *fmtCtx, int streamIndex) override {
+    return open(fmtCtx, streamIndex, "");
+  }
+  bool open(AVFormatContext *fmtCtx, int streamIndex, const std::string &preferredHwDevice);
   // Decode packet and write RGBA data into outBuffer. Returns bytes written.
   int decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) override;
   void flush() override;
@@ -29,6 +36,9 @@ private:
   AVFrame *m_frame{nullptr};
   AVRational m_timeBase{1, 1};
   int64_t m_lastPts{AV_NOPTS_VALUE};
+#ifdef MEDIAPLAYER_HW_DECODING
+  AVBufferRef *m_hwDeviceCtx{nullptr};
+#endif
 };
 
 } // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -35,6 +35,15 @@ MediaPlayer::MediaPlayer() {
 #else
   m_videoOutput = std::make_unique<NullVideoOutput>();
 #endif
+#ifdef MEDIAPLAYER_HW_DECODING
+#ifdef _WIN32
+  m_hwDevice = "dxva2";
+#elif defined(__APPLE__)
+  m_hwDevice = "videotoolbox";
+#elif defined(__linux__)
+  m_hwDevice = "vaapi";
+#endif
+#endif
 }
 
 MediaPlayer::~MediaPlayer() {
@@ -67,7 +76,11 @@ bool MediaPlayer::open(const std::string &path) {
     }
   }
   if (m_demuxer.videoStream() >= 0) {
+#ifdef MEDIAPLAYER_HW_DECODING
+    if (!m_videoDecoder.open(fmtCtx, m_demuxer.videoStream(), m_hwDevice)) {
+#else
     if (!m_videoDecoder.open(fmtCtx, m_demuxer.videoStream())) {
+#endif
       std::cerr << "Failed to open video decoder\n";
       return false;
     }
@@ -159,6 +172,11 @@ void MediaPlayer::setVideoOutput(std::unique_ptr<VideoOutput> output) {
     m_videoOutput->shutdown();
   }
   m_videoOutput = std::move(output);
+}
+
+void MediaPlayer::setPreferredHardwareDevice(const std::string &device) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_hwDevice = device;
 }
 
 void MediaPlayer::setLibrary(LibraryDB *db) {


### PR DESCRIPTION
## Summary
- allow choosing a preferred hardware device when opening VideoDecoder
- try to create hardware devices using FFmpeg and fall back to software
- allow MediaPlayer to select the hardware device at runtime
- add CMake option `ENABLE_HW_DECODING` for build-time control
- document platform support in README

## Testing
- `clang-format -i src/core/include/mediaplayer/VideoDecoder.h src/core/src/VideoDecoder.cpp src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp`
- `cmake ..` *(fails: libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4a0a3ffc8331b4c833cf3bf6cde1