### PR TITLE
Add network streaming helpers and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,16 @@ network access won't run in restricted environments.
 
 ## Usage
 
-Run the resulting `mediaplayer` executable with a media file:
+Run the resulting `mediaplayer` executable with a media file or network stream:
 
 ```
 ./mediaplayer path/to/video.mp4
+./mediaplayer https://example.com/stream.m3u8
 ```
+
+`mediaplayer_network` includes helpers to verify available streaming protocols
+via `listProtocols()` and supports opening internet radio streams with ICY
+metadata when FFmpeg is built with HTTP support.
 
 The graphical interface allows you to open files and manage your library as features are implemented.
 

--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -38,10 +38,10 @@
 | 32 | Video Transcoding Utility | done | implemented in `src/format_conversion` |
 | 33 | Conversion Task Management | done | asynchronous `FormatConverter` |
 | 34 | Integration in UI | done | CLI tool `mediaconvert` and Qt signals via `FormatConverterQt` |
-| 35 | Network Stream Input Support | open | relevant |
-| 36 | YouTube Integration (Optional) | open | relevant |
-| 37 | Streaming Protocols (HLS/DASH) | open | relevant |
-| 38 | Internet Radio Streams | open | relevant |
+| 35 | Network Stream Input Support | done | `NetworkStream` opens HTTP/HTTPS URLs |
+| 36 | YouTube Integration (Optional) | open | Python helper script |
+| 37 | Streaming Protocols (HLS/DASH) | done | handled by FFmpeg demuxers |
+| 38 | Internet Radio Streams | done | `InternetRadioStream` with ICY metadata |
 | 39 | Subtitle Parser (SRT) | done | relevant |
 | 40 | Subtitle Renderer/Provider | done | `SubtitleProvider` supplies cues |
 | 41 | Subtitle Sync Adjustment | done | `SubtitleProvider::setOffset` |

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,19 +1,14 @@
-add_library(mediaplayer_network
-    src/NetworkStream.cpp
-)
+add_library(mediaplayer_network src / NetworkStream.cpp src / NetworkUtils.cpp src /
+            InternetRadioStream.cpp src / YoutubeDL.cpp)
 
-find_package(PkgConfig)
-pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat)
+    find_package(PkgConfig) pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat)
 
-target_include_directories(mediaplayer_network PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${FFMPEG_INCLUDE_DIRS}
-)
+        target_include_directories(
+            mediaplayer_network PUBLIC $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
+                $<INSTALL_INTERFACE : include>
+                    ${FFMPEG_INCLUDE_DIRS})
 
-target_link_libraries(mediaplayer_network PkgConfig::FFMPEG)
+            target_link_libraries(mediaplayer_network PkgConfig::FFMPEG)
 
