### PR TITLE
Use ring buffer in mobile audio outputs

### DIFF
--- a/src/core/include/mediaplayer/AudioOutputAndroid.h
+++ b/src/core/include/mediaplayer/AudioOutputAndroid.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_AUDIOOUTPUTANDROID_H
 
 #include "AudioOutput.h"
+#include "RingBuffer.h"
 #ifdef __ANDROID__
 #include <SLES/OpenSLES.h>
 #include <SLES/OpenSLES_Android.h>
@@ -41,6 +42,7 @@ private:
   SLPlayItf m_player{nullptr};
   SLAndroidSimpleBufferQueueItf m_bufferQueue{nullptr};
   SLVolumeItf m_volumeItf{nullptr};
+  RingBuffer m_buffer{16384};
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/AudioOutputiOS.h
+++ b/src/core/include/mediaplayer/AudioOutputiOS.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_AUDIOOUTPUTIOS_H
 
 #include "AudioOutput.h"
+#include "RingBuffer.h"
 
 namespace mediaplayer {
 
@@ -24,6 +25,8 @@ private:
   void *m_format{nullptr};
   bool m_paused{false};
   double m_volume{1.0};
+  void scheduleNextBuffer();
+  RingBuffer m_buffer{16384};
 };
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `RingBuffer` to `AudioOutputAndroid` and `AudioOutputiOS`
- route `write()` through the ring buffer
- schedule iOS buffers from the ring buffer

## Testing
- `clang-format -i src/core/include/mediaplayer/AudioOutputAndroid.h src/core/include/mediaplayer/AudioOutputiOS.h src/core/src/AudioOutputAndroid.cpp src/core/src/AudioOutputiOS.mm`

------
https://chatgpt.com/codex/tasks/task_e_686069a918788331a19ed1d6d5c2784d