### PR TITLE
Fix frame queue clearing on seek

### DIFF
--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -303,6 +303,7 @@ void MediaPlayer::seek(double seconds) {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_audioPackets.clear();
     m_videoPackets.clear();
+    m_frameQueue.clear();
   }
   m_audioClock = seconds;
   m_videoClock = seconds;

--- a/src/core/src/VideoFrameQueue.cpp
+++ b/src/core/src/VideoFrameQueue.cpp
@@ -39,6 +39,7 @@ void VideoFrameQueue::clear() {
     delete f;
     m_queue.pop();
   }
+  m_cv.notify_all();
 }
 
 size_t VideoFrameQueue::size() const {


### PR DESCRIPTION
## Summary
- clear the frame queue when seeking
- wake waiting threads when clearing the frame queue

## Testing
- `cmake -S . -B build` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e981f0008331b1c7722579281fa8