### PR TITLE
Update format converter APIs and docs

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -34,9 +34,9 @@
 | 28 | Playback State Notifications | done | relevant |
 | 29 | Volume and Audio Effects | done | relevant |
 | 30 | Media Metadata Extraction | done | relevant |
-| 31 | Audio Format Conversion Utility | open | relevant |
-| 32 | Video Transcoding Utility | open | relevant |
-| 33 | Conversion Task Management | open | relevant |
+| 31 | Audio Format Conversion Utility | done | implemented in `src/format_conversion` |
+| 32 | Video Transcoding Utility | done | implemented in `src/format_conversion` |
+| 33 | Conversion Task Management | done | asynchronous `FormatConverter` |
 | 34 | Integration in UI | open | relevant |
 | 35 | Network Stream Input Support | open | relevant |
 | 36 | YouTube Integration (Optional) | open | relevant |

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -63,10 +63,11 @@ public:
   int readAudio(uint8_t *buffer, int bufferSize);
   int readVideo(uint8_t *buffer, int bufferSize);
   void convertAudioFile(const std::string &input, const std::string &output,
+                        const AudioEncodeOptions &options = {},
                         FormatConverter::ProgressCallback progress = {},
                         FormatConverter::CompletionCallback done = {});
-  void convertVideoFile(const std::string &input, const std::string &output, int width = 0,
-                        int height = 0, int bitrate = 1000000,
+  void convertVideoFile(const std::string &input, const std::string &output,
+                        const VideoEncodeOptions &options = {},
                         FormatConverter::ProgressCallback progress = {},
                         FormatConverter::CompletionCallback done = {});
   void waitForConversion();

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -170,17 +170,17 @@ int MediaPlayer::readVideo(uint8_t *buffer, int bufferSize) {
 }
 
 void MediaPlayer::convertAudioFile(const std::string &input, const std::string &output,
+                                   const AudioEncodeOptions &options,
                                    FormatConverter::ProgressCallback progress,
                                    FormatConverter::CompletionCallback done) {
-  m_converter.convertAudioAsync(input, output, std::move(progress), std::move(done));
+  m_converter.convertAudioAsync(input, output, options, std::move(progress), std::move(done));
 }
 
-void MediaPlayer::convertVideoFile(const std::string &input, const std::string &output, int width,
-                                   int height, int bitrate,
+void MediaPlayer::convertVideoFile(const std::string &input, const std::string &output,
+                                   const VideoEncodeOptions &options,
                                    FormatConverter::ProgressCallback progress,
                                    FormatConverter::CompletionCallback done) {
-  m_converter.convertVideoAsync(input, output, width, height, bitrate, std::move(progress),
-                                std::move(done));
+  m_converter.convertVideoAsync(input, output, options, std::move(progress), std::move(done));
 }
 
 void MediaPlayer::waitForConversion() { m_converter.wait(); }

--- a/src/format_conversion/README.md
+++ b/src/format_conversion/README.md
@@ -12,3 +12,27 @@ transcode between formats and optionally resize or set a target bitrate.
 `convertAudioAsync` and `convertVideoAsync` methods execute on a background
 thread and provide progress callbacks (0-1 range) and a completion callback for
 UI integration.
+
+### Example CLI Usage
+
+```
+#include "mediaplayer/FormatConverter.h"
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::cout << "usage: convert <in> <out>" << std::endl;
+        return 0;
+    }
+    mediaplayer::FormatConverter conv;
+    mediaplayer::AudioEncodeOptions opts;
+    opts.bitrate = 128000; // customize encoding settings
+    conv.convertAudioAsync(argv[1], argv[2], opts,
+        [](float p){ std::cout << "progress " << p*100 << "%\n"; },
+        [](bool ok){ std::cout << (ok ? "done" : "error") << std::endl; });
+    conv.wait();
+}
+```
+
+This converts `argv[1]` to the format specified by `argv[2]` while printing
+progress updates.

--- a/src/format_conversion/include/mediaplayer/AudioConverter.h
+++ b/src/format_conversion/include/mediaplayer/AudioConverter.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_AUDIOCONVERTER_H
 #define MEDIAPLAYER_AUDIOCONVERTER_H
 
+#include "EncodeOptions.h"
 #include <functional>
 #include <string>
 
@@ -11,7 +12,7 @@ public:
   // Convert input audio file to the format implied by outputPath extension.
   // Returns true on success.
   bool convert(const std::string &inputPath, const std::string &outputPath,
-               std::function<void(float)> progress = {});
+               const AudioEncodeOptions &options = {}, std::function<void(float)> progress = {});
 };
 
 } // namespace mediaplayer

