### PR TITLE
Track COM initialization success

### DIFF
--- a/src/core/include/mediaplayer/AudioOutputWASAPI.h
+++ b/src/core/include/mediaplayer/AudioOutputWASAPI.h
@@ -34,6 +34,7 @@ private:
   bool m_paused{false};
   double m_volume{1.0};
   RingBuffer m_buffer{16384};
+  bool m_comInit{false};
 };
 #endif
 

--- a/src/core/src/AudioOutputWASAPI.cpp
+++ b/src/core/src/AudioOutputWASAPI.cpp
@@ -6,7 +6,7 @@
 
 namespace mediaplayer {
 
-AudioOutputWASAPI::AudioOutputWASAPI() = default;
+AudioOutputWASAPI::AudioOutputWASAPI() : m_comInit(false) {}
 
 AudioOutputWASAPI::~AudioOutputWASAPI() { shutdown(); }
 
@@ -16,6 +16,7 @@ bool AudioOutputWASAPI::init(int sampleRate, int channels) {
     std::cerr << "CoInitializeEx failed: 0x" << std::hex << hr << '\n';
     return false;
   }
+  m_comInit = SUCCEEDED(hr);
 
   ComPtr<IMMDeviceEnumerator> enumerator;
   hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
@@ -97,7 +98,10 @@ void AudioOutputWASAPI::shutdown() {
   m_client.reset();
   m_device.reset();
   m_format.reset();
-  CoUninitialize();
+  if (m_comInit) {
+    CoUninitialize();
+    m_comInit = false;
+  }
 }
 
 int AudioOutputWASAPI::write(const uint8_t *data, int len) {


### PR DESCRIPTION
## Summary
- store whether COM was initialized successfully
- uninitialize COM only if it was initialized

## Testing
- `g++ -std=c++17 -fsyntax-only src/core/src/AudioOutputWASAPI.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68607c27747083319a3d21143120f8a3