### PR TITLE
Add pull request conflict guide

### DIFF
--- a/docs/merge_conflict.md
+++ b/docs/merge_conflict.md
@@ -60,7 +60,7 @@ locally, run `git merge-base` or `git status` to detect conflicts.
 
 The repository occasionally receives a giant PR that contains all tasks at once, along with individual PRs for each task. The giant PR usually merges first because it covers everything at once. However, the smaller PRs are still useful to check for missed functionality.
 
-### `pullrequest_merge_conflict.md`
+### [`pullrequest_merge_conflict.md`](pullrequest_merge_conflict.md)
 
 #### 📌 Purpose
 

--- a/docs/pullrequest_merge_conflict.md
+++ b/docs/pullrequest_merge_conflict.md
@@ -1,0 +1,18 @@
+# Handling Pull Request Merge Conflicts
+
+This document expands on [merge_conflict.md](merge_conflict.md) and explains how to
+review individual PRs when a giant PR has already landed.
+
+## Workflow Summary
+
+1. **Checkout the latest `main`** which contains the giant PR.
+2. **List the open PRs** using `gh pr list` or the GitHub API.
+3. For each PR:
+   - Fetch the branch with `git fetch upstream <branch>`.
+   - Run `git diff upstream/main..FETCH_HEAD` to inspect differences.
+   - Attempt a merge with `git merge --no-commit --no-ff FETCH_HEAD` to detect conflicts.
+   - Abort the merge with `git merge --abort` when conflicts are found.
+4. Note any features or improvements that are missing from `main`.
+5. Combine all missing pieces into a new task for Codex to implement in a single conflict-free PR.
+
+By following this process the repository retains all useful work from individual PRs without repeatedly resolving the same conflicts.


### PR DESCRIPTION
## Summary
- crosslink PR conflict guide in `merge_conflict.md`
- add new `pullrequest_merge_conflict.md` with step-by-step instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861d58b17ac83318a9807c2fca9f726