### PR TITLE
Add audio effects support

### DIFF
--- a/src/core/include/mediaplayer/AudioEffect.h
+++ b/src/core/include/mediaplayer/AudioEffect.h
@@ -1,0 +1,17 @@
+#ifndef MEDIAPLAYER_AUDIOEFFECT_H
+#define MEDIAPLAYER_AUDIOEFFECT_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mediaplayer {
+
+class AudioEffect {
+public:
+  virtual ~AudioEffect() = default;
+  virtual void process(int16_t *samples, size_t count) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOEFFECT_H

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "AudioDecoder.h"
+#include "AudioEffect.h"
 #include "AudioOutput.h"
 #include "LibraryDB.h"
 #include "MediaDemuxer.h"
@@ -23,6 +24,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 namespace mediaplayer {
 
@@ -45,6 +47,8 @@ public:
   void setPreferredHardwareDevice(const std::string &device);
   void setCallbacks(PlaybackCallbacks callbacks);
   void setLibrary(LibraryDB *db);
+  void addAudioEffect(std::shared_ptr<AudioEffect> effect);
+  void removeAudioEffect(std::shared_ptr<AudioEffect> effect);
   void setVolume(double volume); // 0.0 - 1.0
   double volume() const;
   double position() const; // seconds
@@ -79,6 +83,7 @@ private:
   PacketQueue m_videoPackets;
   VideoFrameQueue m_frameQueue;
   PlaybackCallbacks m_callbacks;
+  std::vector<std::shared_ptr<AudioEffect>> m_audioEffects;
   PlaylistManager m_playlist;
   LibraryDB *m_library{nullptr};
   bool m_playRecorded{false};

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -7,6 +7,7 @@
 #include "mediaplayer/AudioOutputPulse.h"
 #endif
 #include "mediaplayer/VideoFrame.h"
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -192,6 +193,18 @@ void MediaPlayer::setPreferredHardwareDevice(const std::string &device) {
 void MediaPlayer::setLibrary(LibraryDB *db) {
   std::lock_guard<std::mutex> lock(m_mutex);
   m_library = db;
+}
+
+void MediaPlayer::addAudioEffect(std::shared_ptr<AudioEffect> effect) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (effect)
+    m_audioEffects.push_back(std::move(effect));
+}
+
+void MediaPlayer::removeAudioEffect(std::shared_ptr<AudioEffect> effect) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  auto it = std::remove(m_audioEffects.begin(), m_audioEffects.end(), effect);
+  m_audioEffects.erase(it, m_audioEffects.end());
 }
 
 void MediaPlayer::setCallbacks(PlaybackCallbacks callbacks) {
@@ -383,9 +396,9 @@ void MediaPlayer::audioLoop() {
           std::lock_guard<std::mutex> lock(m_mutex);
           vol = m_volume;
         }
+        int16_t *samples = reinterpret_cast<int16_t *>(audioBuffer);
+        int sampleCount = bytes / sizeof(int16_t);
         if (vol < 0.999) {
-          int16_t *samples = reinterpret_cast<int16_t *>(audioBuffer);
-          int sampleCount = bytes / sizeof(int16_t);
           for (int i = 0; i < sampleCount; ++i) {
             int32_t s = static_cast<int32_t>(samples[i] * vol);
             if (s < -32768)
@@ -395,6 +408,13 @@ void MediaPlayer::audioLoop() {
             samples[i] = static_cast<int16_t>(s);
           }
         }
+        std::vector<std::shared_ptr<AudioEffect>> effects;
+        {
+          std::lock_guard<std::mutex> lock(m_mutex);
+          effects = m_audioEffects;
+        }
+        for (auto &effect : effects)
+          effect->process(samples, sampleCount);
         m_output->write(audioBuffer, bytes);
         if (m_callbacks.onPosition)
           m_callbacks.onPosition(m_audioClock);


### PR DESCRIPTION
## Summary
- define `AudioEffect` interface
- allow `MediaPlayer` to add and remove audio effects
- process audio buffers through added effects before output

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e989b1a083319bf41eb90a2bdcbd