### PR TITLE
Add network stream test and optional libcurl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,15 @@ add_subdirectory(src/desktop)
 # Optionally add other modules later
 
 add_subdirectory(src/tools)
+
+option(BUILD_TESTS "Build test programs" OFF)
+
+if(BUILD_TESTS)
+    add_executable(network_stream_test tests/network_stream_test.cpp)
+    target_link_libraries(network_stream_test
+        mediaplayer_network
+        PkgConfig::FFMPEG)
+    if(TARGET PkgConfig::LIBCURL)
+        target_link_libraries(network_stream_test PkgConfig::LIBCURL)
+    endif()
+endif()

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -4,12 +4,18 @@ add_library(mediaplayer_network
 
 find_package(PkgConfig)
 pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat)
+pkg_check_modules(LIBCURL IMPORTED_TARGET libcurl)
 
 target_include_directories(mediaplayer_network PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${FFMPEG_INCLUDE_DIRS}
 )
+
+if(LIBCURL_FOUND)
+    target_include_directories(mediaplayer_network PUBLIC ${LIBCURL_INCLUDE_DIRS})
+    target_link_libraries(mediaplayer_network PkgConfig::LIBCURL)
+endif()
 
 target_link_libraries(mediaplayer_network PkgConfig::FFMPEG)
 

--- a/tests/network_stream_test.cpp
+++ b/tests/network_stream_test.cpp
@@ -1,0 +1,9 @@
+#include "mediaplayer/NetworkStream.h"
+#include <cassert>
+
+int main() {
+  mediaplayer::NetworkStream stream;
+  assert(stream.open("http://example.com/sample.mp4") && "open failed");
+  assert(stream.context() != nullptr && "context null");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- optionally link libcurl in the network module
- create `network_stream_test.cpp`
- build this test when `BUILD_TESTS` is enabled

## Testing
- `clang-format -i tests/network_stream_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686309942af88331b0609e87c0e18da1