### PR TITLE
Add YouTube stream resolver

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
+    src/YouTubeResolver.cpp
 )
 
 find_package(PkgConfig)
 pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat)
+find_package(Python3 COMPONENTS Interpreter)
 
 target_include_directories(mediaplayer_network PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -13,7 +15,15 @@ target_include_directories(mediaplayer_network PUBLIC
 
 target_link_libraries(mediaplayer_network PkgConfig::FFMPEG)
 
+if(Python3_FOUND)
+    target_compile_definitions(mediaplayer_network PRIVATE
+        YOUTUBE_RESOLVER_SCRIPT="${CMAKE_INSTALL_FULL_BINDIR}/youtube_resolver.py")
+endif()
+
 set_target_properties(mediaplayer_network PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
+
+install(TARGETS mediaplayer_network DESTINATION lib)
+install(PROGRAMS ../tools/youtube_resolver.py DESTINATION bin)

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -11,3 +11,16 @@ if (stream.open("https://example.com/video.mp4")) {
   // pass ctx to MediaPlayer or custom processing
 }
 ```
+
+To resolve a YouTube link before opening it with `NetworkStream`, use the
+`YouTubeResolver` helper which internally runs `youtube-dl`:
+
+```cpp
+mediaplayer::YouTubeResolver yt;
+std::string direct = yt.resolve("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+
+mediaplayer::NetworkStream stream;
+if (stream.open(direct)) {
+  // pass stream.context() to the player
+}
+```

--- a/src/network/include/mediaplayer/YouTubeResolver.h
+++ b/src/network/include/mediaplayer/YouTubeResolver.h
@@ -1,0 +1,16 @@
+#ifndef MEDIAPLAYER_YOUTUBERESOLVER_H
+#define MEDIAPLAYER_YOUTUBERESOLVER_H
+
+#include <string>
+
+namespace mediaplayer {
+
+class YouTubeResolver {
+public:
+  // Resolve a YouTube link to a direct media stream URL using youtube-dl.
+  std::string resolve(const std::string &url) const;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_YOUTUBERESOLVER_H

--- a/src/network/src/YouTubeResolver.cpp
+++ b/src/network/src/YouTubeResolver.cpp
@@ -1,0 +1,33 @@
+#include "mediaplayer/YouTubeResolver.h"
+
+#include <array>
+#include <cstdio>
+#include <string>
+
+#ifndef YOUTUBE_RESOLVER_SCRIPT
+#define YOUTUBE_RESOLVER_SCRIPT "youtube_resolver.py"
+#endif
+
+namespace mediaplayer {
+
+static std::string runCommand(const std::string &cmd) {
+  std::array<char, 256> buf{};
+  std::string result;
+  FILE *pipe = popen(cmd.c_str(), "r");
+  if (!pipe)
+    return result;
+  while (fgets(buf.data(), static_cast<int>(buf.size()), pipe)) {
+    result += buf.data();
+  }
+  pclose(pipe);
+  if (!result.empty() && result.back() == '\n')
+    result.pop_back();
+  return result;
+}
+
+std::string YouTubeResolver::resolve(const std::string &url) const {
+  std::string cmd = "python3 \"" YOUTUBE_RESOLVER_SCRIPT "\" \"" + url + "\"";
+  return runCommand(cmd);
+}
+
+} // namespace mediaplayer

--- a/src/tools/youtube_resolver.py
+++ b/src/tools/youtube_resolver.py
@@ -1,0 +1,31 @@
+import sys
+from youtube_dl import YoutubeDL
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: youtube_resolver.py <youtube_url>", file=sys.stderr)
+        return 1
+    url = sys.argv[1]
+    opts = {
+        'quiet': True,
+        'no_warnings': True,
+        'skip_download': True,
+        'format': 'best'
+    }
+    try:
+        with YoutubeDL(opts) as ydl:
+            info = ydl.extract_info(url, download=False)
+            stream_url = info.get('url')
+            if not stream_url:
+                formats = info.get('formats') or []
+                if formats:
+                    stream_url = formats[0].get('url')
+            if stream_url:
+                print(stream_url)
+                return 0
+    except Exception as e:
+        print(f"Error resolving YouTube URL: {e}", file=sys.stderr)
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- implement Python helper to resolve YouTube links
- wrap resolver in `YouTubeResolver` C++ class
- update network build scripts to expose the helper
- document usage in the network README

## Testing
- `clang-format -i src/network/include/mediaplayer/YouTubeResolver.h src/network/src/YouTubeResolver.cpp`
- `cmake ..` *(fails: Package 'libavformat', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_686309b1358883318f96a7f05c40edbd