### PR TITLE
Merge open resetEof PRs

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -29,7 +29,7 @@
 | 23 | Frame Renderer – Android (OpenGL ES) | done | implemented in `src/android/AndroidGLVideoOutput.cpp` |
 | 24 | Frame Renderer – iOS (Metal/GL ES) | done | implemented in `src/core/src/MetalVideoOutput.mm` |
 | 25 | Video Output Integration | done | relevant |
-| 26 | Implement Play/Pause/Seek Logic | done | reset EOF after seeking to resume demuxing |
+| 26 | Implement Play/Pause/Seek Logic | done | seek now calls `MediaDemuxer::resetEof` after `av_seek_frame` to resume demuxing |
 | 27 | Track and Playlist Management (Core) | done | relevant |
 | 28 | Playback State Notifications | done | relevant |
 | 29 | Volume and Audio Effects | done | relevant |

--- a/src/core/include/mediaplayer/MediaDemuxer.h
+++ b/src/core/include/mediaplayer/MediaDemuxer.h
@@ -24,7 +24,7 @@ public:
   int subtitleStream() const { return m_subtitleStream; }
   AVFormatContext *context() const { return m_ctx; }
   bool eof() const { return m_eof; }
-  void resetEof();
+  void resetEof() { m_eof = false; }
   void setBufferSize(size_t size) { m_bufferSize = size; }
   size_t bufferSize() const { return m_bufferSize; }
 

--- a/src/core/src/MediaDemuxer.cpp
+++ b/src/core/src/MediaDemuxer.cpp
@@ -77,6 +77,4 @@ bool MediaDemuxer::readPacket(AVPacket &pkt) {
   return true;
 }
 
-void MediaDemuxer::resetEof() { m_eof = false; }
-
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- inline `resetEof` in `MediaDemuxer`
- clarify EOF reset behaviour in `parallel_tasks.md`

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaDemuxer.h src/core/src/MediaDemuxer.cpp`


------
https://chatgpt.com/codex/tasks/task_e_686207a280f48331af744652b41fccf0