### PR TITLE
Fix merge conflicts with ring buffer support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CORE_SOURCES
     src/MediaDemuxer.cpp
     src/BufferedReader.cpp
     src/OpenGLVideoOutput.cpp
+    src/RingBuffer.cpp
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "iOS")

--- a/src/core/include/mediaplayer/AudioOutputCoreAudio.h
+++ b/src/core/include/mediaplayer/AudioOutputCoreAudio.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_AUDIOOUTPUTCOREAUDIO_H
 
 #include "AudioOutput.h"
+#include "RingBuffer.h"
 #include <AudioToolbox/AudioToolbox.h>
 
 namespace mediaplayer {
@@ -20,11 +21,13 @@ public:
   double volume() const override;
 
 private:
+  friend void BufferCallback(void *, AudioQueueRef, AudioQueueBufferRef);
   AudioQueueRef m_queue{nullptr};
   AudioStreamBasicDescription m_format{};
   bool m_started{false};
   bool m_paused{false};
   double m_volume{1.0};
+  RingBuffer m_buffer{16384};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputPulse.h
+++ b/src/core/include/mediaplayer/AudioOutputPulse.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_AUDIOOUTPUTPULSE_H
 
 #include "AudioOutput.h"
+#include "RingBuffer.h"
 #include <pulse/error.h>
 #include <pulse/simple.h>
 #include <string>
@@ -26,6 +27,7 @@ private:
   pa_sample_spec m_spec{};
   bool m_paused = false;
   double m_volume{1.0};
+  RingBuffer m_buffer{16384};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputWASAPI.h
+++ b/src/core/include/mediaplayer/AudioOutputWASAPI.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_AUDIOOUTPUTWASAPI_H
 
 #include "AudioOutput.h"
+#include "RingBuffer.h"
 #ifdef _WIN32
 #include <Audioclient.h>
 #include <Mmdeviceapi.h>
@@ -31,6 +32,7 @@ private:
   UINT32 m_bufferFrames{0};
   bool m_paused{false};
   double m_volume{1.0};
+  RingBuffer m_buffer{16384};
 };
 #endif
 

