### PR TITLE
Implement resetEof method and update seek behavior

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -29,7 +29,7 @@
 | 23 | Frame Renderer – Android (OpenGL ES) | done | implemented in `src/android/AndroidGLVideoOutput.cpp` |
 | 24 | Frame Renderer – iOS (Metal/GL ES) | done | implemented in `src/core/src/MetalVideoOutput.mm` |
 | 25 | Video Output Integration | done | relevant |
-| 26 | Implement Play/Pause/Seek Logic | done | relevant |
+| 26 | Implement Play/Pause/Seek Logic | done | demuxer `resetEof()` after seeking |
 | 27 | Track and Playlist Management (Core) | done | relevant |
 | 28 | Playback State Notifications | done | relevant |
 | 29 | Volume and Audio Effects | done | relevant |

--- a/src/core/include/mediaplayer/MediaDemuxer.h
+++ b/src/core/include/mediaplayer/MediaDemuxer.h
@@ -24,6 +24,7 @@ public:
   int subtitleStream() const { return m_subtitleStream; }
   AVFormatContext *context() const { return m_ctx; }
   bool eof() const { return m_eof; }
+  void resetEof() { m_eof = false; }
   void setBufferSize(size_t size) { m_bufferSize = size; }
   size_t bufferSize() const { return m_bufferSize; }
 

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -315,6 +315,7 @@ void MediaPlayer::seek(double seconds) {
     return;
   int64_t ts = static_cast<int64_t>(seconds * AV_TIME_BASE);
   av_seek_frame(m_demuxer.context(), -1, ts, AVSEEK_FLAG_BACKWARD);
+  m_demuxer.resetEof();
   m_audioDecoder.flush();
   m_videoDecoder.flush();
   {


### PR DESCRIPTION
## Summary
- add a `resetEof()` helper to `MediaDemuxer`
- reset EOF state after `av_seek_frame` so demuxing resumes
- document the change in task table

## Testing
- `cmake -S . -B build` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd14111883318236d5949aa3ad51