### PR TITLE
Add iOS Metal video output guide

### DIFF
--- a/docs/ios_video_output.md
+++ b/docs/ios_video_output.md
@@ -1,0 +1,27 @@
+# iOS Metal Video Output
+
+This short guide demonstrates how to connect `MetalVideoOutput` from the core engine to an `MTKView`.
+
+## Attaching to `MTKView`
+
+```objective-c
+#import <MetalKit/MetalKit.h>
+#import "mediaplayer/MediaPlayer.h"
+#import "mediaplayer/MetalVideoOutput.h"
+
+using namespace mediaplayer;
+
+- (void)setupPlayerWithView:(MTKView *)view {
+    auto player = std::make_unique<MediaPlayer>();
+    auto output = std::make_unique<MetalVideoOutput>();
+
+    output->init(view.drawableSize.width, view.drawableSize.height);
+    view.layer = (__bridge CAMetalLayer *)output->layer();
+
+    player->setVideoOutput(std::move(output));
+    player->open("movie.mp4");
+    player->play();
+}
+```
+
+The view's `CAMetalLayer` is supplied by `MetalVideoOutput`, which renders each decoded frame directly into the layer attached to the `MTKView`.

--- a/docs/video_output_tasks.md
+++ b/docs/video_output_tasks.md
@@ -37,6 +37,9 @@ This document expands on the Video Output section in [Tasks.MD](../Tasks.MD). Ea
 1. **Use `MTKView` or `GLKView`** to host the graphics context on iOS.
 2. **Render YUV frames** with either Metal shaders or OpenGL ES, depending on the chosen approach.
 
+### Example: MTKView Integration
+See [ios_video_output.md](ios_video_output.md) for a minimal snippet showing how to attach `MetalVideoOutput` to an `MTKView`.
+
 ## 25. Video Output Integration
 
 1. **Connect decoded frames to the renderer** via a thread‑safe queue or double buffer inside `MediaPlayer::videoLoop`.

--- a/src/core/include/mediaplayer/MetalVideoOutput.h
+++ b/src/core/include/mediaplayer/MetalVideoOutput.h
@@ -22,6 +22,7 @@ public:
   void shutdown() override;
   void displayFrame(const uint8_t *rgba, int linesize) override;
   void displayFrame(const VideoFrame &frame);
+  void *layer() const { return m_layer; }
 
 private:
   void *m_layer{nullptr};

--- a/src/core/src/MetalVideoOutput.mm
+++ b/src/core/src/MetalVideoOutput.mm
@@ -194,4 +194,6 @@ void MetalVideoOutput::displayFrame(const VideoFrame &frame) {
   }
 }
 
+void *MetalVideoOutput::layer() const { return m_layer; }
+
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- provide instructions for connecting `MetalVideoOutput` to an `MTKView`
- expose CAMetalLayer pointer from `MetalVideoOutput`
- link the new doc from the video output tasks

## Testing
- `clang++ -ObjC++ -I src/core/include -c src/core/src/MetalVideoOutput.mm -o /tmp/MetalVideoOutput.o` *(fails: 'Metal/Metal.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e01d8b708331b395149419a57fb4