### PR TITLE
Remove redundant frame structs

### DIFF
--- a/src/core/include/mediaplayer/Direct3D11VideoOutput.h
+++ b/src/core/include/mediaplayer/Direct3D11VideoOutput.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_DIRECT3D11VIDEOOUTPUT_H
 
 #include "ComPtr.h"
+#include "VideoFrame.h"
 #include "VideoOutput.h"
 #ifdef _WIN32
 #include <d3d11.h>
@@ -12,17 +13,6 @@
 namespace mediaplayer {
 
 #ifdef _WIN32
-struct VideoFrame {
-  const uint8_t *y{nullptr};
-  const uint8_t *u{nullptr};
-  const uint8_t *v{nullptr};
-  int width{0};
-  int height{0};
-  int linesizeY{0};
-  int linesizeU{0};
-  int linesizeV{0};
-};
-
 class Direct3D11VideoOutput : public VideoOutput {
 public:
   Direct3D11VideoOutput();

--- a/src/core/include/mediaplayer/MetalVideoOutput.h
+++ b/src/core/include/mediaplayer/MetalVideoOutput.h
@@ -1,17 +1,11 @@
 #ifndef MEDIAPLAYER_METALVIDEOOUTPUT_H
 #define MEDIAPLAYER_METALVIDEOOUTPUT_H
 
+#include "VideoFrame.h"
 #include "VideoOutput.h"
 #include <cstdint>
 
 namespace mediaplayer {
-
-struct VideoFrame {
-  const uint8_t *data[3];
-  int linesize[3];
-  int width;
-  int height;
-};
 
 class MetalVideoOutput : public VideoOutput {
 public:

--- a/src/core/src/Direct3D11VideoOutput.cpp
+++ b/src/core/src/Direct3D11VideoOutput.cpp
@@ -212,7 +212,7 @@ void Direct3D11VideoOutput::displayFrame(const VideoFrame &frame) {
   if (SUCCEEDED(m_context->Map(m_yTexture.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
     for (int y = 0; y < frame.height; ++y) {
       memcpy(static_cast<uint8_t *>(mapped.pData) + mapped.RowPitch * y,
-             frame.y + frame.linesizeY * y, frame.width);
+             frame.data[0] + frame.linesize[0] * y, frame.width);
     }
     m_context->Unmap(m_yTexture.get(), 0);
   }
@@ -221,14 +221,14 @@ void Direct3D11VideoOutput::displayFrame(const VideoFrame &frame) {
   if (SUCCEEDED(m_context->Map(m_uTexture.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
     for (int y = 0; y < chromaH; ++y) {
       memcpy(static_cast<uint8_t *>(mapped.pData) + mapped.RowPitch * y,
-             frame.u + frame.linesizeU * y, chromaW);
+             frame.data[1] + frame.linesize[1] * y, chromaW);
     }
     m_context->Unmap(m_uTexture.get(), 0);
   }
   if (SUCCEEDED(m_context->Map(m_vTexture.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
     for (int y = 0; y < chromaH; ++y) {
       memcpy(static_cast<uint8_t *>(mapped.pData) + mapped.RowPitch * y,
-             frame.v + frame.linesizeV * y, chromaW);
+             frame.data[2] + frame.linesize[2] * y, chromaW);
     }
     m_context->Unmap(m_vTexture.get(), 0);
   }


### PR DESCRIPTION
## Summary
- eliminate duplicate `VideoFrame` definitions in platform video outputs
- include shared `VideoFrame.h` for Metal and Direct3D11
- adjust Direct3D11 implementation to use array-based frame access

## Testing
- `clang-format -i src/core/include/mediaplayer/MetalVideoOutput.h src/core/include/mediaplayer/Direct3D11VideoOutput.h src/core/src/Direct3D11VideoOutput.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6861e015cbac8331bb01f916113b33ad