### PR TITLE
Add shuffle mode to playlist manager

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -40,6 +40,8 @@ public:
   void addToPlaylist(const std::string &path);
   void clearPlaylist();
   bool nextTrack();
+  void enableShuffle(bool enabled);
+  bool shuffleEnabled() const;
   void setAudioOutput(std::unique_ptr<AudioOutput> output);
   void setVideoOutput(std::unique_ptr<VideoOutput> output);
   void setPreferredHardwareDevice(const std::string &device);

--- a/src/core/include/mediaplayer/PlaylistManager.h
+++ b/src/core/include/mediaplayer/PlaylistManager.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_PLAYLISTMANAGER_H
 #define MEDIAPLAYER_PLAYLISTMANAGER_H
 
+#include <random>
 #include <string>
 #include <vector>
 
@@ -14,10 +15,16 @@ public:
   std::string next();
   bool empty() const;
   void reset();
+  void enableShuffle(bool enabled);
+  bool shuffleEnabled() const;
 
 private:
   std::vector<std::string> m_items;
   size_t m_index{0};
+  bool m_shuffle{false};
+  std::vector<size_t> m_unusedIndices;
+  std::mt19937 m_rng{std::random_device{}()};
+  void resetShuffle();
 };
 
 } // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -323,6 +323,16 @@ void MediaPlayer::clearPlaylist() {
   m_playlist.clear();
 }
 
+void MediaPlayer::enableShuffle(bool enabled) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_playlist.enableShuffle(enabled);
+}
+
+bool MediaPlayer::shuffleEnabled() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_playlist.shuffleEnabled();
+}
+
 bool MediaPlayer::nextTrack() {
   std::string path;
   {

--- a/src/core/src/PlaylistManager.cpp
+++ b/src/core/src/PlaylistManager.cpp
@@ -5,24 +5,59 @@ namespace mediaplayer {
 void PlaylistManager::set(const std::vector<std::string> &paths) {
   m_items = paths;
   m_index = 0;
+  resetShuffle();
 }
 
-void PlaylistManager::add(const std::string &path) { m_items.push_back(path); }
+void PlaylistManager::add(const std::string &path) {
+  m_items.push_back(path);
+  if (m_shuffle)
+    m_unusedIndices.push_back(m_items.size() - 1);
+}
 
 void PlaylistManager::clear() {
   m_items.clear();
   m_index = 0;
+  m_unusedIndices.clear();
 }
 
 std::string PlaylistManager::next() {
-  if (m_index < m_items.size()) {
-    return m_items[m_index++];
+  if (m_shuffle) {
+    if (m_unusedIndices.empty())
+      return {};
+    std::uniform_int_distribution<size_t> dist(0, m_unusedIndices.size() - 1);
+    size_t pos = dist(m_rng);
+    size_t idx = m_unusedIndices[pos];
+    m_unusedIndices.erase(m_unusedIndices.begin() + pos);
+    return m_items[idx];
   }
+  if (m_index < m_items.size())
+    return m_items[m_index++];
   return {};
 }
 
-bool PlaylistManager::empty() const { return m_index >= m_items.size(); }
+bool PlaylistManager::empty() const {
+  if (m_shuffle)
+    return m_unusedIndices.empty();
+  return m_index >= m_items.size();
+}
 
-void PlaylistManager::reset() { m_index = 0; }
+void PlaylistManager::reset() {
+  m_index = 0;
+  resetShuffle();
+}
+
+void PlaylistManager::enableShuffle(bool enabled) {
+  m_shuffle = enabled;
+  reset();
+}
+
+bool PlaylistManager::shuffleEnabled() const { return m_shuffle; }
+
+void PlaylistManager::resetShuffle() {
+  m_unusedIndices.clear();
+  if (m_shuffle)
+    for (size_t i = 0; i < m_items.size(); ++i)
+      m_unusedIndices.push_back(i);
+}
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- support shuffling in `PlaylistManager`
- expose shuffle toggle in `MediaPlayer`

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp src/core/include/mediaplayer/PlaylistManager.h src/core/src/PlaylistManager.cpp`
- `cmake -S . -B build` *(fails: libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e98771f483318b3129e5f0d6516a