### PR TITLE
Implement HlsStream and DashStream

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
+    src/HlsStream.cpp
+    src/DashStream.cpp
 )
 
 find_package(PkgConfig)

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -11,3 +11,16 @@ if (stream.open("https://example.com/video.mp4")) {
   // pass ctx to MediaPlayer or custom processing
 }
 ```
+
+`HlsStream` and `DashStream` handle adaptive streaming playlists:
+
+```cpp
+mediaplayer::HlsStream hls;
+if (hls.open("https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8")) {
+  AVFormatContext *ctx = hls.context();
+  // use the context
+}
+
+mediaplayer::DashStream dash;
+dash.open("https://example.com/manifest.mpd", /*variant index*/ 0);
+```

--- a/src/network/include/mediaplayer/DashStream.h
+++ b/src/network/include/mediaplayer/DashStream.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_DASHSTREAM_H
+#define MEDIAPLAYER_DASHSTREAM_H
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <string>
+
+namespace mediaplayer {
+
+class DashStream {
+public:
+  DashStream();
+  ~DashStream();
+
+  bool open(const std::string &url, int variantIndex = -1, int bandwidth = 0);
+  AVFormatContext *context() const { return m_ctx; }
+  AVFormatContext *release();
+
+private:
+  AVFormatContext *m_ctx{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_DASHSTREAM_H

--- a/src/network/include/mediaplayer/HlsStream.h
+++ b/src/network/include/mediaplayer/HlsStream.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_HLSSTREAM_H
+#define MEDIAPLAYER_HLSSTREAM_H
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <string>
+
+namespace mediaplayer {
+
+class HlsStream {
+public:
+  HlsStream();
+  ~HlsStream();
+
+  bool open(const std::string &url, int variantIndex = -1, int bandwidth = 0);
+  AVFormatContext *context() const { return m_ctx; }
+  AVFormatContext *release();
+
+private:
+  AVFormatContext *m_ctx{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_HLSSTREAM_H

--- a/src/network/src/DashStream.cpp
+++ b/src/network/src/DashStream.cpp
@@ -1,0 +1,41 @@
+#include "mediaplayer/DashStream.h"
+#include <iostream>
+#include <mutex>
+
+namespace mediaplayer {
+
+DashStream::DashStream() = default;
+
+DashStream::~DashStream() {
+  if (m_ctx) {
+    avformat_close_input(&m_ctx);
+  }
+}
+
+bool DashStream::open(const std::string &url, int variantIndex, int bandwidth) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, [] { avformat_network_init(); });
+
+  AVDictionary *opts = nullptr;
+  if (variantIndex >= 0)
+    av_dict_set_int(&opts, "program", variantIndex, 0);
+  if (bandwidth > 0)
+    av_dict_set_int(&opts, "variant_bitrate", bandwidth, 0);
+
+  if (avformat_open_input(&m_ctx, url.c_str(), nullptr, &opts) < 0) {
+    std::cerr << "Failed to open DASH URL: " << url << '\n';
+    av_dict_free(&opts);
+    return false;
+  }
+
+  av_dict_free(&opts);
+  return true;
+}
+
+AVFormatContext *DashStream::release() {
+  AVFormatContext *ctx = m_ctx;
+  m_ctx = nullptr;
+  return ctx;
+}
+
+} // namespace mediaplayer

--- a/src/network/src/HlsStream.cpp
+++ b/src/network/src/HlsStream.cpp
@@ -1,0 +1,41 @@
+#include "mediaplayer/HlsStream.h"
+#include <iostream>
+#include <mutex>
+
+namespace mediaplayer {
+
+HlsStream::HlsStream() = default;
+
+HlsStream::~HlsStream() {
+  if (m_ctx) {
+    avformat_close_input(&m_ctx);
+  }
+}
+
+bool HlsStream::open(const std::string &url, int variantIndex, int bandwidth) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, [] { avformat_network_init(); });
+
+  AVDictionary *opts = nullptr;
+  if (variantIndex >= 0)
+    av_dict_set_int(&opts, "program", variantIndex, 0);
+  if (bandwidth > 0)
+    av_dict_set_int(&opts, "variant_bitrate", bandwidth, 0);
+
+  if (avformat_open_input(&m_ctx, url.c_str(), nullptr, &opts) < 0) {
+    std::cerr << "Failed to open HLS URL: " << url << '\n';
+    av_dict_free(&opts);
+    return false;
+  }
+
+  av_dict_free(&opts);
+  return true;
+}
+
+AVFormatContext *HlsStream::release() {
+  AVFormatContext *ctx = m_ctx;
+  m_ctx = nullptr;
+  return ctx;
+}
+
+} // namespace mediaplayer

--- a/tests/hls_stream_test.cpp
+++ b/tests/hls_stream_test.cpp
@@ -1,0 +1,11 @@
+#include "mediaplayer/HlsStream.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+  mediaplayer::HlsStream stream;
+  assert(stream.open("https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"));
+  assert(stream.context() != nullptr);
+  std::cout << "HlsStream test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add new `HlsStream` and `DashStream` classes for adaptive playlists
- compile new sources in network CMake
- document how to open HLS/DASH URLs
- add basic test opening an HLS playlist

## Testing
- `clang-format -i src/network/include/mediaplayer/HlsStream.h src/network/include/mediaplayer/DashStream.h src/network/src/HlsStream.cpp src/network/src/DashStream.cpp tests/hls_stream_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686309b280848331b28784b51477ab83