### PR TITLE
Implement network streaming and YouTube helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ Run the resulting `mediaplayer` executable with a media file:
 
 The graphical interface allows you to open files and manage your library as features are implemented.
 
+### Streaming URLs
+
+`MediaPlayer` can open network streams such as HTTP(S) or HLS playlists directly:
+
+```
+./mediaplayer https://example.com/stream.m3u8
+```
+
+Internet radio streams expose ICY metadata when available. To play a YouTube
+link, first resolve it using the optional helper:
+
+```
+mediaplayer::NetworkStream stream;
+auto url = mediaplayer::fetchYouTubeStream("https://youtu.be/VIDEO_ID");
+if (url)
+  stream.open(*url);
+```
+
 ## Contributing
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.

--- a/docs/building.md
+++ b/docs/building.md
@@ -19,7 +19,14 @@ On Ubuntu the packages can be installed with:
 ```bash
 sudo apt-get install -y build-essential cmake git \
     libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
-    libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev
+    libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev \
+    libcurl4-openssl-dev
+```
+
+To enable optional YouTube playback support install `youtube_dl`:
+
+```bash
+pip install --user youtube_dl
 ```
 
 ## Audio Output Backends

--- a/src/core/include/mediaplayer/MediaMetadata.h
+++ b/src/core/include/mediaplayer/MediaMetadata.h
@@ -10,6 +10,8 @@ struct MediaMetadata {
   std::string title;    // Title (from tags or file name)
   std::string artist;   // Artist if available
   std::string album;    // Album if available
+  std::string icyName;  // Station name for internet radio
+  std::string icyTitle; // Current song title from ICY metadata
   double duration{0.0}; // In seconds
   int width{0};         // Video width, 0 for audio-only
   int height{0};        // Video height

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -116,6 +116,12 @@ bool MediaPlayer::open(const std::string &path) {
   tag = av_dict_get(fmtCtx->metadata, "album", nullptr, 0);
   if (tag && tag->value)
     m_metadata.album = tag->value;
+  tag = av_dict_get(fmtCtx->metadata, "icy-name", nullptr, 0);
+  if (tag && tag->value)
+    m_metadata.icyName = tag->value;
+  tag = av_dict_get(fmtCtx->metadata, "icy-title", nullptr, 0);
+  if (tag && tag->value)
+    m_metadata.icyTitle = tag->value;
   if (!isUrl(path)) {
     TagLib::FileRef f(path.c_str());
     if (!f.isNull() && f.tag()) {

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
+    src/YouTubeDL.cpp
 )
 
 find_package(PkgConfig)

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -2,12 +2,24 @@
 
 This module contains basic networking helpers.
 
-The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs.
+The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs. ICY
+metadata is requested automatically so internet radio streams expose song
+information when available.
 
 ```cpp
 mediaplayer::NetworkStream stream;
 if (stream.open("https://example.com/video.mp4")) {
   AVFormatContext *ctx = stream.context();
   // pass ctx to MediaPlayer or custom processing
+}
+```
+
+For YouTube links, the optional helper `fetchYouTubeStream()` uses
+`youtube-dl` to resolve the direct media URL:
+
+```cpp
+auto url = mediaplayer::fetchYouTubeStream("https://youtu.be/VIDEO_ID");
+if (url) {
+  stream.open(*url);
 }
 ```

--- a/src/network/include/mediaplayer/YouTubeDL.h
+++ b/src/network/include/mediaplayer/YouTubeDL.h
@@ -1,0 +1,13 @@
+#ifndef MEDIAPLAYER_YOUTUBEDL_H
+#define MEDIAPLAYER_YOUTUBEDL_H
+
+#include <optional>
+#include <string>
+
+namespace mediaplayer {
+
+std::optional<std::string> fetchYouTubeStream(const std::string &url);
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_YOUTUBEDL_H

--- a/src/network/src/NetworkStream.cpp
+++ b/src/network/src/NetworkStream.cpp
@@ -15,7 +15,9 @@ NetworkStream::~NetworkStream() {
 bool NetworkStream::open(const std::string &url) {
   static std::once_flag initFlag;
   std::call_once(initFlag, [] { avformat_network_init(); });
-  if (avformat_open_input(&m_ctx, url.c_str(), nullptr, nullptr) < 0) {
+  AVDictionary *opts = nullptr;
+  av_dict_set(&opts, "icy", "1", 0);
+  if (avformat_open_input(&m_ctx, url.c_str(), nullptr, &opts) < 0) {
     std::cerr << "Failed to open URL: " << url << '\n';
     return false;
   }

--- a/src/network/src/YouTubeDL.cpp
+++ b/src/network/src/YouTubeDL.cpp
@@ -1,0 +1,28 @@
+#include "mediaplayer/YouTubeDL.h"
+#include <array>
+#include <cstdio>
+#include <iostream>
+
+namespace mediaplayer {
+
+std::optional<std::string> fetchYouTubeStream(const std::string &url) {
+  std::string cmd = "python3 -m youtube_dl -g \"" + url + "\" 2>/dev/null";
+  std::array<char, 512> buffer{};
+  std::string output;
+  FILE *pipe = popen(cmd.c_str(), "r");
+  if (!pipe) {
+    std::cerr << "youtube_dl not available\n";
+    return std::nullopt;
+  }
+  while (fgets(buffer.data(), buffer.size(), pipe)) {
+    output += buffer.data();
+  }
+  int ret = pclose(pipe);
+  if (ret != 0 || output.empty())
+    return std::nullopt;
+  if (!output.empty() && output.back() == '\n')
+    output.pop_back();
+  return output;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- install libcurl and youtube_dl in docs
- request ICY metadata in NetworkStream
- expose YouTubeDL helper and document usage
- capture ICY metadata in MediaPlayer

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaMetadata.h src/core/src/MediaPlayer.cpp src/network/src/NetworkStream.cpp src/network/include/mediaplayer/YouTubeDL.h src/network/src/YouTubeDL.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68630a787ac883318b5b0473a2b874bf