--- a/src/core/include/mediaplayer/RingBuffer.h
+++ b/src/core/include/mediaplayer/RingBuffer.h
@@ -1,0 +1,34 @@
+#ifndef MEDIAPLAYER_RINGBUFFER_H
+#define MEDIAPLAYER_RINGBUFFER_H
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace mediaplayer {
+
+class RingBuffer {
+public:
+  explicit RingBuffer(size_t capacity = 16384);
+  size_t write(const int16_t *data, size_t samples);
+  size_t mix(const int16_t *data, size_t samples);
+  size_t read(int16_t *out, size_t samples);
+  void clear();
+  size_t available() const;
+  size_t freeSpace() const;
+
+private:
+  size_t increment(size_t idx, size_t val) const;
+
+  std::vector<int16_t> m_buffer;
+  size_t m_size{0};
+  std::atomic<size_t> m_head{0};
+  std::atomic<size_t> m_tail{0};
+  mutable std::mutex m_mixMutex;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_RINGBUFFER_H

--- a/src/core/src/AudioOutputPulse.cpp
+++ b/src/core/src/AudioOutputPulse.cpp
@@ -34,10 +34,18 @@ void AudioOutputPulse::shutdown() {
 int AudioOutputPulse::write(const uint8_t *data, int len) {
   if (!m_pa || m_paused)
     return 0;
+  size_t samples = static_cast<size_t>(len) / sizeof(int16_t);
+  const int16_t *input = reinterpret_cast<const int16_t *>(data);
+  m_buffer.mix(input, samples);
+
+  int16_t temp[1024];
   int error = 0;
-  if (pa_simple_write(m_pa, data, static_cast<size_t>(len), &error) < 0) {
-    std::cerr << "PulseAudio write failed: " << pa_strerror(error) << "\n";
-    return -1;
+  while (m_buffer.available() >= 1024) {
+    size_t n = m_buffer.read(temp, 1024);
+    if (pa_simple_write(m_pa, temp, n * sizeof(int16_t), &error) < 0) {
+      std::cerr << "PulseAudio write failed: " << pa_strerror(error) << "\n";
+      return -1;
+    }
   }
   return len;
 }

--- a/src/core/src/RingBuffer.cpp
+++ b/src/core/src/RingBuffer.cpp
@@ -1,0 +1,75 @@
+#include "mediaplayer/RingBuffer.h"
+
+#include <algorithm>
+
+namespace mediaplayer {
+
+RingBuffer::RingBuffer(size_t capacity) {
+  m_size = capacity + 1; // one slot unused
+  m_buffer.resize(m_size);
+  m_head.store(0);
+  m_tail.store(0);
+}
+
+size_t RingBuffer::increment(size_t idx, size_t val) const { return (idx + val) % m_size; }
+
+size_t RingBuffer::available() const {
+  size_t head = m_head.load(std::memory_order_acquire);
+  size_t tail = m_tail.load(std::memory_order_acquire);
+  if (tail >= head)
+    return tail - head;
+  return m_size - head + tail;
+}
+
+size_t RingBuffer::freeSpace() const { return m_size - available() - 1; }
+
+void RingBuffer::clear() {
+  m_head.store(0, std::memory_order_release);
+  m_tail.store(0, std::memory_order_release);
+  std::fill(m_buffer.begin(), m_buffer.end(), 0);
+}
+
+size_t RingBuffer::write(const int16_t *data, size_t samples) {
+  size_t space = freeSpace();
+  size_t toWrite = std::min(samples, space);
+  size_t tail = m_tail.load(std::memory_order_relaxed);
+  for (size_t i = 0; i < toWrite; ++i) {
+    m_buffer[tail] = data[i];
+    tail = increment(tail, 1);
+  }
+  m_tail.store(tail, std::memory_order_release);
+  return toWrite;
+}
+
+size_t RingBuffer::mix(const int16_t *data, size_t samples) {
+  std::lock_guard<std::mutex> lock(m_mixMutex);
+  size_t space = freeSpace();
+  size_t toWrite = std::min(samples, space);
+  size_t tail = m_tail.load(std::memory_order_relaxed);
+  for (size_t i = 0; i < toWrite; ++i) {
+    int32_t sum = static_cast<int32_t>(m_buffer[tail]) + data[i];
+    if (sum < -32768)
+      sum = -32768;
+    else if (sum > 32767)
+      sum = 32767;
+    m_buffer[tail] = static_cast<int16_t>(sum);
+    tail = increment(tail, 1);
+  }
+  m_tail.store(tail, std::memory_order_release);
+  return toWrite;
+}
+
+size_t RingBuffer::read(int16_t *out, size_t samples) {
+  size_t avail = available();
+  size_t toRead = std::min(samples, avail);
+  size_t head = m_head.load(std::memory_order_relaxed);
+  for (size_t i = 0; i < toRead; ++i) {
+    out[i] = m_buffer[head];
+    m_buffer[head] = 0; // clear after reading for mixing
+    head = increment(head, 1);
+  }
+  m_head.store(head, std::memory_order_release);
+  return toRead;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- integrate ring buffer implementation for audio outputs
- keep existing volume controls and platform backends

## Testing
- `clang-format -i src/core/include/mediaplayer/RingBuffer.h src/core/src/RingBuffer.cpp src/core/include/mediaplayer/AudioOutputCoreAudio.h src/core/include/mediaplayer/AudioOutputPulse.h src/core/include/mediaplayer/AudioOutputWASAPI.h src/core/src/AudioOutputCoreAudio.mm src/core/src/AudioOutputPulse.cpp src/core/src/AudioOutputWASAPI.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686059d74268833183319ee6abfc92e7