### PR TITLE
Add hardware decoding fallback and HW frame handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MediaPlayer
+#MediaPlayer
 
 MediaPlayer is an open-source, cross-platform AI-enabled media player focused on speed and a polished user experience.
 High level design is described in [Masterplan.MD](Masterplan.MD) and a breakdown of work items is in [Tasks.MD](Tasks.MD).
@@ -27,7 +27,7 @@ See [docs/building.md](docs/building.md) for a complete build walkthrough,
 including how to compile the sample test programs.
 
 ```
-# Example build steps
+#Example build steps
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make
@@ -46,8 +46,10 @@ field, and updates play counts when items are played through the core engine.
 ## Hardware Decoding
 
 Hardware accelerated video decoding is supported on major desktop platforms when
-FFmpeg is built with the appropriate backends. The default device used can be
-overridden at runtime via `MediaPlayer::setPreferredHardwareDevice()`.
+FFmpeg is built with the appropriate backends. Make sure FFmpeg was configured
+with `--enable-hwaccels` and the relevant device options. The default device
+used can be overridden at runtime via `MediaPlayer::setPreferredHardwareDevice()`.
+Pass `-DENABLE_HW_DECODING=OFF` to CMake to force software decoding.
 
 - **Windows**: DXVA2
 - **macOS**: VideoToolbox

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,6 +17,8 @@ elseif(UNIX)
     list(APPEND CORE_SOURCES src/AudioOutputPulse.cpp)
 endif()
 
+# Hardware decoding requires FFmpeg to be built with `--enable-hwaccels` and
+# the relevant device backends (e.g. `--enable-vaapi`).
 option(ENABLE_HW_DECODING "Enable hardware accelerated video decoding" ON)
 
 add_library(mediaplayer_core ${CORE_SOURCES})

--- a/src/core/include/mediaplayer/VideoDecoder.h
+++ b/src/core/include/mediaplayer/VideoDecoder.h
@@ -30,6 +30,10 @@ public:
   int height() const { return m_codecCtx ? m_codecCtx->height : 0; }
   double lastPts() const;
 
+#ifdef MEDIAPLAYER_HW_DECODING
+  static enum AVPixelFormat get_hw_format(AVCodecContext *ctx, const enum AVPixelFormat *fmts);
+#endif
+
 private:
   AVCodecContext *m_codecCtx{nullptr};
   SwsContext *m_swsCtx{nullptr};
@@ -38,6 +42,8 @@ private:
   int64_t m_lastPts{AV_NOPTS_VALUE};
 #ifdef MEDIAPLAYER_HW_DECODING
   AVBufferRef *m_hwDeviceCtx{nullptr};
+  AVPixelFormat m_hwPixFmt{AV_PIX_FMT_NONE};
+  AVFrame *m_swFrame{nullptr};
 #endif
 };
 


### PR DESCRIPTION
## Summary
- refine VideoDecoder to initialise hardware decoding via `av_hwdevice_find_type_by_name`
- copy hardware frames back to CPU memory with `av_hwframe_transfer_data`
- mention FFmpeg flags required for hardware accel in CMake option
- document FFmpeg build requirement and cmake flag in README

## Testing
- `cmake ..` *(fails: required ffmpeg packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f54afb9b88331866b745d9b61eba7