### PR TITLE
Add iOS audio output

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,7 +9,9 @@ set(CORE_SOURCES
     src/OpenGLVideoOutput.cpp
 )
 
-if(APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND CORE_SOURCES src/AudioOutputiOS.mm)
+elseif(APPLE)
     list(APPEND CORE_SOURCES src/AudioOutputCoreAudio.mm)
 elseif(WIN32)
     list(APPEND CORE_SOURCES src/AudioOutputWASAPI.cpp)
@@ -67,7 +69,11 @@ if(ENABLE_HW_DECODING)
     endif()
 endif()
 
-if(APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    target_link_libraries(mediaplayer_core
+        "-framework AVFoundation"
+        "-framework AudioToolbox")
+elseif(APPLE)
     target_link_libraries(mediaplayer_core
         "-framework AudioToolbox"
         "-framework CoreAudio")

--- a/src/core/include/mediaplayer/AudioOutput.h
+++ b/src/core/include/mediaplayer/AudioOutput.h
@@ -13,6 +13,8 @@ public:
   virtual int write(const uint8_t *data, int len) = 0;
   virtual void pause() = 0;
   virtual void resume() = 0;
+  virtual void setVolume(double volume) = 0;
+  virtual double volume() const = 0;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputCoreAudio.h
+++ b/src/core/include/mediaplayer/AudioOutputCoreAudio.h
@@ -16,12 +16,15 @@ public:
   int write(const uint8_t *data, int len) override;
   void pause() override;
   void resume() override;
+  void setVolume(double volume) override;
+  double volume() const override;
 
 private:
   AudioQueueRef m_queue{nullptr};
   AudioStreamBasicDescription m_format{};
   bool m_started{false};
   bool m_paused{false};
+  double m_volume{1.0};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputWASAPI.h
+++ b/src/core/include/mediaplayer/AudioOutputWASAPI.h
@@ -20,6 +20,8 @@ public:
   int write(const uint8_t *data, int len) override;
   void pause() override;
   void resume() override;
+  void setVolume(double volume) override;
+  double volume() const override;
 
 private:
   IMMDevice *m_device{nullptr};
@@ -28,6 +30,7 @@ private:
   WAVEFORMATEX *m_format{nullptr};
   UINT32 m_bufferFrames{0};
   bool m_paused{false};
+  double m_volume{1.0};
 };
 #endif
 

--- a/src/core/include/mediaplayer/AudioOutputiOS.h
+++ b/src/core/include/mediaplayer/AudioOutputiOS.h
@@ -1,17 +1,14 @@
-#ifndef MEDIAPLAYER_AUDIOOUTPUTPULSE_H
-#define MEDIAPLAYER_AUDIOOUTPUTPULSE_H
+#ifndef MEDIAPLAYER_AUDIOOUTPUTIOS_H
+#define MEDIAPLAYER_AUDIOOUTPUTIOS_H
 
 #include "AudioOutput.h"
-#include <pulse/error.h>
-#include <pulse/simple.h>
-#include <string>
 
 namespace mediaplayer {
 
-class AudioOutputPulse : public AudioOutput {
+class AudioOutputiOS : public AudioOutput {
 public:
-  AudioOutputPulse();
-  ~AudioOutputPulse() override;
+  AudioOutputiOS();
+  ~AudioOutputiOS() override;
 
   bool init(int sampleRate, int channels) override;
   void shutdown() override;
@@ -22,12 +19,13 @@ public:
   double volume() const override;
 
 private:
-  pa_simple *m_pa = nullptr;
-  pa_sample_spec m_spec{};
-  bool m_paused = false;
+  void *m_engine{nullptr};
+  void *m_player{nullptr};
+  void *m_format{nullptr};
+  bool m_paused{false};
   double m_volume{1.0};
 };
 
 } // namespace mediaplayer
 
-#endif // MEDIAPLAYER_AUDIOOUTPUTPULSE_H
+#endif // MEDIAPLAYER_AUDIOOUTPUTIOS_H

--- a/src/core/include/mediaplayer/NullAudioOutput.h
+++ b/src/core/include/mediaplayer/NullAudioOutput.h
@@ -18,6 +18,11 @@ public:
   }
   void pause() override {}
   void resume() override {}
