### PR TITLE
Add onTrackLoaded callback

### DIFF
--- a/src/core/include/mediaplayer/PlaybackCallbacks.h
+++ b/src/core/include/mediaplayer/PlaybackCallbacks.h
@@ -3,6 +3,8 @@
 
 #include <functional>
 
+#include "MediaMetadata.h"
+
 namespace mediaplayer {
 
 struct PlaybackCallbacks {
@@ -10,6 +12,7 @@ struct PlaybackCallbacks {
   std::function<void()> onPause;
   std::function<void()> onStop;
   std::function<void()> onFinished;
+  std::function<void(const MediaMetadata &)> onTrackLoaded;
   std::function<void(double)> onPosition;
 };
 

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -131,6 +131,8 @@ bool MediaPlayer::open(const std::string &path) {
   }
   if (m_metadata.title.empty())
     m_metadata.title = std::filesystem::path(path).filename().string();
+  if (m_callbacks.onTrackLoaded)
+    m_callbacks.onTrackLoaded(m_metadata);
   m_audioClock = 0.0;
   m_videoClock = 0.0;
   m_audioPackets.clear();


### PR DESCRIPTION
## Summary
- extend `PlaybackCallbacks` with `onTrackLoaded`
- invoke `onTrackLoaded` after parsing metadata in `MediaPlayer::open`

## Testing
- `clang++ -std=c++17 -I src/core/include -c src/core/src/MediaPlayer.cpp` *(fails: 'libavcodec/avcodec.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f33b1b648331927b585cdc64f9f0