### PR TITLE
Add volume support to AudioOutput classes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CORE_SOURCES
     src/PacketQueue.cpp
     src/MediaDemuxer.cpp
     src/BufferedReader.cpp
+    src/NullAudioOutput.cpp
     src/OpenGLVideoOutput.cpp
 )
 

--- a/src/core/include/mediaplayer/AudioOutput.h
+++ b/src/core/include/mediaplayer/AudioOutput.h
@@ -13,6 +13,8 @@ public:
   virtual int write(const uint8_t *data, int len) = 0;
   virtual void pause() = 0;
   virtual void resume() = 0;
+  virtual void setVolume(double volume) = 0;
+  virtual double volume() const = 0;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputCoreAudio.h
+++ b/src/core/include/mediaplayer/AudioOutputCoreAudio.h
@@ -16,12 +16,15 @@ public:
   int write(const uint8_t *data, int len) override;
   void pause() override;
   void resume() override;
+  void setVolume(double volume) override;
+  double volume() const override;
 
 private:
   AudioQueueRef m_queue{nullptr};
   AudioStreamBasicDescription m_format{};
   bool m_started{false};
   bool m_paused{false};
+  double m_volume{1.0};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputPulse.h
+++ b/src/core/include/mediaplayer/AudioOutputPulse.h
@@ -18,11 +18,14 @@ public:
   int write(const uint8_t *data, int len) override;
   void pause() override;
   void resume() override;
+  void setVolume(double volume) override;
+  double volume() const override;
 
 private:
   pa_simple *m_pa = nullptr;
   pa_sample_spec m_spec{};
   bool m_paused = false;
+  double m_volume{1.0};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputWASAPI.h
+++ b/src/core/include/mediaplayer/AudioOutputWASAPI.h
@@ -20,6 +20,8 @@ public:
   int write(const uint8_t *data, int len) override;
   void pause() override;
   void resume() override;
+  void setVolume(double volume) override;
+  double volume() const override;
 
 private:
   IMMDevice *m_device{nullptr};
@@ -28,6 +30,7 @@ private:
   WAVEFORMATEX *m_format{nullptr};
   UINT32 m_bufferFrames{0};
   bool m_paused{false};
+  double m_volume{1.0};
 };
 #endif
 

--- a/src/core/include/mediaplayer/NullAudioOutput.h
+++ b/src/core/include/mediaplayer/NullAudioOutput.h
@@ -18,6 +18,11 @@ public:
   }
   void pause() override {}
   void resume() override {}
+  void setVolume(double volume) override;
+  double volume() const override;
+
+private:
+  double m_volume{1.0};
 };
 
 } // namespace mediaplayer

--- a/src/core/src/AudioOutputCoreAudio.mm
+++ b/src/core/src/AudioOutputCoreAudio.mm
@@ -75,4 +75,8 @@ void AudioOutputCoreAudio::resume() {
   }
 }
 
+void AudioOutputCoreAudio::setVolume(double volume) { m_volume = volume; }
+
+double AudioOutputCoreAudio::volume() const { return m_volume; }
+
 } // namespace mediaplayer

--- a/src/core/src/AudioOutputPulse.cpp
+++ b/src/core/src/AudioOutputPulse.cpp
@@ -46,4 +46,8 @@ void AudioOutputPulse::pause() { m_paused = true; }
 
 void AudioOutputPulse::resume() { m_paused = false; }
 
+void AudioOutputPulse::setVolume(double volume) { m_volume = volume; }
+
+double AudioOutputPulse::volume() const { return m_volume; }
+
 } // namespace mediaplayer

--- a/src/core/src/AudioOutputWASAPI.cpp
+++ b/src/core/src/AudioOutputWASAPI.cpp
@@ -124,5 +124,9 @@ void AudioOutputWASAPI::resume() {
   }
 }
 
+void AudioOutputWASAPI::setVolume(double volume) { m_volume = volume; }
+
+double AudioOutputWASAPI::volume() const { return m_volume; }
+
 } // namespace mediaplayer
 #endif

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -197,6 +197,8 @@ void MediaPlayer::setVolume(double volume) {
   if (volume > 1.0)
     volume = 1.0;
   m_volume = volume;
+  if (m_output)
+    m_output->setVolume(m_volume);
 }
 
 double MediaPlayer::volume() const {

--- a/src/core/src/NullAudioOutput.cpp
+++ b/src/core/src/NullAudioOutput.cpp
@@ -1,0 +1,9 @@
+#include "mediaplayer/NullAudioOutput.h"
+
+namespace mediaplayer {
+
+void NullAudioOutput::setVolume(double volume) { m_volume = volume; }
+
+double NullAudioOutput::volume() const { return m_volume; }
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- expose volume controls in `AudioOutput`
- store volume in derived audio output classes
- propagate volume changes from `MediaPlayer`
- add `NullAudioOutput.cpp` implementation
- include new file in core build

## Testing
- `clang-format -i src/core/include/mediaplayer/AudioOutput.h src/core/include/mediaplayer/AudioOutputCoreAudio.h src/core/include/mediaplayer/AudioOutputPulse.h src/core/include/mediaplayer/AudioOutputWASAPI.h src/core/include/mediaplayer/NullAudioOutput.h src/core/src/AudioOutputCoreAudio.mm src/core/src/AudioOutputPulse.cpp src/core/src/AudioOutputWASAPI.cpp src/core/src/MediaPlayer.cpp src/core/src/NullAudioOutput.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6860520754b48331b6bbfc3a94a47c54