+  void setVolume(double volume) override { m_volume = volume; }
+  double volume() const override { return m_volume; }
+
+private:
+  double m_volume{1.0};
 };
 
 } // namespace mediaplayer

--- a/src/core/src/AudioOutputCoreAudio.mm
+++ b/src/core/src/AudioOutputCoreAudio.mm
@@ -33,6 +33,7 @@ bool AudioOutputCoreAudio::init(int sampleRate, int channels) {
     m_queue = nullptr;
     return false;
   }
+  AudioQueueSetParameter(m_queue, kAudioQueueParam_Volume, static_cast<Float32>(m_volume));
   m_started = true;
   return true;
 }
@@ -74,5 +75,17 @@ void AudioOutputCoreAudio::resume() {
     m_paused = false;
   }
 }
+
+void AudioOutputCoreAudio::setVolume(double volume) {
+  if (volume < 0.0)
+    volume = 0.0;
+  else if (volume > 1.0)
+    volume = 1.0;
+  m_volume = volume;
+  if (m_queue)
+    AudioQueueSetParameter(m_queue, kAudioQueueParam_Volume, static_cast<Float32>(volume));
+}
+
+double AudioOutputCoreAudio::volume() const { return m_volume; }
 
 } // namespace mediaplayer

--- a/src/core/src/AudioOutputPulse.cpp
+++ b/src/core/src/AudioOutputPulse.cpp
@@ -46,4 +46,14 @@ void AudioOutputPulse::pause() { m_paused = true; }
 
 void AudioOutputPulse::resume() { m_paused = false; }
 
+void AudioOutputPulse::setVolume(double volume) {
+  if (volume < 0.0)
+    volume = 0.0;
+  else if (volume > 1.0)
+    volume = 1.0;
+  m_volume = volume;
+}
+
+double AudioOutputPulse::volume() const { return m_volume; }
+
 } // namespace mediaplayer

--- a/src/core/src/AudioOutputWASAPI.cpp
+++ b/src/core/src/AudioOutputWASAPI.cpp
@@ -124,5 +124,15 @@ void AudioOutputWASAPI::resume() {
   }
 }
 
+void AudioOutputWASAPI::setVolume(double volume) {
+  if (volume < 0.0)
+    volume = 0.0;
+  else if (volume > 1.0)
+    volume = 1.0;
+  m_volume = volume;
+}
+
+double AudioOutputWASAPI::volume() const { return m_volume; }
+
 } // namespace mediaplayer
 #endif

