### PR TITLE
Enable cross-platform hardware decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ field, and updates play counts when items are played through the core engine.
 
 ## Hardware Decoding
 
-Hardware accelerated video decoding is supported on major desktop platforms when
-FFmpeg is built with the appropriate backends. Make sure FFmpeg was configured
-with `--enable-hwaccels` and the relevant device options. The default device
-used can be overridden at runtime via `MediaPlayer::setPreferredHardwareDevice()`.
-Pass `-DENABLE_HW_DECODING=OFF` to CMake to force software decoding.
+Hardware accelerated video decoding is supported when FFmpeg is built with the
+appropriate backends. Use `MediaPlayer::setPreferredHardwareDevice()` to select
+the device at runtime. Pass `-DENABLE_HW_DECODING=OFF` to CMake to force
+software decoding.
+Supported device names are `dxva2`, `d3d11va`, `videotoolbox`, `vaapi` and
+`mediacodec` depending on the platform.
 
-- **Windows**: DXVA2
-- **macOS**: VideoToolbox
+- **Windows**: DXVA2 or D3D11
+- **macOS/iOS**: VideoToolbox
 - **Linux**: VAAPI
+- **Android**: MediaCodec (via JNI)
 
 ## Continuous Integration
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -50,6 +50,23 @@ target_link_libraries(mediaplayer_core
     glfw
 )
 
+if(ENABLE_HW_DECODING)
+    if(WIN32)
+        target_link_libraries(mediaplayer_core dxva2 d3d11 dxgi)
+    elseif(APPLE)
+        target_link_libraries(mediaplayer_core
+            "-framework VideoToolbox"
+            "-framework CoreVideo")
+    elseif(ANDROID)
+        find_library(ANDROID_LOG_LIB log)
+        find_library(JNIGRAPHICS_LIB jnigraphics)
+        target_link_libraries(mediaplayer_core ${ANDROID_LOG_LIB} ${JNIGRAPHICS_LIB})
+    elseif(UNIX)
+        pkg_check_modules(LIBVA REQUIRED IMPORTED_TARGET libva)
+        target_link_libraries(mediaplayer_core PkgConfig::LIBVA)
+    endif()
+endif()
+
 if(APPLE)
     target_link_libraries(mediaplayer_core
         "-framework AudioToolbox"

--- a/src/core/include/mediaplayer/VideoDecoder.h
+++ b/src/core/include/mediaplayer/VideoDecoder.h
@@ -5,6 +5,9 @@
 #include <string>
 #ifdef MEDIAPLAYER_HW_DECODING
 #include <libavutil/hwcontext.h>
+#if defined(__ANDROID__)
+#include <jni.h>
+#endif
 #endif
 
 extern "C" {
@@ -22,6 +25,8 @@ public:
   bool open(AVFormatContext *fmtCtx, int streamIndex) override {
     return open(fmtCtx, streamIndex, "");
   }
+  // `preferredHwDevice` can be one of "dxva2", "d3d11va", "videotoolbox",
+  // "vaapi" or "mediacodec" depending on the platform.
   bool open(AVFormatContext *fmtCtx, int streamIndex, const std::string &preferredHwDevice);
   // Decode packet and write RGBA data into outBuffer. Returns bytes written.
   int decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) override;

--- a/src/core/src/VideoDecoder.cpp
+++ b/src/core/src/VideoDecoder.cpp
@@ -83,8 +83,13 @@ bool VideoDecoder::open(AVFormatContext *fmtCtx, int streamIndex,
           break;
         }
       }
+      const char *deviceArg = nullptr;
+#if defined(__linux__) && !defined(__ANDROID__)
+      if (type == AV_HWDEVICE_TYPE_VAAPI)
+        deviceArg = "/dev/dri/renderD128";
+#endif
       if (m_hwPixFmt != AV_PIX_FMT_NONE &&
-          av_hwdevice_ctx_create(&m_hwDeviceCtx, type, nullptr, nullptr, 0) >= 0) {
+          av_hwdevice_ctx_create(&m_hwDeviceCtx, type, deviceArg, nullptr, 0) >= 0) {
         AVBufferRef *framesRef = av_hwframe_ctx_alloc(m_hwDeviceCtx);
         if (framesRef) {
           AVHWFramesContext *framesCtx = (AVHWFramesContext *)framesRef->data;


### PR DESCRIPTION
## Summary
- expand `VideoDecoder` to initialize platform specific hardware devices
- link platform SDKs in `mediaplayer_core`
- document hardware decoding and runtime device selection in README

## Testing
- `cmake ..` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f58d6dc388331a4ad0ceecf7a4807