### PR TITLE
Fix build and network init for conversion utilities

### DIFF
--- a/src/format_conversion/src/AudioConverter.cpp
+++ b/src/format_conversion/src/AudioConverter.cpp
@@ -116,7 +116,7 @@ bool AudioConverter::convert(const std::string &inputPath, const std::string &ou
   resampled->format = encCtx->sample_fmt;
   resampled->sample_rate = encCtx->sample_rate;
   int outSamples = encCtx->frame_size > 0 ? encCtx->frame_size : 1024;
-  av_frame_set_nb_samples(resampled, outSamples);
+  resampled->nb_samples = outSamples;
   av_frame_get_buffer(resampled, 0);
 
   while (av_read_frame(inCtx, &pkt) >= 0) {

--- a/src/network/src/NetworkStream.cpp
+++ b/src/network/src/NetworkStream.cpp
@@ -1,5 +1,6 @@
 #include "mediaplayer/NetworkStream.h"
 #include <iostream>
+#include <mutex>
 
 namespace mediaplayer {
 
@@ -12,6 +13,8 @@ NetworkStream::~NetworkStream() {
 }
 
 bool NetworkStream::open(const std::string &url) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, [] { avformat_network_init(); });
   if (avformat_open_input(&m_ctx, url.c_str(), nullptr, nullptr) < 0) {
     std::cerr << "Failed to open URL: " << url << '\n';
     return false;


### PR DESCRIPTION
## Summary
- fix AudioConverter for new FFmpeg API
- initialize FFmpeg network subsystem in NetworkStream

## Testing
- `cmake --build . --target mediaplayer_conversion mediaplayer_network`

------
https://chatgpt.com/codex/tasks/task_e_6862bd875a448331a56a4aea5b02e72c