### PR TITLE
Implement PlaylistManager::remove and tests

### DIFF
--- a/src/core/include/mediaplayer/PlaylistManager.h
+++ b/src/core/include/mediaplayer/PlaylistManager.h
@@ -11,6 +11,7 @@ class PlaylistManager {
 public:
   void set(const std::vector<std::string> &paths);
   void add(const std::string &path);
+  bool remove(const std::string &path);
   void clear();
   std::string next();
   bool empty() const;

--- a/src/core/src/PlaylistManager.cpp
+++ b/src/core/src/PlaylistManager.cpp
@@ -14,6 +14,31 @@ void PlaylistManager::add(const std::string &path) {
     m_unusedIndices.push_back(m_items.size() - 1);
 }
 
+bool PlaylistManager::remove(const std::string &path) {
+  bool removed = false;
+  for (size_t i = 0; i < m_items.size();) {
+    if (m_items[i] == path) {
+      removed = true;
+      m_items.erase(m_items.begin() + i);
+      if (!m_shuffle && i < m_index)
+        --m_index;
+      for (auto it = m_unusedIndices.begin(); it != m_unusedIndices.end();) {
+        if (*it == i) {
+          it = m_unusedIndices.erase(it);
+          continue;
+        } else {
+          if (*it > i)
+            --(*it);
+        }
+        ++it;
+      }
+      continue; // do not increment i after erase
+    }
+    ++i;
+  }
+  return removed;
+}
+
 void PlaylistManager::clear() {
   m_items.clear();
   m_index = 0;

--- a/tests/library_playlist_test.cpp
+++ b/tests/library_playlist_test.cpp
@@ -1,4 +1,5 @@
 #include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/PlaylistManager.h"
 #include <cassert>
 #include <cstdio>
 
@@ -20,5 +21,14 @@ int main() {
   assert(db.deletePlaylist("fav"));
   db.close();
   std::remove(dbPath);
+
+  mediaplayer::PlaylistManager pm;
+  pm.set({"a.mp3", "b.mp3", "a.mp3"});
+  pm.enableShuffle(true);
+  assert(pm.remove("a.mp3"));
+  auto next = pm.next();
+  assert(next == "b.mp3");
+  assert(pm.empty());
+  assert(!pm.remove("c.mp3"));
   return 0;
 }


### PR DESCRIPTION
## Summary
- extend PlaylistManager with `remove` to drop all occurrences of a path
- keep shuffle bookkeeping accurate when removing
- test removing playlist items in the SQLite DB and PlaylistManager

## Testing
- `clang-format -i src/core/include/mediaplayer/PlaylistManager.h`
- `clang-format -i src/core/src/PlaylistManager.cpp`
- `clang-format -i tests/library_playlist_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6861f33ccff48331b7e59c7eead9dead