### PR TITLE
Improve WASAPI init with RAII and logging

### DIFF
--- a/src/core/include/mediaplayer/AudioOutputWASAPI.h
+++ b/src/core/include/mediaplayer/AudioOutputWASAPI.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_AUDIOOUTPUTWASAPI_H
 
 #include "AudioOutput.h"
+#include "ComPtr.h"
 #include "RingBuffer.h"
 #ifdef _WIN32
 #include <Audioclient.h>
@@ -25,10 +26,10 @@ public:
   double volume() const override;
 
 private:
-  IMMDevice *m_device{nullptr};
-  IAudioClient *m_client{nullptr};
-  IAudioRenderClient *m_render{nullptr};
-  WAVEFORMATEX *m_format{nullptr};
+  ComPtr<IMMDevice> m_device;
+  ComPtr<IAudioClient> m_client;
+  ComPtr<IAudioRenderClient> m_render;
+  std::unique_ptr<WAVEFORMATEX, void (*)(void *)> m_format{nullptr, CoTaskMemFree};
   UINT32 m_bufferFrames{0};
   bool m_paused{false};
   double m_volume{1.0};

--- a/src/core/include/mediaplayer/ComPtr.h
+++ b/src/core/include/mediaplayer/ComPtr.h
@@ -1,0 +1,54 @@
+#ifndef MEDIAPLAYER_COMPTR_H
+#define MEDIAPLAYER_COMPTR_H
+
+#ifdef _WIN32
+#include <utility>
+
+namespace mediaplayer {
+
+template <typename T> class ComPtr {
+public:
+  ComPtr() = default;
+  ComPtr(T *p) : m_ptr(p) {}
+  ComPtr(const ComPtr &) = delete;
+  ComPtr &operator=(const ComPtr &) = delete;
+  ComPtr(ComPtr &&other) noexcept : m_ptr(other.m_ptr) { other.m_ptr = nullptr; }
+  ComPtr &operator=(ComPtr &&other) noexcept {
+    if (this != &other) {
+      reset();
+      m_ptr = other.m_ptr;
+      other.m_ptr = nullptr;
+    }
+    return *this;
+  }
+  ~ComPtr() { reset(); }
+
+  T **operator&() {
+    reset();
+    return &m_ptr;
+  }
+  T *get() const { return m_ptr; }
+  T *operator->() const { return m_ptr; }
+  explicit operator bool() const { return m_ptr != nullptr; }
+
+  void reset(T *p = nullptr) {
+    if (m_ptr)
+      m_ptr->Release();
+    m_ptr = p;
+  }
+
+  T *detach() {
+    T *temp = m_ptr;
+    m_ptr = nullptr;
+    return temp;
+  }
+
+private:
+  T *m_ptr{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // _WIN32
+
+#endif // MEDIAPLAYER_COMPTR_H

--- a/src/core/src/AudioOutputWASAPI.cpp
+++ b/src/core/src/AudioOutputWASAPI.cpp
@@ -2,6 +2,7 @@
 #include "mediaplayer/AudioOutputWASAPI.h"
 #include <algorithm>
 #include <cstring>
+#include <iostream>
 
 namespace mediaplayer {
 
@@ -11,24 +12,33 @@ AudioOutputWASAPI::~AudioOutputWASAPI() { shutdown(); }
 
 bool AudioOutputWASAPI::init(int sampleRate, int channels) {
   HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-  if (FAILED(hr) && hr != RPC_E_CHANGED_MODE)
+  if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+    std::cerr << "CoInitializeEx failed: 0x" << std::hex << hr << '\n';
     return false;
+  }
 
-  IMMDeviceEnumerator *enumerator = nullptr;
+  ComPtr<IMMDeviceEnumerator> enumerator;
   hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
                         IID_PPV_ARGS(&enumerator));
-  if (FAILED(hr))
+  if (FAILED(hr)) {
+    std::cerr << "CoCreateInstance failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
 
   hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &m_device);
-  enumerator->Release();
-  if (FAILED(hr))
+  if (FAILED(hr)) {
+    std::cerr << "GetDefaultAudioEndpoint failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
 
-  hr = m_device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-                          reinterpret_cast<void **>(&m_client));
-  if (FAILED(hr))
+  hr = m_device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr, IID_PPV_ARGS(&m_client));
+  if (FAILED(hr)) {
+    std::cerr << "Activate IAudioClient failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
 
   WAVEFORMATEX waveFmt{};
   waveFmt.wFormatTag = WAVE_FORMAT_PCM;
@@ -41,25 +51,40 @@ bool AudioOutputWASAPI::init(int sampleRate, int channels) {
 
   REFERENCE_TIME bufferDuration = 1000000;
   hr = m_client->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, bufferDuration, 0, &waveFmt, nullptr);
-  if (FAILED(hr))
+  if (FAILED(hr)) {
+    std::cerr << "IAudioClient::Initialize failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
 
   hr = m_client->GetBufferSize(&m_bufferFrames);
-  if (FAILED(hr))
+  if (FAILED(hr)) {
+    std::cerr << "GetBufferSize failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
 
-  hr = m_client->GetService(__uuidof(IAudioRenderClient), reinterpret_cast<void **>(&m_render));
-  if (FAILED(hr))
+  hr = m_client->GetService(__uuidof(IAudioRenderClient), IID_PPV_ARGS(&m_render));
+  if (FAILED(hr)) {
+    std::cerr << "GetService IAudioRenderClient failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
 
-  m_format = reinterpret_cast<WAVEFORMATEX *>(CoTaskMemAlloc(sizeof(WAVEFORMATEX)));
-  if (!m_format)
+  m_format.reset(reinterpret_cast<WAVEFORMATEX *>(CoTaskMemAlloc(sizeof(WAVEFORMATEX))));
+  if (!m_format) {
+    std::cerr << "CoTaskMemAlloc failed for format\n";
+    shutdown();
     return false;
+  }
   *m_format = waveFmt;
 
   hr = m_client->Start();
-  if (FAILED(hr))
+  if (FAILED(hr)) {
+    std::cerr << "IAudioClient::Start failed: 0x" << std::hex << hr << '\n';
+    shutdown();
     return false;
+  }
   m_paused = false;
   return true;
 }
@@ -68,22 +93,10 @@ void AudioOutputWASAPI::shutdown() {
   if (m_client) {
     m_client->Stop();
   }
-  if (m_render) {
-    m_render->Release();
-    m_render = nullptr;
-  }
-  if (m_client) {
-    m_client->Release();
-    m_client = nullptr;
-  }
-  if (m_device) {
-    m_device->Release();
-    m_device = nullptr;
-  }
-  if (m_format) {
-    CoTaskMemFree(m_format);
-    m_format = nullptr;
-  }
+  m_render.reset();
+  m_client.reset();
+  m_device.reset();
+  m_format.reset();
   CoUninitialize();
 }
 


### PR DESCRIPTION
## Summary
- introduce a small `ComPtr` RAII wrapper for COM objects
- update `AudioOutputWASAPI` to use `ComPtr` and a smart pointer for the
  `WAVEFORMATEX` allocation
- release resources on any initialization failure and log the error codes

## Testing
- `clang-format -i src/core/include/mediaplayer/ComPtr.h src/core/include/mediaplayer/AudioOutputWASAPI.h src/core/src/AudioOutputWASAPI.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686069abcb3c8331b69c891e98b4bf9a