### PR TITLE
Add YoutubeResolver helper

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
+    src/YoutubeResolver.cpp
 )
 
 find_package(PkgConfig)

--- a/src/network/include/mediaplayer/YoutubeResolver.h
+++ b/src/network/include/mediaplayer/YoutubeResolver.h
@@ -1,0 +1,16 @@
+#ifndef MEDIAPLAYER_YOUTUBERESOLVER_H
+#define MEDIAPLAYER_YOUTUBERESOLVER_H
+
+#include <string>
+
+namespace mediaplayer {
+
+class YoutubeResolver {
+public:
+  // Resolve a YouTube URL to a direct stream URL using the helper script.
+  static std::string resolve(const std::string &ytUrl);
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_YOUTUBERESOLVER_H

--- a/src/network/src/YoutubeResolver.cpp
+++ b/src/network/src/YoutubeResolver.cpp
@@ -1,0 +1,34 @@
+#include "mediaplayer/YoutubeResolver.h"
+
+#include <cstdio>
+#include <iostream>
+#include <memory>
+
+namespace mediaplayer {
+
+static std::string readPipe(FILE *pipe) {
+  std::string result;
+  char buffer[256];
+  while (fgets(buffer, sizeof(buffer), pipe)) {
+    result += buffer;
+  }
+  return result;
+}
+
+std::string YoutubeResolver::resolve(const std::string &ytUrl) {
+  std::string cmd = "python3 scripts/youtube_resolve.py \"" + ytUrl + "\"";
+  FILE *pipe = popen(cmd.c_str(), "r");
+  if (!pipe) {
+    std::cerr << "Failed to run youtube resolver script\n";
+    return {};
+  }
+  std::string output = readPipe(pipe);
+  pclose(pipe);
+  // trim newline characters
+  while (!output.empty() && (output.back() == '\n' || output.back() == '\r')) {
+    output.pop_back();
+  }
+  return output;
+}
+
+} // namespace mediaplayer

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -10,3 +10,17 @@ mediaconvert <audio|video> <input> <output> [options]
 Options include bitrate, codec and, for video, the width/height or `--crf` value
 to control quality. Conversion progress is printed to the console.
 
+## Playing a YouTube URL
+
+`YoutubeResolver` uses a small Python helper to turn YouTube links into direct
+stream URLs. The resolved URL can then be passed to `NetworkStream`:
+
+```cpp
+std::string direct = mediaplayer::YoutubeResolver::resolve(
+    "https://www.youtube.com/watch?v=VIDEO_ID");
+mediaplayer::NetworkStream stream;
+if (stream.open(direct)) {
+  // pass stream.context() to your player
+}
+```
+


### PR DESCRIPTION
## Summary
- add `YoutubeResolver` helper class
- update network library build to compile YoutubeResolver
- document example usage for passing YouTube URLs

## Testing
- `clang-format -n src/network/include/mediaplayer/YoutubeResolver.h src/network/src/YoutubeResolver.cpp >/tmp/format.log && cat /tmp/format.log`

------
https://chatgpt.com/codex/tasks/task_e_68630997a5c483318f127b506a18b6db