### PR TITLE
Implement YUV OpenGL video output

### DIFF
--- a/src/core/include/mediaplayer/NullVideoOutput.h
+++ b/src/core/include/mediaplayer/NullVideoOutput.h
@@ -13,7 +13,7 @@ public:
     return true;
   }
   void shutdown() override { std::cout << "NullVideoOutput shutdown\n"; }
-  void displayFrame(const uint8_t *, int) override {}
+  void displayFrame(const VideoFrame &) override {}
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/OpenGLVideoOutput.h
+++ b/src/core/include/mediaplayer/OpenGLVideoOutput.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_OPENGLVIDEOOUTPUT_H
 #define MEDIAPLAYER_OPENGLVIDEOOUTPUT_H
 
+#include "VideoFrame.h"
 #include "VideoOutput.h"
 #include <GLFW/glfw3.h>
 
@@ -11,13 +12,18 @@ public:
   OpenGLVideoOutput();
   ~OpenGLVideoOutput() override;
 
-  bool init(int width, int height) override;
+  bool init(int width, int height) override { return init(width, height, nullptr); }
+  bool init(int width, int height, void *externalContext);
   void shutdown() override;
-  void displayFrame(const uint8_t *rgba, int linesize) override;
+  void displayFrame(const VideoFrame &frame) override;
 
 private:
   GLFWwindow *m_window{nullptr};
-  unsigned int m_texture{0};
+  bool m_external{false};
+  unsigned int m_texY{0};
+  unsigned int m_texU{0};
+  unsigned int m_texV{0};
+  unsigned int m_program{0};
   int m_width{0};
   int m_height{0};
 };

--- a/src/core/include/mediaplayer/VideoDecoder.h
+++ b/src/core/include/mediaplayer/VideoDecoder.h
@@ -28,7 +28,7 @@ public:
   // `preferredHwDevice` can be one of "dxva2", "d3d11va", "videotoolbox",
   // "vaapi" or "mediacodec" depending on the platform.
   bool open(AVFormatContext *fmtCtx, int streamIndex, const std::string &preferredHwDevice);
-  // Decode packet and write RGBA data into outBuffer. Returns bytes written.
+  // Decode packet and write YUV420P data into outBuffer. Returns bytes written.
   int decode(AVPacket *pkt, uint8_t *outBuffer, int outBufferSize) override;
   void flush() override;
   int width() const { return m_codecCtx ? m_codecCtx->width : 0; }

