### PR TITLE
Add network streaming utilities

### DIFF
--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -4,6 +4,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         build-essential cmake git \
         libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
+        libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docs/building.md
+++ b/docs/building.md
@@ -8,7 +8,7 @@ Ensure the following packages are installed:
 
 - **CMake** 3.15 or newer
 - A C++17 compatible compiler
-- **FFmpeg** development libraries
+- **FFmpeg** development libraries (with HTTP/HLS protocol support)
 - **TagLib** development headers
 - **PulseAudio** (`libpulse` and `libpulse-simple`)
 - **SQLite** development library
@@ -19,6 +19,7 @@ On Ubuntu the packages can be installed with:
 ```bash
 sudo apt-get install -y build-essential cmake git \
     libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
+    libcurl4-openssl-dev \
     libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev
 ```
 

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -1,8 +1,15 @@
 # Streaming & Networking
 
-This module contains basic networking helpers.
+This module contains networking helpers and wrappers over FFmpeg's
+protocol implementations. FFmpeg must be built with networking support
+(HTTP/HTTPS, HLS, etc.) and the system needs `libcurl` development
+headers available. The Dockerfile and build instructions include the
+`libcurl4-openssl-dev` package to satisfy this dependency.
 
-The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs.
+`NetworkStream` wraps FFmpeg to open media from remote URLs including
+static files, HLS/DASH playlists and internet radio streams.
+It automatically initializes FFmpeg's network layer and exposes
+metadata such as ICY headers when available.
 
 ```cpp
 mediaplayer::NetworkStream stream;
@@ -10,4 +17,18 @@ if (stream.open("https://example.com/video.mp4")) {
   AVFormatContext *ctx = stream.context();
   // pass ctx to MediaPlayer or custom processing
 }
+```
+
+After opening a radio stream you can query metadata keys such as
+`icy-title` using `getMetadata()`:
+
+```cpp
+std::string title = stream.getMetadata("icy-title");
+```
+
+For sites like YouTube you can use the helper script in `src/tools` to
+resolve a direct streaming URL:
+
+```
+./youtube_fetch.py "https://www.youtube.com/watch?v=..."
 ```

--- a/src/network/include/mediaplayer/NetworkStream.h
+++ b/src/network/include/mediaplayer/NetworkStream.h
@@ -5,6 +5,7 @@ extern "C" {
 #include <libavformat/avformat.h>
 }
 
+#include <map>
 #include <string>
 
 namespace mediaplayer {
@@ -15,11 +16,15 @@ public:
   ~NetworkStream();
 
   bool open(const std::string &url);
+  void setOption(const std::string &key, const std::string &value);
+  std::string getMetadata(const std::string &key) const;
+  std::map<std::string, std::string> metadata() const;
   AVFormatContext *context() const { return m_ctx; }
   AVFormatContext *release();
 
 private:
   AVFormatContext *m_ctx{nullptr};
+  AVDictionary *m_opts{nullptr};
 };
 
 } // namespace mediaplayer

--- a/src/network/src/NetworkStream.cpp
+++ b/src/network/src/NetworkStream.cpp
@@ -1,5 +1,6 @@
 #include "mediaplayer/NetworkStream.h"
 #include <iostream>
+#include <map>
 #include <mutex>
 
 namespace mediaplayer {
@@ -7,19 +8,45 @@ namespace mediaplayer {
 NetworkStream::NetworkStream() = default;
 
 NetworkStream::~NetworkStream() {
-  if (m_ctx) {
+  if (m_ctx)
     avformat_close_input(&m_ctx);
-  }
+  if (m_opts)
+    av_dict_free(&m_opts);
 }
 
 bool NetworkStream::open(const std::string &url) {
   static std::once_flag initFlag;
   std::call_once(initFlag, [] { avformat_network_init(); });
-  if (avformat_open_input(&m_ctx, url.c_str(), nullptr, nullptr) < 0) {
+  if (avformat_open_input(&m_ctx, url.c_str(), nullptr, &m_opts) < 0) {
     std::cerr << "Failed to open URL: " << url << '\n';
     return false;
   }
+  av_dict_free(&m_opts);
   return true;
+}
+
+void NetworkStream::setOption(const std::string &key, const std::string &value) {
+  av_dict_set(&m_opts, key.c_str(), value.c_str(), 1);
+}
+
+std::string NetworkStream::getMetadata(const std::string &key) const {
+  if (!m_ctx)
+    return {};
+  AVDictionaryEntry *tag = av_dict_get(m_ctx->metadata, key.c_str(), nullptr, 0);
+  if (tag)
+    return tag->value;
+  return {};
+}
+
+std::map<std::string, std::string> NetworkStream::metadata() const {
+  std::map<std::string, std::string> map;
+  if (!m_ctx)
+    return map;
+  AVDictionaryEntry *tag = nullptr;
+  while ((tag = av_dict_get(m_ctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+    map[tag->key] = tag->value ? tag->value : "";
+  }
+  return map;
 }
 
 AVFormatContext *NetworkStream::release() {

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -10,3 +10,14 @@ mediaconvert <audio|video> <input> <output> [options]
 Options include bitrate, codec and, for video, the width/height or `--crf` value
 to control quality. Conversion progress is printed to the console.
 
+## youtube_fetch
+
+`youtube_fetch.py` is a tiny helper script that uses `youtube-dl` (or
+`youtube-dlp`) to resolve streaming URLs from services like YouTube. It
+prints the direct media URL so the core player can open it with
+`NetworkStream`.
+
+```
+./youtube_fetch.py "https://www.youtube.com/watch?v=..."
+```
+

--- a/src/tools/youtube_fetch.py
+++ b/src/tools/youtube_fetch.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Fetch direct media URLs using youtube-dl/youtube-dlp.
+
+Usage:
+  youtube_fetch.py <youtube-url>
+"""
+import sys
+
+try:
+    from youtube_dl import YoutubeDL  # type: ignore
+except Exception:
+    print("youtube_dl module not installed. Run 'pip install youtube_dl'.")
+    sys.exit(1)
+
+if len(sys.argv) != 2:
+    print(__doc__)
+    sys.exit(1)
+
+url = sys.argv[1]
+opts = {
+    'quiet': True,
+    'skip_download': True,
+    'format': 'best',
+}
+with YoutubeDL(opts) as ydl:
+    info = ydl.extract_info(url, download=False)
+    if 'url' in info:
+        print(info['url'])
+    elif 'entries' in info and info['entries']:
+        print(info['entries'][0]['url'])
+    else:
+        print('Failed to retrieve stream URL')


### PR DESCRIPTION
## Summary
- expand Dockerfile to include libcurl
- document network dependencies in build guide
- enhance NetworkStream wrapper with options and metadata APIs
- document streaming features
- add helper script for fetching YouTube stream URLs

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630a787ac883318b5b0473a2b874bf