### PR TITLE
Add visualization hook to core

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -19,6 +19,7 @@
 #include "VideoDecoder.h"
 #include "VideoFrameQueue.h"
 #include "VideoOutput.h"
+#include "Visualizer.h"
 #include "mediaplayer/FormatConverter.h"
 
 #include <atomic>
@@ -51,6 +52,7 @@ public:
   void setPreferredHardwareDevice(const std::string &device);
   void setCallbacks(PlaybackCallbacks callbacks);
   void setLibrary(LibraryDB *db);
+  void setVisualizer(std::shared_ptr<Visualizer> vis);
   void addAudioEffect(std::shared_ptr<AudioEffect> effect);
   void removeAudioEffect(std::shared_ptr<AudioEffect> effect);
   void setVolume(double volume); // 0.0 - 1.0
@@ -118,6 +120,7 @@ private:
   FormatConverter m_converter;
   SubtitleDecoder m_subtitleDecoder;
   std::thread m_subtitleThread;
+  std::shared_ptr<Visualizer> m_visualizer;
 };
 
 } // namespace mediaplayer

--- a/src/core/include/mediaplayer/SimpleFFT.h
+++ b/src/core/include/mediaplayer/SimpleFFT.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_SIMPLEFFT_H
+#define MEDIAPLAYER_SIMPLEFFT_H
+
+#include <complex>
+#include <vector>
+
+namespace mediaplayer {
+
+inline std::vector<float> simpleFFT(const int16_t *samples, size_t count) {
+  size_t n = count;
+  std::vector<float> out(n / 2);
+  const double twoPi = 6.283185307179586476925286766559;
+  for (size_t k = 0; k < out.size(); ++k) {
+    std::complex<double> sum{0.0, 0.0};
+    for (size_t t = 0; t < n; ++t) {
+      double angle = twoPi * k * t / n;
+      std::complex<double> w{std::cos(angle), -std::sin(angle)};
+      sum += static_cast<double>(samples[t]) * w;
+    }
+    out[k] = static_cast<float>(std::abs(sum));
+  }
+  return out;
+}
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_SIMPLEFFT_H

--- a/src/core/include/mediaplayer/Visualizer.h
+++ b/src/core/include/mediaplayer/Visualizer.h
@@ -1,0 +1,17 @@
+#ifndef MEDIAPLAYER_VISUALIZER_H
+#define MEDIAPLAYER_VISUALIZER_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mediaplayer {
+
+class Visualizer {
+public:
+  virtual ~Visualizer() = default;
+  virtual void onAudioPCM(const int16_t *samples, size_t count, int sampleRate, int channels) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VISUALIZER_H


### PR DESCRIPTION
## Summary
- implement `Visualizer` interface for plugins
- provide optional simple FFT function
- add visualizer setter to `MediaPlayer` and feed PCM data after decode

## Testing
- `clang-format -i src/core/include/mediaplayer/Visualizer.h src/core/include/mediaplayer/SimpleFFT.h src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp`
- `g++ -std=c++17 -I src/core/include -I src/library/include -I src/subtitles/include -c src/core/src/MediaPlayer.cpp -o /tmp/MediaPlayer.o` *(fails: libavcodec/avcodec.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686324c3b32883319b3a698d7dfe45d7