### PR TITLE
Implement playlist shuffle and audio effect hooks

### DIFF
--- a/src/core/include/mediaplayer/AudioEffect.h
+++ b/src/core/include/mediaplayer/AudioEffect.h
@@ -1,0 +1,18 @@
+#ifndef MEDIAPLAYER_AUDIOEFFECT_H
+#define MEDIAPLAYER_AUDIOEFFECT_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mediaplayer {
+
+class AudioEffect {
+public:
+  virtual ~AudioEffect() = default;
+  // Process PCM samples in-place. Samples are signed 16-bit interleaved.
+  virtual void process(int16_t *samples, size_t sampleCount, int channels, int sampleRate) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOEFFECT_H

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "AudioDecoder.h"
+#include "AudioEffect.h"
 #include "AudioOutput.h"
 #include "LibraryDB.h"
 #include "MediaDemuxer.h"
@@ -23,6 +24,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 namespace mediaplayer {
 
@@ -40,6 +42,12 @@ public:
   void addToPlaylist(const std::string &path);
   void clearPlaylist();
   bool nextTrack();
+  void setShuffle(bool enabled);
+  bool shuffle() const;
+  void setAutoAdvance(bool enabled);
+  bool autoAdvance() const;
+  void addAudioEffect(std::shared_ptr<AudioEffect> effect);
+  void clearAudioEffects();
   void setAudioOutput(std::unique_ptr<AudioOutput> output);
   void setVideoOutput(std::unique_ptr<VideoOutput> output);
   void setPreferredHardwareDevice(const std::string &device);
@@ -80,11 +88,13 @@ private:
   VideoFrameQueue m_frameQueue;
   PlaybackCallbacks m_callbacks;
   PlaylistManager m_playlist;
+  bool m_autoAdvance{true};
   LibraryDB *m_library{nullptr};
   bool m_playRecorded{false};
   double m_volume{1.0};
   MediaMetadata m_metadata;
   std::string m_hwDevice;
+  std::vector<std::shared_ptr<AudioEffect>> m_effects;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/PlaybackCallbacks.h
+++ b/src/core/include/mediaplayer/PlaybackCallbacks.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_PLAYBACKCALLBACKS_H
 #define MEDIAPLAYER_PLAYBACKCALLBACKS_H
 
+#include "MediaMetadata.h"
 #include <functional>
 
 namespace mediaplayer {
@@ -11,6 +12,8 @@ struct PlaybackCallbacks {
   std::function<void()> onStop;
   std::function<void()> onFinished;
   std::function<void(double)> onPosition;
+  // Called whenever a new track is loaded. Provides the metadata of the track.
+  std::function<void(const MediaMetadata &)> onTrackChanged;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/PlaylistManager.h
+++ b/src/core/include/mediaplayer/PlaylistManager.h
@@ -14,10 +14,14 @@ public:
   std::string next();
   bool empty() const;
   void reset();
+  void setShuffle(bool enabled);
+  bool shuffle() const;
 
 private:
   std::vector<std::string> m_items;
+  std::vector<size_t> m_order;
   size_t m_index{0};
+  bool m_shuffle{false};
 };
 
 } // namespace mediaplayer

--- a/src/core/src/PlaylistManager.cpp
+++ b/src/core/src/PlaylistManager.cpp
@@ -1,28 +1,59 @@
 #include "mediaplayer/PlaylistManager.h"
+#include <algorithm>
+#include <numeric>
+#include <random>
 
 namespace mediaplayer {
 
 void PlaylistManager::set(const std::vector<std::string> &paths) {
   m_items = paths;
   m_index = 0;
+  m_order.resize(m_items.size());
+  std::iota(m_order.begin(), m_order.end(), 0);
+  if (m_shuffle)
+    std::shuffle(m_order.begin(), m_order.end(), std::mt19937{std::random_device{}()});
 }
 
-void PlaylistManager::add(const std::string &path) { m_items.push_back(path); }
+void PlaylistManager::add(const std::string &path) {
+  m_items.push_back(path);
+  m_order.push_back(m_items.size() - 1);
+  if (m_shuffle) {
+    std::shuffle(m_order.begin(), m_order.end(), std::mt19937{std::random_device{}()});
+  }
+}
 
 void PlaylistManager::clear() {
   m_items.clear();
+  m_order.clear();
   m_index = 0;
 }
 
 std::string PlaylistManager::next() {
   if (m_index < m_items.size()) {
-    return m_items[m_index++];
+    size_t idx = m_shuffle ? m_order[m_index] : m_index;
+    ++m_index;
+    return m_items[idx];
   }
   return {};
 }
 
 bool PlaylistManager::empty() const { return m_index >= m_items.size(); }
 
-void PlaylistManager::reset() { m_index = 0; }
+void PlaylistManager::reset() {
+  m_index = 0;
+  if (m_shuffle && !m_order.empty()) {
+    std::shuffle(m_order.begin(), m_order.end(), std::mt19937{std::random_device{}()});
+  }
+}
+
+void PlaylistManager::setShuffle(bool enabled) {
+  m_shuffle = enabled;
+  m_order.resize(m_items.size());
+  std::iota(m_order.begin(), m_order.end(), 0);
+  if (m_shuffle)
+    std::shuffle(m_order.begin(), m_order.end(), std::mt19937{std::random_device{}()});
+}
+
+bool PlaylistManager::shuffle() const { return m_shuffle; }
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `AudioEffect` interface for DSP plugins
- extend `PlaybackCallbacks` with track-changed notification
- support shuffle mode in `PlaylistManager`
- expose playlist/auto-advance settings and audio effects in `MediaPlayer`
- apply audio effects and auto-advance logic during playback

## Testing
- `clang-format -i src/core/include/mediaplayer/AudioEffect.h src/core/include/mediaplayer/PlaybackCallbacks.h src/core/include/mediaplayer/PlaylistManager.h src/core/include/mediaplayer/MediaPlayer.h src/core/src/PlaylistManager.cpp src/core/src/MediaPlayer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6861e56635488331b6cfdd9ff533e60e