### PR TITLE
Add FFmpeg protocol checker and libcurl docs

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -9,6 +9,7 @@ Ensure the following packages are installed:
 - **CMake** 3.15 or newer
 - A C++17 compatible compiler
 - **FFmpeg** development libraries
+- **libcurl** development headers (`libcurl4-openssl-dev`) so FFmpeg supports HTTP/HTTPS streaming
 - **TagLib** development headers
 - **PulseAudio** (`libpulse` and `libpulse-simple`)
 - **SQLite** development library
@@ -19,6 +20,7 @@ On Ubuntu the packages can be installed with:
 ```bash
 sudo apt-get install -y build-essential cmake git \
     libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
+    libcurl4-openssl-dev \
     libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev
 ```
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
+    src/ProtocolSupport.cpp
 )
 
 find_package(PkgConfig)
 pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat)
+pkg_check_modules(LIBCURL REQUIRED IMPORTED_TARGET libcurl)
 
 target_include_directories(mediaplayer_network PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -11,7 +13,7 @@ target_include_directories(mediaplayer_network PUBLIC
     ${FFMPEG_INCLUDE_DIRS}
 )
 
-target_link_libraries(mediaplayer_network PkgConfig::FFMPEG)
+target_link_libraries(mediaplayer_network PkgConfig::FFMPEG PkgConfig::LIBCURL)
 
 set_target_properties(mediaplayer_network PROPERTIES
     CXX_STANDARD 17

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -11,3 +11,12 @@ if (stream.open("https://example.com/video.mp4")) {
   // pass ctx to MediaPlayer or custom processing
 }
 ```
+
+The helper function `protocolAvailable` can be used to verify that a protocol
+such as `"http"` or `"rtmp"` is supported by the FFmpeg build:
+
+```cpp
+if (mediaplayer::protocolAvailable("http")) {
+  // safe to open HTTP URLs
+}
+```

--- a/src/network/include/mediaplayer/ProtocolSupport.h
+++ b/src/network/include/mediaplayer/ProtocolSupport.h
@@ -1,0 +1,12 @@
+#ifndef MEDIAPLAYER_PROTOCOLSUPPORT_H
+#define MEDIAPLAYER_PROTOCOLSUPPORT_H
+
+#include <string>
+
+namespace mediaplayer {
+
+bool protocolAvailable(const std::string &name);
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_PROTOCOLSUPPORT_H

--- a/src/network/src/ProtocolSupport.cpp
+++ b/src/network/src/ProtocolSupport.cpp
@@ -1,0 +1,19 @@
+#include "mediaplayer/ProtocolSupport.h"
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+namespace mediaplayer {
+
+bool protocolAvailable(const std::string &name) {
+  void *opaque = nullptr;
+  const char *protocol = nullptr;
+  while ((protocol = avio_enum_protocols(&opaque, 0))) {
+    if (name == protocol)
+      return true;
+  }
+  return false;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- note installing libcurl4-openssl-dev for FFmpeg streaming
- link libcurl to the network module
- add `ProtocolSupport` helper to query available protocols
- show how to use `protocolAvailable` in README

## Testing
- `clang-format -i src/network/include/mediaplayer/ProtocolSupport.h src/network/src/ProtocolSupport.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686309b67b5483319682a6865d8f085a