### PR TITLE
Implement conversion APIs

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(mediaplayer_core PUBLIC
     $<INSTALL_INTERFACE:include>
     ${FFMPEG_INCLUDE_DIRS}
     ${TAGLIB_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/src/library/include/mediaplayer
     $<$<PLATFORM_ID:Android>:${CMAKE_SOURCE_DIR}/src/android>
 )
 
@@ -54,6 +55,7 @@ target_link_libraries(mediaplayer_core
     PkgConfig::FFMPEG
     PkgConfig::TAGLIB
     mediaplayer_network
+    mediaplayer_conversion
     OpenGL::GL
     glfw
 )

--- a/src/core/include/mediaplayer/MediaDemuxer.h
+++ b/src/core/include/mediaplayer/MediaDemuxer.h
@@ -5,6 +5,7 @@ extern "C" {
 #include <libavformat/avformat.h>
 }
 
+#include <memory>
 #include <string>
 
 namespace mediaplayer {

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -18,6 +18,7 @@
 #include "VideoDecoder.h"
 #include "VideoFrameQueue.h"
 #include "VideoOutput.h"
+#include "mediaplayer/FormatConverter.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -61,6 +62,15 @@ public:
   const MediaMetadata &metadata() const { return m_metadata; }
   int readAudio(uint8_t *buffer, int bufferSize);
   int readVideo(uint8_t *buffer, int bufferSize);
+  void convertAudioFile(const std::string &input, const std::string &output,
+                        FormatConverter::ProgressCallback progress = {},
+                        FormatConverter::CompletionCallback done = {});
+  void convertVideoFile(const std::string &input, const std::string &output, int width = 0,
+                        int height = 0, int bitrate = 1000000,
+                        FormatConverter::ProgressCallback progress = {},
+                        FormatConverter::CompletionCallback done = {});
+  void waitForConversion();
+  bool conversionRunning() const;
 
 private:
   void demuxLoop();
@@ -95,6 +105,7 @@ private:
   MediaMetadata m_metadata;
   std::string m_hwDevice;
   bool m_autoAdvance{true};
+  FormatConverter m_converter;
 };
 
 } // namespace mediaplayer

--- a/src/core/src/BufferedReader.cpp
+++ b/src/core/src/BufferedReader.cpp
@@ -1,5 +1,6 @@
 #include "mediaplayer/BufferedReader.h"
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 
 extern "C" {

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -169,6 +169,24 @@ int MediaPlayer::readVideo(uint8_t *buffer, int bufferSize) {
   return 0;
 }
 
+void MediaPlayer::convertAudioFile(const std::string &input, const std::string &output,
+                                   FormatConverter::ProgressCallback progress,
+                                   FormatConverter::CompletionCallback done) {
+  m_converter.convertAudioAsync(input, output, std::move(progress), std::move(done));
+}
+
+void MediaPlayer::convertVideoFile(const std::string &input, const std::string &output, int width,
+                                   int height, int bitrate,
+                                   FormatConverter::ProgressCallback progress,
+                                   FormatConverter::CompletionCallback done) {
+  m_converter.convertVideoAsync(input, output, width, height, bitrate, std::move(progress),
+                                std::move(done));
+}
+
+void MediaPlayer::waitForConversion() { m_converter.wait(); }
+
+bool MediaPlayer::conversionRunning() const { return m_converter.isRunning(); }
+
 void MediaPlayer::setAudioOutput(std::unique_ptr<AudioOutput> output) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_output) {


### PR DESCRIPTION
## Summary
- expose FormatConverter through the core MediaPlayer API
- link core with conversion module and update include paths
- fix missing headers in MediaDemuxer and BufferedReader

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build . --target mediaplayer_core`
- `cmake --build . --target mediaplayer_conversion`

------
https://chatgpt.com/codex/tasks/task_e_6862c43edc608331970f9ca023771c16