--- a/src/core/include/mediaplayer/VideoFrame.h
+++ b/src/core/include/mediaplayer/VideoFrame.h
@@ -1,0 +1,17 @@
+#ifndef MEDIAPLAYER_VIDEOFRAME_H
+#define MEDIAPLAYER_VIDEOFRAME_H
+
+#include <cstdint>
+
+namespace mediaplayer {
+
+struct VideoFrame {
+  const uint8_t *planes[3]{nullptr, nullptr, nullptr};
+  int linesize[3]{0, 0, 0};
+  int width{0};
+  int height{0};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VIDEOFRAME_H

--- a/src/core/include/mediaplayer/VideoOutput.h
+++ b/src/core/include/mediaplayer/VideoOutput.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_VIDEOOUTPUT_H
 #define MEDIAPLAYER_VIDEOOUTPUT_H
 
+#include "VideoFrame.h"
 #include <cstdint>
 
 namespace mediaplayer {
@@ -10,7 +11,7 @@ public:
   virtual ~VideoOutput() = default;
   virtual bool init(int width, int height) = 0;
   virtual void shutdown() = 0;
-  virtual void displayFrame(const uint8_t *rgba, int linesize) = 0;
+  virtual void displayFrame(const VideoFrame &frame) = 0;
 };
 
 } // namespace mediaplayer

--- a/src/core/src/OpenGLVideoOutput.cpp
+++ b/src/core/src/OpenGLVideoOutput.cpp
@@ -1,58 +1,139 @@
 #include "mediaplayer/OpenGLVideoOutput.h"
 
 #include <GL/gl.h>
+#include <fstream>
 #include <iostream>
 
 namespace mediaplayer {
+
+static std::string loadFile(const char *path) {
+  std::ifstream f(path);
+  return std::string((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+static GLuint compileShader(GLenum type, const std::string &src) {
+  GLuint shader = glCreateShader(type);
+  const char *cstr = src.c_str();
+  glShaderSource(shader, 1, &cstr, nullptr);
+  glCompileShader(shader);
+  GLint status = 0;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+  if (!status) {
+    char log[512];
+    glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+    std::cerr << "Shader compile error: " << log << std::endl;
+  }
+  return shader;
+}
 
 OpenGLVideoOutput::OpenGLVideoOutput() = default;
 
 OpenGLVideoOutput::~OpenGLVideoOutput() { shutdown(); }
 
-bool OpenGLVideoOutput::init(int width, int height) {
-  if (!glfwInit()) {
-    std::cerr << "Failed to init GLFW\n";
-    return false;
-  }
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-  m_window = glfwCreateWindow(width, height, "MediaPlayer", nullptr, nullptr);
-  if (!m_window) {
-    std::cerr << "Failed to create GLFW window\n";
-    glfwTerminate();
-    return false;
+bool OpenGLVideoOutput::init(int width, int height, void *externalContext) {
+  if (externalContext) {
+    m_window = static_cast<GLFWwindow *>(externalContext);
+    m_external = true;
+  } else {
+    if (!glfwInit()) {
+      std::cerr << "Failed to init GLFW\n";
+      return false;
+    }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    m_window = glfwCreateWindow(width, height, "MediaPlayer", nullptr, nullptr);
+    if (!m_window) {
+      std::cerr << "Failed to create GLFW window\n";
+      glfwTerminate();
+      return false;
+    }
   }
   glfwMakeContextCurrent(m_window);
-  glGenTextures(1, &m_texture);
-  glBindTexture(GL_TEXTURE_2D, m_texture);
+
+  std::string vertSrc = loadFile("yuv.vert");
+  std::string fragSrc = loadFile("yuv.frag");
+  GLuint vs = compileShader(GL_VERTEX_SHADER, vertSrc);
+  GLuint fs = compileShader(GL_FRAGMENT_SHADER, fragSrc);
+  m_program = glCreateProgram();
+  glAttachShader(m_program, vs);
+  glAttachShader(m_program, fs);
+  glLinkProgram(m_program);
+  glDeleteShader(vs);
+  glDeleteShader(fs);
+
+  glGenTextures(1, &m_texY);
+  glBindTexture(GL_TEXTURE_2D, m_texY);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+  glGenTextures(1, &m_texU);
+  glBindTexture(GL_TEXTURE_2D, m_texU);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+  glGenTextures(1, &m_texV);
+  glBindTexture(GL_TEXTURE_2D, m_texV);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
   m_width = width;
   m_height = height;
   return true;
 }
 
 void OpenGLVideoOutput::shutdown() {
-  if (m_texture) {
-    glDeleteTextures(1, &m_texture);
-    m_texture = 0;
+  if (m_texY) {
+    glDeleteTextures(1, &m_texY);
+    m_texY = 0;
   }
-  if (m_window) {
+  if (m_texU) {
+    glDeleteTextures(1, &m_texU);
+    m_texU = 0;
+  }
+  if (m_texV) {
+    glDeleteTextures(1, &m_texV);
+    m_texV = 0;
+  }
+  if (m_program) {
+    glDeleteProgram(m_program);
+    m_program = 0;
+  }
+  if (m_window && !m_external) {
     glfwDestroyWindow(m_window);
     m_window = nullptr;
     glfwTerminate();
   }
 }
 
-void OpenGLVideoOutput::displayFrame(const uint8_t *rgba, int linesize) {
+void OpenGLVideoOutput::displayFrame(const VideoFrame &frame) {
   if (!m_window)
     return;
   glfwMakeContextCurrent(m_window);
+
+  glUseProgram(m_program);
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, m_texY);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, frame.linesize[0]);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, frame.width, frame.height, 0, GL_LUMINANCE,
+               GL_UNSIGNED_BYTE, frame.planes[0]);
+  glUniform1i(glGetUniformLocation(m_program, "texY"), 0);
+
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, m_texU);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, frame.linesize[1]);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, frame.width / 2, frame.height / 2, 0, GL_LUMINANCE,
+               GL_UNSIGNED_BYTE, frame.planes[1]);
+  glUniform1i(glGetUniformLocation(m_program, "texU"), 1);
+
+  glActiveTexture(GL_TEXTURE2);
+  glBindTexture(GL_TEXTURE_2D, m_texV);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, frame.linesize[2]);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, frame.width / 2, frame.height / 2, 0, GL_LUMINANCE,
+               GL_UNSIGNED_BYTE, frame.planes[2]);
+  glUniform1i(glGetUniformLocation(m_program, "texV"), 2);
+
   glClear(GL_COLOR_BUFFER_BIT);
-  glBindTexture(GL_TEXTURE_2D, m_texture);
-  glPixelStorei(GL_UNPACK_ROW_LENGTH, linesize / 4);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
-  glEnable(GL_TEXTURE_2D);
   glBegin(GL_QUADS);
   glTexCoord2f(0.f, 1.f);
   glVertex2f(-1.f, -1.f);

--- a/src/core/src/yuv.frag
+++ b/src/core/src/yuv.frag
@@ -1,0 +1,15 @@
+#version 120
+varying vec2 vTex;
+uniform sampler2D texY;
+uniform sampler2D texU;
+uniform sampler2D texV;
+void main() {
+    float y = texture2D(texY, vTex).r;
+    float u = texture2D(texU, vTex).r - 0.5;
+    float v = texture2D(texV, vTex).r - 0.5;
+    vec3 rgb;
+    rgb.r = y + 1.402 * v;
+    rgb.g = y - 0.344136 * u - 0.714136 * v;
+    rgb.b = y + 1.772 * u;
+    gl_FragColor = vec4(rgb, 1.0);
+}

--- a/src/core/src/yuv.vert
+++ b/src/core/src/yuv.vert
@@ -1,0 +1,6 @@
+#version 120
+varying vec2 vTex;
+void main() {
+    gl_Position = gl_Vertex;
+    vTex = gl_MultiTexCoord0.xy;
+}


### PR DESCRIPTION
## Summary
- add `VideoFrame` structure for YUV plane data
- switch `VideoOutput` interface to use `VideoFrame`
- update `VideoDecoder` to output YUV420P
- render YUV textures in `OpenGLVideoOutput` via shader program
- expose optional external context and load GLSL sources

## Testing
- `clang-format -i src/core/include/mediaplayer/NullVideoOutput.h src/core/include/mediaplayer/OpenGLVideoOutput.h src/core/include/mediaplayer/VideoDecoder.h src/core/include/mediaplayer/VideoOutput.h src/core/include/mediaplayer/VideoFrame.h src/core/src/MediaPlayer.cpp src/core/src/OpenGLVideoOutput.cpp src/core/src/VideoDecoder.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6861ba1565f48331a29a91f727d89e12