--- a/src/core/src/AudioOutputiOS.mm
+++ b/src/core/src/AudioOutputiOS.mm
@@ -1,0 +1,95 @@
+#include "mediaplayer/AudioOutputiOS.h"
+
+#import <AVFoundation/AVFoundation.h>
+
+namespace mediaplayer {
+
+AudioOutputiOS::AudioOutputiOS() = default;
+
+AudioOutputiOS::~AudioOutputiOS() { shutdown(); }
+
+bool AudioOutputiOS::init(int sampleRate, int channels) {
+  @autoreleasepool {
+    m_engine = [[AVAudioEngine alloc] init];
+    m_player = [[AVAudioPlayerNode alloc] init];
+    [(__bridge AVAudioEngine *)m_engine attachNode:(__bridge AVAudioPlayerNode *)m_player];
+
+    AVAudioFormat *format = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:sampleRate
+                                                                           channels:channels];
+    m_format = (__bridge_retained void *)format;
+    [(__bridge AVAudioEngine *)m_engine
+        connect:(__bridge AVAudioPlayerNode *)m_player
+             to:(__bridge AVAudioNode *)[(AVAudioEngine *)m_engine mainMixerNode]
+         format:format];
+    NSError *error = nil;
+    if (![(__bridge AVAudioEngine *)m_engine startAndReturnError:&error]) {
+      shutdown();
+      return false;
+    }
+    [(__bridge AVAudioPlayerNode *)m_player play];
+    m_paused = false;
+    m_volume = 1.0;
+    return true;
+  }
+}
+
+void AudioOutputiOS::shutdown() {
+  @autoreleasepool {
+    if (m_player) {
+      [(__bridge AVAudioPlayerNode *)m_player stop];
+      m_player = nullptr;
+    }
+    if (m_engine) {
+      [(__bridge AVAudioEngine *)m_engine stop];
+      m_engine = nullptr;
+    }
+    if (m_format) {
+      CFRelease(m_format);
+      m_format = nullptr;
+    }
+  }
+}
+
+int AudioOutputiOS::write(const uint8_t *data, int len) {
+  @autoreleasepool {
+    if (!m_engine || !m_player || m_paused)
+      return 0;
+    AVAudioFormat *format = (__bridge AVAudioFormat *)m_format;
+    NSUInteger frameSize = format.streamDescription->mBytesPerFrame;
+    NSUInteger frames = len / frameSize;
+    AVAudioPCMBuffer *buffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:format
+                                                             frameCapacity:frames];
+    buffer.frameLength = frames;
+    memcpy(buffer.int16ChannelData[0], data, len);
+    [(__bridge AVAudioPlayerNode *)m_player scheduleBuffer:buffer completionHandler:nil];
+    return len;
+  }
+}
+
+void AudioOutputiOS::pause() {
+  if (m_player && !m_paused) {
+    [(__bridge AVAudioPlayerNode *)m_player pause];
+    m_paused = true;
+  }
+}
+
+void AudioOutputiOS::resume() {
+  if (m_player && m_paused) {
+    [(__bridge AVAudioPlayerNode *)m_player play];
+    m_paused = false;
+  }
+}
+
+void AudioOutputiOS::setVolume(double volume) {
+  if (volume < 0.0)
+    volume = 0.0;
+  else if (volume > 1.0)
+    volume = 1.0;
+  m_volume = volume;
+  if (m_player)
+    [(__bridge AVAudioPlayerNode *)m_player setVolume:static_cast<float>(volume)];
+}
+
+double AudioOutputiOS::volume() const { return m_volume; }
+
+} // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -165,6 +165,8 @@ void MediaPlayer::setAudioOutput(std::unique_ptr<AudioOutput> output) {
     m_output->shutdown();
   }
   m_output = std::move(output);
+  if (m_output)
+    m_output->setVolume(m_volume);
 }
 
 void MediaPlayer::setVideoOutput(std::unique_ptr<VideoOutput> output) {
@@ -197,6 +199,8 @@ void MediaPlayer::setVolume(double volume) {
   if (volume > 1.0)
     volume = 1.0;
   m_volume = volume;
+  if (m_output)
+    m_output->setVolume(volume);
 }
 
 double MediaPlayer::volume() const {


### PR DESCRIPTION
## Summary
- implement new `AudioOutputiOS` using AVAudioEngine
- extend `AudioOutput` interface with volume controls
- update existing outputs to store volume and handle new API
- propagate volume in `MediaPlayer`
- support building on iOS in `src/core/CMakeLists.txt`

## Testing
- `clang-format -i src/core/include/mediaplayer/AudioOutputiOS.h src/core/src/AudioOutputiOS.mm src/core/include/mediaplayer/AudioOutput.h src/core/include/mediaplayer/NullAudioOutput.h src/core/include/mediaplayer/AudioOutputCoreAudio.h src/core/src/AudioOutputCoreAudio.mm src/core/include/mediaplayer/AudioOutputPulse.h src/core/src/AudioOutputPulse.cpp src/core/include/mediaplayer/AudioOutputWASAPI.h src/core/src/AudioOutputWASAPI.cpp src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6860520aa134833188f1178a99675aaf