### PR TITLE
Fix video seek timing

### DIFF
--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -323,6 +323,7 @@ void MediaPlayer::seek(double seconds) {
     m_videoPackets.clear();
     m_frameQueue.clear();
   }
+  m_startTime = av_gettime() / 1000000.0 - seconds;
   m_audioClock = seconds;
   m_videoClock = seconds;
 }


### PR DESCRIPTION
## Summary
- reset `m_startTime` after flushing decoders in `MediaPlayer::seek`
- keep video-only files in sync by updating start time when seeking

## Testing
- `cmake -S . -B build` *(fails: required packages not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f33e794083319edbceb1db2dc29f