--- a/src/format_conversion/include/mediaplayer/EncodeOptions.h
+++ b/src/format_conversion/include/mediaplayer/EncodeOptions.h
@@ -1,0 +1,23 @@
+#ifndef MEDIAPLAYER_ENCODEOPTIONS_H
+#define MEDIAPLAYER_ENCODEOPTIONS_H
+
+#include <string>
+
+namespace mediaplayer {
+
+struct AudioEncodeOptions {
+  int bitrate = 192000; // bits per second
+  int sampleRate = 0;   // 0 = keep input sample rate
+  std::string codec;    // encoder name, empty for default
+};
+
+struct VideoEncodeOptions {
+  int width = 0;         // 0 = keep input width
+  int height = 0;        // 0 = keep input height
+  int bitrate = 1000000; // bits per second
+  std::string codec;     // encoder name, empty for default
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_ENCODEOPTIONS_H

--- a/src/format_conversion/include/mediaplayer/FormatConverter.h
+++ b/src/format_conversion/include/mediaplayer/FormatConverter.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_FORMATCONVERTER_H
 
 #include "AudioConverter.h"
+#include "EncodeOptions.h"
 #include "VideoConverter.h"
 
 #include <atomic>
@@ -20,10 +21,11 @@ public:
   ~FormatConverter();
 
   void convertAudioAsync(const std::string &input, const std::string &output,
-                         ProgressCallback progress = {}, CompletionCallback done = {});
+                         const AudioEncodeOptions &options = {}, ProgressCallback progress = {},
+                         CompletionCallback done = {});
 
-  void convertVideoAsync(const std::string &input, const std::string &output, int width = 0,
-                         int height = 0, int bitrate = 1000000, ProgressCallback progress = {},
+  void convertVideoAsync(const std::string &input, const std::string &output,
+                         const VideoEncodeOptions &options = {}, ProgressCallback progress = {},
                          CompletionCallback done = {});
 
   void wait();

--- a/src/format_conversion/include/mediaplayer/VideoConverter.h
+++ b/src/format_conversion/include/mediaplayer/VideoConverter.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_VIDEOCONVERTER_H
 #define MEDIAPLAYER_VIDEOCONVERTER_H
 
+#include "EncodeOptions.h"
 #include <functional>
 #include <string>
 
@@ -10,8 +11,8 @@ class VideoConverter {
 public:
   // Convert input video to output path. If width/height are 0, keep input size.
   // Bitrate is in bits per second.
-  bool convert(const std::string &inputPath, const std::string &outputPath, int width = 0,
-               int height = 0, int bitrate = 1000000, std::function<void(float)> progress = {});
+  bool convert(const std::string &inputPath, const std::string &outputPath,
+               const VideoEncodeOptions &options = {}, std::function<void(float)> progress = {});
 };
 
 } // namespace mediaplayer

--- a/src/format_conversion/src/FormatConverter.cpp
+++ b/src/format_conversion/src/FormatConverter.cpp
@@ -9,12 +9,13 @@ FormatConverter::FormatConverter() = default;
 FormatConverter::~FormatConverter() { wait(); }
 
 void FormatConverter::convertAudioAsync(const std::string &input, const std::string &output,
+                                        const AudioEncodeOptions &options,
                                         ProgressCallback progress, CompletionCallback done) {
   wait();
   m_running = true;
   m_thread = std::thread([=]() {
     AudioConverter conv;
-    bool ok = conv.convert(input, output, progress);
+    bool ok = conv.convert(input, output, options, progress);
     if (done)
       done(ok);
     m_running = false;
@@ -22,13 +23,13 @@ void FormatConverter::convertAudioAsync(const std::string &input, const std::str
 }
 
 void FormatConverter::convertVideoAsync(const std::string &input, const std::string &output,
-                                        int width, int height, int bitrate,
+                                        const VideoEncodeOptions &options,
                                         ProgressCallback progress, CompletionCallback done) {
   wait();
   m_running = true;
   m_thread = std::thread([=]() {
     VideoConverter conv;
-    bool ok = conv.convert(input, output, width, height, bitrate, progress);
+    bool ok = conv.convert(input, output, options, progress);
     if (done)
       done(ok);
     m_running = false;

--- a/tests/format_conversion_test.cpp
+++ b/tests/format_conversion_test.cpp
@@ -41,7 +41,9 @@ int main() {
   const std::string mp3 = "test_output.mp3";
   createTestWav(wav);
   mediaplayer::AudioConverter conv;
-  bool ok = conv.convert(wav, mp3);
+  mediaplayer::AudioEncodeOptions opts;
+  opts.bitrate = 128000;
+  bool ok = conv.convert(wav, mp3, opts);
   assert(ok && "conversion failed");
   std::ifstream f(mp3, std::ios::binary);
   assert(f.good() && "output file missing");

--- a/tests/video_conversion_test.cpp
+++ b/tests/video_conversion_test.cpp
@@ -66,7 +66,11 @@ int main() {
   const std::string out = "test_out.mp4";
   createTestMp4(in);
   mediaplayer::VideoConverter conv;
-  bool ok = conv.convert(in, out, 16, 16, 500000);
+  mediaplayer::VideoEncodeOptions opts;
+  opts.width = 16;
+  opts.height = 16;
+  opts.bitrate = 500000;
+  bool ok = conv.convert(in, out, opts);
   assert(ok && "conversion failed");
   AVFormatContext *ctx = nullptr;
   assert(avformat_open_input(&ctx, out.c_str(), nullptr, nullptr) == 0);


### PR DESCRIPTION
## Summary
- document completed format conversion tasks
- add customizable encoding options for conversions
- expose new options through `MediaPlayer` API
- provide CLI example in format conversion README
- adjust tests for the updated API

## Testing
- `clang-format -i $(git ls-files '*.cpp' '*.h' | tr '\n' ' ')`
- `g++ -std=c++17 -I src/format_conversion/include -I src/core/include -c src/format_conversion/src/AudioConverter.cpp -o /tmp/a.o` *(fails: libavcodec not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c80cf0dc833196770429aa44e43a