### PR TITLE
Fix conversion module CMake

### DIFF
--- a/src/format_conversion/CMakeLists.txt
+++ b/src/format_conversion/CMakeLists.txt
@@ -1,22 +1,36 @@
-add_library(mediaplayer_conversion src / AudioConverter.cpp src / VideoConverter.cpp src /
-            FormatConverter.cpp)
+add_library(mediaplayer_conversion
+    src/AudioConverter.cpp
+    src/VideoConverter.cpp
+    src/FormatConverter.cpp
+)
 
-    find_package(PkgConfig) pkg_check_modules(
-        FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil libswresample libswscale)
+find_package(PkgConfig)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
+    libavformat
+    libavcodec
+    libavutil
+    libswresample
+    libswscale
+)
 
-        target_include_directories(
-            mediaplayer_conversion PUBLIC $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
-                $<INSTALL_INTERFACE : include>
-                    ${FFMPEG_INCLUDE_DIRS})
+target_include_directories(mediaplayer_conversion PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${FFMPEG_INCLUDE_DIRS}
+)
 
-            target_link_libraries(mediaplayer_conversion PkgConfig::FFMPEG)
+target_link_libraries(mediaplayer_conversion PkgConfig::FFMPEG)
 
-                set_target_properties(
-                    mediaplayer_conversion PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaplayer_conversion PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
 
-                    add_executable(mediaconvert src / mediaconvert.cpp)
+add_executable(mediaconvert src/mediaconvert.cpp)
 
-                        target_link_libraries(mediaconvert PRIVATE mediaplayer_conversion)
+target_link_libraries(mediaconvert PRIVATE mediaplayer_conversion)
 
-                            set_target_properties(
-                                mediaconvert PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaconvert PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)


### PR DESCRIPTION
## Summary
- clean up `src/format_conversion/CMakeLists.txt`
- define library and executable targets in the style of other modules

## Testing
- `cmake -S . -B build` *(fails: required FFmpeg packages not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e6c2ee9083319fe8b0532fa35d94