### PR TITLE
Add basic spectrum visualizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,5 +14,6 @@ add_subdirectory(src/format_conversion)
 add_subdirectory(src/desktop)
 
 # Optionally add other modules later
+add_subdirectory(src/visualization)
 
 add_subdirectory(src/tools)

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(mediaplayer_visualization
+    src/BasicVisualizer.cpp
+)
+
+target_include_directories(mediaplayer_visualization PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${CMAKE_SOURCE_DIR}/src/core/include
+)
+
+target_link_libraries(mediaplayer_visualization
+    mediaplayer_core
+)
+
+set_target_properties(mediaplayer_visualization PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -1,1 +1,5 @@
 # Visualization Module
+
+This module contains plug-in visualizers that can be attached to the core media player.
+
+`BasicVisualizer` demonstrates how to implement the `Visualizer` interface. It performs a simple FFT on incoming PCM data using the utility `simpleFFT` and stores the latest frequency spectrum.

--- a/src/visualization/include/mediaplayer/BasicVisualizer.h
+++ b/src/visualization/include/mediaplayer/BasicVisualizer.h
@@ -1,0 +1,26 @@
+#ifndef MEDIAPLAYER_BASICVISUALIZER_H
+#define MEDIAPLAYER_BASICVISUALIZER_H
+
+#include "mediaplayer/SimpleFFT.h"
+#include "mediaplayer/Visualizer.h"
+
+#include <mutex>
+#include <vector>
+
+namespace mediaplayer {
+
+class BasicVisualizer : public Visualizer {
+public:
+  BasicVisualizer() = default;
+  void onAudioPCM(const int16_t *samples, size_t count, int sampleRate, int channels) override;
+
+  const std::vector<float> &spectrum() const;
+
+private:
+  std::vector<float> m_spectrum;
+  mutable std::mutex m_mutex;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_BASICVISUALIZER_H

--- a/src/visualization/src/BasicVisualizer.cpp
+++ b/src/visualization/src/BasicVisualizer.cpp
@@ -1,0 +1,28 @@
+#include "mediaplayer/BasicVisualizer.h"
+
+namespace mediaplayer {
+
+void BasicVisualizer::onAudioPCM(const int16_t *samples, size_t count, int /*sampleRate*/,
+                                 int channels) {
+  if (!samples || count == 0)
+    return;
+
+  size_t frameCount = count / (channels > 0 ? channels : 1);
+  std::vector<int16_t> mono(frameCount);
+  for (size_t i = 0; i < frameCount; ++i) {
+    int32_t sum = 0;
+    for (int ch = 0; ch < channels; ++ch)
+      sum += samples[i * channels + ch];
+    mono[i] = static_cast<int16_t>(sum / (channels > 0 ? channels : 1));
+  }
+
+  auto spectrum = simpleFFT(mono.data(), mono.size());
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_spectrum = std::move(spectrum);
+  }
+}
+
+const std::vector<float> &BasicVisualizer::spectrum() const { return m_spectrum; }
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- integrate new optional visualization module
- implement BasicVisualizer using simple FFT
- feed PCM audio samples to visualizers

## Testing
- `clang++ -std=c++17 -I src/visualization/include -I src/core/include -c src/visualization/src/BasicVisualizer.cpp -o /tmp/basic.o`

------
https://chatgpt.com/codex/tasks/task_e_6863264d85008331909fdb82e16d3530