### PR TITLE
Implement playlist auto-advance

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -50,6 +50,8 @@ public:
   double position() const; // seconds
   void setNetworkBufferSize(size_t size);
   size_t networkBufferSize() const;
+  void setAutoAdvance(bool enable);
+  bool autoAdvance() const { return m_autoAdvance; }
   const MediaMetadata &metadata() const { return m_metadata; }
   int readAudio(uint8_t *buffer, int bufferSize);
   int readVideo(uint8_t *buffer, int bufferSize);
@@ -85,6 +87,7 @@ private:
   double m_volume{1.0};
   MediaMetadata m_metadata;
   std::string m_hwDevice;
+  bool m_autoAdvance{true};
 };
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- allow enabling/disabling automatic playlist advance
- trigger `nextTrack()` from `demuxLoop` when EOF is reached

## Testing
- `clang++ -std=c++17 -I src/core/include -I src/library/include -I src/subtitles/include -I src/conversion/include -fsyntax-only src/core/src/MediaPlayer.cpp` *(fails: 'libavcodec/avcodec.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e98881b8833186bda8674c19ba10