### PR TITLE
Add libcurl build dependency

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -4,6 +4,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         build-essential cmake git \
         libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
+        libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docs/building.md
+++ b/docs/building.md
@@ -9,6 +9,7 @@ Ensure the following packages are installed:
 - **CMake** 3.15 or newer
 - A C++17 compatible compiler
 - **FFmpeg** development libraries
+- **libcurl** development headers (e.g., `libcurl4-openssl-dev`)
 - **TagLib** development headers
 - **PulseAudio** (`libpulse` and `libpulse-simple`)
 - **SQLite** development library
@@ -19,7 +20,8 @@ On Ubuntu the packages can be installed with:
 ```bash
 sudo apt-get install -y build-essential cmake git \
     libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
-    libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev
+    libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev \
+    libcurl4-openssl-dev
 ```
 
 ## Audio Output Backends


### PR DESCRIPTION
## Summary
- install `libcurl4-openssl-dev` in Dockerfile.core
- document libcurl requirement in docs/building.md

## Testing
- `docker build -t mediaplayer_test -f Dockerfile.core .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630990fda48331a1b34fb283935585