### PR TITLE
Add subtitle stream support in MediaDemuxer

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -11,3 +11,6 @@ make
 
 The resulting `mediaplayer_core` library is currently a stub and does not yet
 perform any decoding.
+
+`MediaDemuxer` uses FFmpeg to open media files and enumerate audio, video and
+subtitle streams. Decoding and playback will be added in future modules.

--- a/src/core/include/mediaplayer/MediaDemuxer.h
+++ b/src/core/include/mediaplayer/MediaDemuxer.h
@@ -19,6 +19,7 @@ public:
   bool readPacket(AVPacket &pkt);
   int audioStream() const { return m_audioStream; }
   int videoStream() const { return m_videoStream; }
+  int subtitleStream() const { return m_subtitleStream; }
   AVFormatContext *context() const { return m_ctx; }
   bool eof() const { return m_eof; }
 
@@ -28,6 +29,7 @@ private:
   AVFormatContext *m_ctx{nullptr};
   int m_audioStream{-1};
   int m_videoStream{-1};
+  int m_subtitleStream{-1};
   bool m_eof{false};
 };
 

--- a/src/core/src/MediaDemuxer.cpp
+++ b/src/core/src/MediaDemuxer.cpp
@@ -4,7 +4,7 @@
 
 namespace mediaplayer {
 
-MediaDemuxer::MediaDemuxer() = default;
+MediaDemuxer::MediaDemuxer() { m_subtitleStream = -1; }
 
 MediaDemuxer::~MediaDemuxer() { close(); }
 
@@ -18,6 +18,7 @@ void MediaDemuxer::close() {
   }
   m_audioStream = -1;
   m_videoStream = -1;
+  m_subtitleStream = -1;
   m_eof = false;
 }
 
@@ -43,6 +44,9 @@ bool MediaDemuxer::open(const std::string &path) {
       m_audioStream = i;
     } else if (m_ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && m_videoStream < 0) {
       m_videoStream = i;
+    } else if (m_ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE &&
+               m_subtitleStream < 0) {
+      m_subtitleStream = i;
     }
   }
   m_eof = false;


### PR DESCRIPTION
## Summary
- track subtitle streams in `MediaDemuxer`
- reset and detect subtitle streams when opening media
- document stream enumeration capability in core README

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaDemuxer.h src/core/src/MediaDemuxer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_685f4a0838748331a04d2d5f4e4c0a15