### PR TITLE
Fix seek demuxing EOF reset

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -29,7 +29,7 @@
 | 23 | Frame Renderer – Android (OpenGL ES) | done | implemented in `src/android/AndroidGLVideoOutput.cpp` |
 | 24 | Frame Renderer – iOS (Metal/GL ES) | done | implemented in `src/core/src/MetalVideoOutput.mm` |
 | 25 | Video Output Integration | done | relevant |
-| 26 | Implement Play/Pause/Seek Logic | done | relevant |
+| 26 | Implement Play/Pause/Seek Logic | done | seek now calls `MediaDemuxer::resetEof` after `av_seek_frame` |
 | 27 | Track and Playlist Management (Core) | done | relevant |
 | 28 | Playback State Notifications | done | relevant |
 | 29 | Volume and Audio Effects | done | relevant |

--- a/src/core/include/mediaplayer/MediaDemuxer.h
+++ b/src/core/include/mediaplayer/MediaDemuxer.h
@@ -24,6 +24,7 @@ public:
   int subtitleStream() const { return m_subtitleStream; }
   AVFormatContext *context() const { return m_ctx; }
   bool eof() const { return m_eof; }
+  void resetEof();
   void setBufferSize(size_t size) { m_bufferSize = size; }
   size_t bufferSize() const { return m_bufferSize; }
 

--- a/src/core/src/MediaDemuxer.cpp
+++ b/src/core/src/MediaDemuxer.cpp
@@ -77,4 +77,6 @@ bool MediaDemuxer::readPacket(AVPacket &pkt) {
   return true;
 }
 
+void MediaDemuxer::resetEof() { m_eof = false; }
+
 } // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -315,6 +315,7 @@ void MediaPlayer::seek(double seconds) {
     return;
   int64_t ts = static_cast<int64_t>(seconds * AV_TIME_BASE);
   av_seek_frame(m_demuxer.context(), -1, ts, AVSEEK_FLAG_BACKWARD);
+  m_demuxer.resetEof();
   m_audioDecoder.flush();
   m_videoDecoder.flush();
   {


### PR DESCRIPTION
## Summary
- add `resetEof()` to `MediaDemuxer`
- reset demuxer EOF after seeking in `MediaPlayer`
- document EOF reset in task 26 notes

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaDemuxer.h src/core/src/MediaDemuxer.cpp src/core/src/MediaPlayer.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6861fcfcc5b48331b8086de07725f2bf