### PR TITLE
Integrate streaming features

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,19 +1,26 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
     src/ProtocolSupport.cpp
+    src/HlsStream.cpp
+    src/DashStream.cpp
+    src/InternetRadioStream.cpp
 )
 
 find_package(PkgConfig)
 pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat)
-pkg_check_modules(LIBCURL REQUIRED IMPORTED_TARGET libcurl)
+find_package(CURL REQUIRED)
 
 target_include_directories(mediaplayer_network PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${FFMPEG_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
 )
 
-target_link_libraries(mediaplayer_network PkgConfig::FFMPEG PkgConfig::LIBCURL)
+target_link_libraries(mediaplayer_network
+    PkgConfig::FFMPEG
+    CURL::libcurl
+)
 
 set_target_properties(mediaplayer_network PROPERTIES
     CXX_STANDARD 17

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -4,6 +4,10 @@ This module contains basic networking helpers.
 
 The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs.
 
+`DashStream` builds on top of this to handle simple MPEG‑DASH manifests. It
+downloads the MPD file, picks the first audio and video representations and then
+opens the stream with FFmpeg's dash demuxer.
+
 ```cpp
 mediaplayer::NetworkStream stream;
 if (stream.open("https://example.com/video.mp4")) {
@@ -19,4 +23,38 @@ such as `"http"` or `"rtmp"` is supported by the FFmpeg build:
 if (mediaplayer::protocolAvailable("http")) {
   // safe to open HTTP URLs
 }
+```
+
+The `HlsStream` helper selects the highest quality variant from an HLS playlist.
+
+```cpp
+mediaplayer::HlsStream hls;
+if (hls.open("https://example.com/live/stream.m3u8")) {
+  AVFormatContext *ctx = hls.context();
+  // use ctx for playback
+}
+```
+
+Using `DashStream`:
+
+```cpp
+mediaplayer::DashStream dash;
+if (dash.open("https://example.com/manifest.mpd")) {
+  AVFormatContext *ctx = dash.context();
+  // ctx contains the selected audio and video streams
+}
+```
+
+## InternetRadioStream
+
+`InternetRadioStream` uses libcurl to read ICY metadata from internet radio
+streams. When a `StreamTitle` change is detected, the provided callback is
+invoked with the new title.
+
+```cpp
+mediaplayer::InternetRadioStream radio;
+radio.setMetadataCallback([](const std::string &title) {
+  std::cout << "Now playing: " << title << std::endl;
+});
+radio.open("http://example.com/stream");
 ```

--- a/src/network/include/mediaplayer/DashStream.h
+++ b/src/network/include/mediaplayer/DashStream.h
@@ -1,0 +1,35 @@
+#ifndef MEDIAPLAYER_DASHSTREAM_H
+#define MEDIAPLAYER_DASHSTREAM_H
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <string>
+
+namespace mediaplayer {
+
+class DashStream {
+public:
+  DashStream();
+  ~DashStream();
+
+  bool open(const std::string &mpdUrl);
+  AVFormatContext *context() const { return m_ctx; }
+  AVFormatContext *release();
+
+  const std::string &videoRepresentation() const { return m_videoRep; }
+  const std::string &audioRepresentation() const { return m_audioRep; }
+
+private:
+  bool parseManifest(const std::string &manifest);
+  bool downloadFile(const std::string &url, std::string &data);
+
+  AVFormatContext *m_ctx{nullptr};
+  std::string m_videoRep;
+  std::string m_audioRep;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_DASHSTREAM_H

--- a/src/network/include/mediaplayer/HlsStream.h
+++ b/src/network/include/mediaplayer/HlsStream.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_HLSSTREAM_H
+#define MEDIAPLAYER_HLSSTREAM_H
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <string>
+
+namespace mediaplayer {
+
+class HlsStream {
+public:
+  HlsStream();
+  ~HlsStream();
+
+  bool open(const std::string &playlistUrl);
+  AVFormatContext *context() const { return m_ctx; }
+  AVFormatContext *release();
+
+private:
+  AVFormatContext *m_ctx{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_HLSSTREAM_H

--- a/src/network/include/mediaplayer/InternetRadioStream.h
+++ b/src/network/include/mediaplayer/InternetRadioStream.h
@@ -1,0 +1,41 @@
+#ifndef MEDIAPLAYER_INTERNETRADIOSTREAM_H
+#define MEDIAPLAYER_INTERNETRADIOSTREAM_H
+
+#include <functional>
+#include <string>
+#include <thread>
+
+#include <curl/curl.h>
+
+namespace mediaplayer {
+
+class InternetRadioStream {
+public:
+  InternetRadioStream();
+  ~InternetRadioStream();
+
+  bool open(const std::string &url);
+  void close();
+
+  using MetadataCallback = std::function<void(const std::string &)>;
+  void setMetadataCallback(MetadataCallback cb);
+
+private:
+  static size_t writeCallback(char *ptr, size_t size, size_t nmemb, void *userdata);
+  static size_t headerCallback(char *buffer, size_t size, size_t nitems, void *userdata);
+  void readLoop();
+  void parseMetadata(const std::string &data);
+
+private:
+  CURL *m_curl{nullptr};
+  std::thread m_thread;
+  bool m_stop{false};
+  long m_metaInt{0};
+  long m_bytesUntilMeta{0};
+  std::string m_partialMetadata;
+  MetadataCallback m_callback;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_INTERNETRADIOSTREAM_H

--- a/src/network/src/DashStream.cpp
+++ b/src/network/src/DashStream.cpp
@@ -1,0 +1,97 @@
+#include "mediaplayer/DashStream.h"
+#include <iostream>
+#include <mutex>
+#include <regex>
+
+namespace mediaplayer {
+
+DashStream::DashStream() = default;
+
+DashStream::~DashStream() {
+  if (m_ctx) {
+    avformat_close_input(&m_ctx);
+  }
+}
+
+static std::string extractBaseURL(const std::string &section) {
+  const std::regex baseRegex("<BaseURL>([^<]+)</BaseURL>", std::regex_constants::icase);
+  std::smatch match;
+  if (std::regex_search(section, match, baseRegex)) {
+    return match[1];
+  }
+  return {};
+}
+
+bool DashStream::parseManifest(const std::string &manifest) {
+  std::regex adaptRegex("<AdaptationSet[^>]+>", std::regex_constants::icase);
+  std::regex videoRegex("contentType=\"video\"|mimeType=\"video", std::regex_constants::icase);
+  std::regex audioRegex("contentType=\"audio\"|mimeType=\"audio", std::regex_constants::icase);
+  auto begin = std::sregex_iterator(manifest.begin(), manifest.end(), adaptRegex);
+  auto end = std::sregex_iterator();
+  size_t pos = 0;
+  for (auto it = begin; it != end; ++it) {
+    const auto &match = *it;
+    size_t start = match.position(0) + match.length(0);
+    size_t close = manifest.find("</AdaptationSet>", start);
+    if (close == std::string::npos)
+      continue;
+    std::string block = manifest.substr(start, close - start);
+    bool isVideo = std::regex_search(match.str(0), videoRegex);
+    bool isAudio = std::regex_search(match.str(0), audioRegex);
+    std::regex repRegex("<Representation[^>]*>", std::regex_constants::icase);
+    std::smatch repMatch;
+    if (std::regex_search(block, repMatch, repRegex)) {
+      std::string repBlock = block.substr(repMatch.position(0) + repMatch.length(0));
+      std::string url = extractBaseURL(repBlock);
+      if (isVideo && m_videoRep.empty()) {
+        m_videoRep = url;
+      } else if (isAudio && m_audioRep.empty()) {
+        m_audioRep = url;
+      }
+    }
+    if (!m_videoRep.empty() && !m_audioRep.empty())
+      break;
+    pos = close + 1;
+  }
+  return !m_videoRep.empty() || !m_audioRep.empty();
+}
+
+bool DashStream::downloadFile(const std::string &url, std::string &data) {
+  AVIOContext *ioCtx = nullptr;
+  if (avio_open2(&ioCtx, url.c_str(), AVIO_FLAG_READ, nullptr, nullptr) < 0) {
+    std::cerr << "Failed to download: " << url << '\n';
+    return false;
+  }
+  unsigned char buf[4096];
+  while (true) {
+    int ret = avio_read(ioCtx, buf, sizeof(buf));
+    if (ret <= 0)
+      break;
+    data.append(reinterpret_cast<char *>(buf), ret);
+  }
+  avio_close(ioCtx);
+  return true;
+}
+
+bool DashStream::open(const std::string &mpdUrl) {
+  static std::once_flag initFlag;
+  std::call_once(initFlag, [] { avformat_network_init(); });
+
+  std::string manifest;
+  if (!downloadFile(mpdUrl, manifest))
+    return false;
+  parseManifest(manifest);
+  if (avformat_open_input(&m_ctx, mpdUrl.c_str(), nullptr, nullptr) < 0) {
+    std::cerr << "Failed to open DASH stream: " << mpdUrl << '\n';
+    return false;
+  }
+  return true;
+}
+
+AVFormatContext *DashStream::release() {
+  AVFormatContext *ctx = m_ctx;
+  m_ctx = nullptr;
+  return ctx;
+}
+
+} // namespace mediaplayer

--- a/src/network/src/HlsStream.cpp
+++ b/src/network/src/HlsStream.cpp
@@ -1,0 +1,94 @@
+#include "mediaplayer/HlsStream.h"
+#include <algorithm>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <libavformat/avio.h>
+}
+
+namespace mediaplayer {
+
+HlsStream::HlsStream() = default;
+
+HlsStream::~HlsStream() {
+  if (m_ctx) {
+    avformat_close_input(&m_ctx);
+  }
+}
+
+static std::string resolveUrl(const std::string &base, const std::string &rel) {
+  if (rel.rfind("http://", 0) == 0 || rel.rfind("https://", 0) == 0)
+    return rel;
+  auto pos = base.find_last_of('/');
+  if (pos == std::string::npos)
+    return rel;
+  return base.substr(0, pos + 1) + rel;
+}
+
+bool HlsStream::open(const std::string &playlistUrl) {
+  if (m_ctx) {
+    avformat_close_input(&m_ctx);
+  }
+  static std::once_flag initFlag;
+  std::call_once(initFlag, [] { avformat_network_init(); });
+
+  AVIOContext *pb = nullptr;
+  if (avio_open2(&pb, playlistUrl.c_str(), AVIO_FLAG_READ, nullptr, nullptr) < 0) {
+    std::cerr << "Failed to open playlist: " << playlistUrl << '\n';
+    return false;
+  }
+  std::vector<char> buf(4096);
+  std::string data;
+  for (;;) {
+    int r = avio_read(pb, reinterpret_cast<unsigned char *>(buf.data()), buf.size());
+    if (r < 0) {
+      avio_closep(&pb);
+      return false;
+    }
+    if (r == 0)
+      break;
+    data.append(buf.data(), r);
+  }
+  avio_closep(&pb);
+
+  std::istringstream iss(data);
+  std::string line;
+  int bestBw = -1;
+  std::string bestUrl;
+  while (std::getline(iss, line)) {
+    if (line.rfind("#EXT-X-STREAM-INF", 0) == 0) {
+      size_t bwPos = line.find("BANDWIDTH=");
+      if (bwPos != std::string::npos) {
+        bwPos += 10; // length of "BANDWIDTH="
+        size_t end = line.find(',', bwPos);
+        int bw = std::stoi(line.substr(bwPos, end - bwPos));
+        std::string next;
+        if (std::getline(iss, next)) {
+          if (bw > bestBw) {
+            bestBw = bw;
+            bestUrl = resolveUrl(playlistUrl, next);
+          }
+        }
+      }
+    }
+  }
+
+  std::string finalUrl = bestUrl.empty() ? playlistUrl : bestUrl;
+  if (avformat_open_input(&m_ctx, finalUrl.c_str(), nullptr, nullptr) < 0) {
+    std::cerr << "Failed to open stream: " << finalUrl << '\n';
+    return false;
+  }
+  return true;
+}
+
+AVFormatContext *HlsStream::release() {
+  AVFormatContext *ctx = m_ctx;
+  m_ctx = nullptr;
+  return ctx;
+}
+
+} // namespace mediaplayer

--- a/src/network/src/InternetRadioStream.cpp
+++ b/src/network/src/InternetRadioStream.cpp
@@ -1,0 +1,133 @@
+#include "mediaplayer/InternetRadioStream.h"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+
+namespace mediaplayer {
+
+InternetRadioStream::InternetRadioStream() = default;
+
+InternetRadioStream::~InternetRadioStream() { close(); }
+
+void InternetRadioStream::setMetadataCallback(MetadataCallback cb) { m_callback = std::move(cb); }
+
+bool InternetRadioStream::open(const std::string &url) {
+  m_curl = curl_easy_init();
+  if (!m_curl)
+    return false;
+
+  curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, &InternetRadioStream::writeCallback);
+  curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, this);
+  curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, &InternetRadioStream::headerCallback);
+  curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, this);
+  curl_easy_setopt(m_curl, CURLOPT_USERAGENT, "MediaPlayer/1.0");
+  curl_easy_setopt(m_curl, CURLOPT_BUFFERSIZE, 4096L);
+  curl_easy_setopt(m_curl, CURLOPT_NOPROGRESS, 1L);
+
+  m_stop = false;
+  m_metaInt = 0;
+  m_bytesUntilMeta = 0;
+
+  m_thread = std::thread(&InternetRadioStream::readLoop, this);
+  return true;
+}
+
+void InternetRadioStream::close() {
+  if (!m_curl)
+    return;
+  m_stop = true;
+  if (m_thread.joinable())
+    m_thread.join();
+  curl_easy_cleanup(m_curl);
+  m_curl = nullptr;
+}
+
+size_t InternetRadioStream::headerCallback(char *buffer, size_t size, size_t nitems,
+                                           void *userdata) {
+  InternetRadioStream *self = static_cast<InternetRadioStream *>(userdata);
+  size_t total = size * nitems;
+  std::string header(buffer, total);
+  const std::string key = "icy-metaint:";
+  auto it = std::search(header.begin(), header.end(), key.begin(), key.end(),
+                        [](char a, char b) { return std::tolower(a) == std::tolower(b); });
+  if (it != header.end()) {
+    long value = std::strtol(header.c_str() + (it - header.begin()) + key.size(), nullptr, 10);
+    if (value > 0) {
+      self->m_metaInt = value;
+      self->m_bytesUntilMeta = value;
+    }
+  }
+  return total;
+}
+
+size_t InternetRadioStream::writeCallback(char *ptr, size_t size, size_t nmemb, void *userdata) {
+  InternetRadioStream *self = static_cast<InternetRadioStream *>(userdata);
+  size_t total = size * nmemb;
+  size_t offset = 0;
+
+  while (offset < total) {
+    if (self->m_metaInt > 0 && self->m_bytesUntilMeta == 0) {
+      unsigned char metaLen = ptr[offset++];
+      size_t toRead = static_cast<size_t>(metaLen) * 16;
+      size_t available = std::min(toRead, total - offset);
+      self->m_partialMetadata.append(ptr + offset, available);
+      offset += available;
+      toRead -= available;
+      if (toRead == 0) {
+        self->parseMetadata(self->m_partialMetadata);
+        self->m_partialMetadata.clear();
+        self->m_bytesUntilMeta = self->m_metaInt;
+      } else {
+        self->m_bytesUntilMeta = -static_cast<long>(toRead);
+      }
+    } else if (self->m_metaInt > 0) {
+      size_t consume = std::min(static_cast<size_t>(self->m_bytesUntilMeta), total - offset);
+      offset += consume;
+      self->m_bytesUntilMeta -= consume;
+    } else {
+      offset = total;
+    }
+
+    if (self->m_bytesUntilMeta < 0) {
+      long needed = -self->m_bytesUntilMeta;
+      size_t available = std::min(static_cast<size_t>(needed), total - offset);
+      self->m_partialMetadata.append(ptr + offset, available);
+      offset += available;
+      needed -= available;
+      if (needed == 0) {
+        self->parseMetadata(self->m_partialMetadata);
+        self->m_partialMetadata.clear();
+        self->m_bytesUntilMeta = self->m_metaInt;
+      } else {
+        self->m_bytesUntilMeta = -needed;
+      }
+    }
+  }
+  return total;
+}
+
+void InternetRadioStream::parseMetadata(const std::string &data) {
+  auto pos = data.find("StreamTitle='");
+  if (pos == std::string::npos)
+    return;
+  pos += 13; // length of "StreamTitle='"
+  auto end = data.find("';", pos);
+  if (end == std::string::npos)
+    end = data.find('\'', pos);
+  if (end == std::string::npos)
+    return;
+  std::string title = data.substr(pos, end - pos);
+  if (m_callback)
+    m_callback(title);
+}
+
+void InternetRadioStream::readLoop() {
+  CURLcode res = curl_easy_perform(m_curl);
+  if (res != CURLE_OK) {
+    std::cerr << "CURL error: " << curl_easy_strerror(res) << '\n';
+  }
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- incorporate features from HlsStream, DashStream and InternetRadioStream PRs
- update network module build settings for libcurl
- document usage of the new streaming classes

## Testing
- `clang-format -i src/network/include/mediaplayer/HlsStream.h src/network/include/mediaplayer/DashStream.h src/network/include/mediaplayer/InternetRadioStream.h src/network/src/HlsStream.cpp src/network/src/DashStream.cpp src/network/src/InternetRadioStream.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68630da101e083318a76fbb881b89523