-set_target_properties(mediaplayer_network PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-)
+                set_target_properties(
+                    mediaplayer_network PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -2,7 +2,28 @@
 
 This module contains basic networking helpers.
 
-The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs.
+The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs. It
+initializes FFmpeg's network stack and can be used for HLS/DASH streams as well
+when the corresponding demuxers are available in the local FFmpeg build.
+
+`NetworkUtils` exposes helper functions to query supported protocols and input
+formats. These are useful to verify that the FFmpeg build includes modules such
+as `http`, `hls` or `dash`:
+
+```cpp
+for (const auto &p : mediaplayer::listProtocols())
+  std::cout << p << "\n";
+if (mediaplayer::supportsDemuxer("hls"))
+  std::cout << "HLS supported" << std::endl;
+```
+
+`InternetRadioStream` extends `NetworkStream` and parses ICY metadata from audio
+streams. The metadata can be refreshed at runtime to obtain the current song
+title.
+
+YouTube URLs can be resolved to direct media streams using the optional helper
+`YoutubeDL` which calls `youtube_dl` via Python. Ensure `pip install youtube_dl`
+is run so the Python module is available.
 
 ```cpp
 mediaplayer::NetworkStream stream;

--- a/src/network/include/mediaplayer/InternetRadioStream.h
+++ b/src/network/include/mediaplayer/InternetRadioStream.h
@@ -1,0 +1,29 @@
+#ifndef MEDIAPLAYER_INTERNETRADIOSTREAM_H
+#define MEDIAPLAYER_INTERNETRADIOSTREAM_H
+
+#include "NetworkStream.h"
+#include <string>
+
+namespace mediaplayer {
+
+struct IcyMetadata {
+  std::string name;
+  std::string genre;
+  std::string url;
+  std::string title;
+  std::string description;
+};
+
+class InternetRadioStream : public NetworkStream {
+public:
+  bool open(const std::string &url);
+  const IcyMetadata &metadata() const { return m_metadata; }
+  bool refreshMetadata();
+
+private:
+  IcyMetadata m_metadata;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_INTERNETRADIOSTREAM_H

--- a/src/network/include/mediaplayer/NetworkUtils.h
+++ b/src/network/include/mediaplayer/NetworkUtils.h
@@ -1,0 +1,15 @@
+#ifndef MEDIAPLAYER_NETWORKUTILS_H
+#define MEDIAPLAYER_NETWORKUTILS_H
+
+#include <string>
+#include <vector>
+
+namespace mediaplayer {
+
+std::vector<std::string> listProtocols(bool output = false);
+bool supportsProtocol(const std::string &protocol);
+bool supportsDemuxer(const std::string &name);
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_NETWORKUTILS_H

--- a/src/network/include/mediaplayer/YoutubeDL.h
+++ b/src/network/include/mediaplayer/YoutubeDL.h
@@ -1,0 +1,12 @@
+#ifndef MEDIAPLAYER_YOUTUBEDL_H
+#define MEDIAPLAYER_YOUTUBEDL_H
+
+#include <string>
+
+namespace mediaplayer {
+
+std::string resolveYouTubeUrl(const std::string &url);
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_YOUTUBEDL_H

--- a/src/network/src/InternetRadioStream.cpp
+++ b/src/network/src/InternetRadioStream.cpp
@@ -1,0 +1,30 @@
+#include "mediaplayer/InternetRadioStream.h"
+#include <iostream>
+#include <libavformat/avformat.h>
+
+namespace mediaplayer {
+
+bool InternetRadioStream::open(const std::string &url) {
+  if (!NetworkStream::open(url))
+    return false;
+  return refreshMetadata();
+}
+
+static std::string getTag(AVFormatContext *ctx, const char *key) {
+  AVDictionaryEntry *tag = av_dict_get(ctx->metadata, key, nullptr, 0);
+  return tag && tag->value ? tag->value : std::string();
+}
+
+bool InternetRadioStream::refreshMetadata() {
+  AVFormatContext *ctx = context();
+  if (!ctx)
+    return false;
+  m_metadata.name = getTag(ctx, "icy-name");
+  m_metadata.genre = getTag(ctx, "icy-genre");
+  m_metadata.url = getTag(ctx, "icy-url");
+  m_metadata.title = getTag(ctx, "icy-title");
+  m_metadata.description = getTag(ctx, "icy-description");
+  return true;
+}
+
+} // namespace mediaplayer

--- a/src/network/src/NetworkUtils.cpp
+++ b/src/network/src/NetworkUtils.cpp
@@ -1,0 +1,45 @@
+#include "mediaplayer/NetworkUtils.h"
+extern "C" {
+#include <libavformat/avformat.h>
+}
+#include <string>
+#include <vector>
+
+namespace mediaplayer {
+
+std::vector<std::string> listProtocols(bool output) {
+  void *opaque = nullptr;
+  const char *name = nullptr;
+  std::vector<std::string> result;
+  (void)output;
+  while ((name = avio_enum_protocols(&opaque, 0))) {
+    result.emplace_back(name);
+  }
+  opaque = nullptr;
+  while ((name = avio_enum_protocols(&opaque, 1))) {
+    if (std::find(result.begin(), result.end(), name) == result.end())
+      result.emplace_back(name);
+  }
+  return result;
+}
+
+bool supportsProtocol(const std::string &protocol) {
+  void *opaque = nullptr;
+  const char *name = nullptr;
+  while ((name = avio_enum_protocols(&opaque, 0))) {
+    if (protocol == name)
+      return true;
+  }
+  opaque = nullptr;
+  while ((name = avio_enum_protocols(&opaque, 1))) {
+    if (protocol == name)
+      return true;
+  }
+  return false;
+}
+
+bool supportsDemuxer(const std::string &name) {
+  return av_find_input_format(name.c_str()) != nullptr;
+}
+
+} // namespace mediaplayer

--- a/src/network/src/YoutubeDL.cpp
+++ b/src/network/src/YoutubeDL.cpp
@@ -1,0 +1,29 @@
+#include "mediaplayer/YoutubeDL.h"
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+namespace mediaplayer {
+
+static std::string exec(const std::string &cmd) {
+  std::array<char, 256> buf{};
+  std::string result;
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+  if (!pipe)
+    return result;
+  while (fgets(buf.data(), buf.size(), pipe.get()))
+    result += buf.data();
+  return result;
+}
+
+std::string resolveYouTubeUrl(const std::string &url) {
+  std::string cmd = "python3 -m youtube_dl -g '" + url + "' 2>/dev/null";
+  std::string out = exec(cmd);
+  size_t pos = out.find_last_not_of(" \n\r\t");
+  if (pos != std::string::npos)
+    out = out.substr(0, pos + 1);
+  return out;
+}
+
+} // namespace mediaplayer

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -10,3 +10,10 @@ mediaconvert <audio|video> <input> <output> [options]
 Options include bitrate, codec and, for video, the width/height or `--crf` value
 to control quality. Conversion progress is printed to the console.
 
+`youtube_resolve.py` is a small helper script that uses `youtube_dl` to resolve a
+YouTube URL to a direct media stream URL:
+
+```
+python3 youtube_resolve.py https://youtube.com/watch?v=...
+```
+

--- a/src/tools/youtube_resolve.py
+++ b/src/tools/youtube_resolve.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Resolve a YouTube URL to a direct media stream using youtube_dl."""
+import sys
+from youtube_dl import YoutubeDL
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: youtube_resolve.py <URL>")
+        return
+    url = sys.argv[1]
+    ydl_opts = {"quiet": True, "skip_download": True, "format": "best"}
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=False)
+        print(info.get("url", ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/network_protocol_test.cpp
+++ b/tests/network_protocol_test.cpp
@@ -1,0 +1,13 @@
+#include "mediaplayer/NetworkUtils.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+  auto protocols = mediaplayer::listProtocols();
+  assert(!protocols.empty());
+  assert(mediaplayer::supportsProtocol("http"));
+  std::cout << "Available protocols: " << protocols.size() << std::endl;
+  if (mediaplayer::supportsDemuxer("hls"))
+    std::cout << "HLS supported" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add NetworkUtils to query available protocols
- implement InternetRadioStream with ICY metadata parsing
- add YoutubeDL helper for resolving YouTube URLs
- document streaming features and update tasks
- provide python youtube_resolve script
- add network protocol test example

## Testing
- `g++ -std=c++17 -I src/network/include tests/network_protocol_test.cpp src/network/src/NetworkStream.cpp src/network/src/NetworkUtils.cpp src/network/src/InternetRadioStream.cpp src/network/src/YoutubeDL.cpp -lavformat -lavcodec -lavutil -lswresample -lswscale -o /tmp/network_test` *(fails: libavformat/avformat.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68630a787ac883318b5b0473a2b874bf