### PR TITLE
Add network streaming helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Run the resulting `mediaplayer` executable with a media file:
 ```
 
 The graphical interface allows you to open files and manage your library as features are implemented.
+Network streams (HTTP/HTTPS, HLS or DASH) can be opened via `NetworkStream` when FFmpeg is built with protocol support. Optional helpers integrate `youtube_dl` for resolving YouTube links.
 
 ## Contributing
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mediaplayer_network
     src/NetworkStream.cpp
+    src/YouTubeDl.cpp
 )
 
 find_package(PkgConfig)

--- a/src/network/README.md
+++ b/src/network/README.md
@@ -1,8 +1,16 @@
 # Streaming & Networking
 
-This module contains basic networking helpers.
+This module contains basic networking helpers. FFmpeg handles the actual
+protocol implementations; make sure it is built with network support and
+linked against `libcurl` so that HTTP(S), HLS, DASH and RTMP streams work.
+On Ubuntu systems install `ffmpeg` and `libcurl4-openssl-dev`:
 
-The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs.
+```bash
+sudo apt-get install ffmpeg libcurl4-openssl-dev
+```
+
+The `NetworkStream` class wraps FFmpeg to open media from HTTP/HTTPS URLs and
+provides helpers to read ICY metadata from internet radio streams.
 
 ```cpp
 mediaplayer::NetworkStream stream;
@@ -10,4 +18,19 @@ if (stream.open("https://example.com/video.mp4")) {
   AVFormatContext *ctx = stream.context();
   // pass ctx to MediaPlayer or custom processing
 }
+```
+
+To retrieve radio metadata:
+
+```cpp
+std::cout << stream.icyTitle() << std::endl;
+```
+
+### YouTube links
+
+`youtube_dl` can be used to resolve streaming URLs. The helper function
+`youtubeDlUrl()` returns a direct URL:
+
+```cpp
+auto direct = mediaplayer::youtubeDlUrl("https://www.youtube.com/watch?v=...");
 ```

--- a/src/network/include/mediaplayer/NetworkStream.h
+++ b/src/network/include/mediaplayer/NetworkStream.h
@@ -18,6 +18,12 @@ public:
   AVFormatContext *context() const { return m_ctx; }
   AVFormatContext *release();
 
+  // Retrieve a metadata value from the opened stream.
+  std::string metadata(const std::string &key) const;
+  // Convenience helpers for common ICY tags used by internet radio streams.
+  std::string icyTitle() const;
+  std::string icyName() const;
+
 private:
   AVFormatContext *m_ctx{nullptr};
 };

--- a/src/network/include/mediaplayer/YouTubeDl.h
+++ b/src/network/include/mediaplayer/YouTubeDl.h
@@ -1,0 +1,14 @@
+#ifndef MEDIAPLAYER_YOUTUBEDL_H
+#define MEDIAPLAYER_YOUTUBEDL_H
+
+#include <string>
+
+namespace mediaplayer {
+
+// Return direct media stream URL by invoking youtube-dl.
+// Returns empty string on failure.
+std::string youtubeDlUrl(const std::string &url);
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_YOUTUBEDL_H

--- a/src/network/src/NetworkStream.cpp
+++ b/src/network/src/NetworkStream.cpp
@@ -28,4 +28,27 @@ AVFormatContext *NetworkStream::release() {
   return ctx;
 }
 
+std::string NetworkStream::metadata(const std::string &key) const {
+  if (!m_ctx)
+    return {};
+  AVDictionaryEntry *tag = av_dict_get(m_ctx->metadata, key.c_str(), nullptr, 0);
+  if (tag && tag->value)
+    return tag->value;
+  return {};
+}
+
+std::string NetworkStream::icyTitle() const {
+  auto title = metadata("icy-title");
+  if (title.empty())
+    title = metadata("StreamTitle");
+  return title;
+}
+
+std::string NetworkStream::icyName() const {
+  auto name = metadata("icy-name");
+  if (name.empty())
+    name = metadata("icy-description");
+  return name;
+}
+
 } // namespace mediaplayer

--- a/src/network/src/YouTubeDl.cpp
+++ b/src/network/src/YouTubeDl.cpp
@@ -1,0 +1,23 @@
+#include "mediaplayer/YouTubeDl.h"
+
+#include <array>
+#include <cstdio>
+#include <memory>
+
+namespace mediaplayer {
+
+std::string youtubeDlUrl(const std::string &url) {
+  std::string cmd = "python3 -m youtube_dl -g --no-playlist \"" + url + "\" 2>/dev/null";
+  std::array<char, 1024> buffer{};
+  std::string result;
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+  if (!pipe)
+    return {};
+  if (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()))
+    result = buffer.data();
+  if (!result.empty() && result.back() == '\n')
+    result.pop_back();
+  return result;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `youtubeDlUrl()` helper and integrate it into network module
- extend `NetworkStream` with metadata helpers for internet radio
- document streaming requirements and YouTube resolver in network README
- mention network streaming in main README

## Testing
- `cmake ..`
- `cmake --build . --target mediaplayer_network`


------
https://chatgpt.com/codex/tasks/task_e_68630a787ac883318b5b0473a2b874bf