### PR TITLE
Update FormatConverter thread state

### DIFF
--- a/src/format_conversion/src/FormatConverter.cpp
+++ b/src/format_conversion/src/FormatConverter.cpp
@@ -14,12 +14,12 @@ void FormatConverter::convertAudioAsync(const std::string &input, const std::str
   wait();
   m_cancelFlag = false;
   m_running = true;
-  m_thread = std::thread([=]() {
+  m_thread = std::thread([=, this]() {
     AudioConverter conv;
-    bool ok = conv.convert(input, output, options, progress, &m_cancelFlag);
+    bool ok = conv.convert(input, output, options, progress, &this->m_cancelFlag);
     if (done)
-      done(ok && !m_cancelFlag.load());
-    m_running = false;
+      done(ok && !this->m_cancelFlag.load());
+    this->m_running = false;
   });
 }
 
@@ -29,12 +29,12 @@ void FormatConverter::convertVideoAsync(const std::string &input, const std::str
   wait();
   m_cancelFlag = false;
   m_running = true;
-  m_thread = std::thread([=]() {
+  m_thread = std::thread([=, this]() {
     VideoConverter conv;
-    bool ok = conv.convert(input, output, options, progress, &m_cancelFlag);
+    bool ok = conv.convert(input, output, options, progress, &this->m_cancelFlag);
     if (done)
-      done(ok && !m_cancelFlag.load());
-    m_running = false;
+      done(ok && !this->m_cancelFlag.load());
+    this->m_running = false;
   });
 }
 
@@ -46,6 +46,7 @@ void FormatConverter::wait() {
   if (m_thread.joinable())
     m_thread.join();
   m_cancelFlag = false;
+  m_running = false;
 }
 
 bool FormatConverter::isRunning() const { return m_running.load(); }


### PR DESCRIPTION
## Summary
- fix lambda captures to include `this`
- use `this->` when modifying state members
- reset running state in worker and wait()

## Testing
- `clang-format -i src/format_conversion/src/FormatConverter.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6862e6c521f08331be13881175781c41