### PR TITLE
Add efficient FFT implementation

### DIFF
--- a/src/core/include/mediaplayer/SimpleFFT.h
+++ b/src/core/include/mediaplayer/SimpleFFT.h
@@ -1,24 +1,42 @@
 #ifndef MEDIAPLAYER_SIMPLEFFT_H
 #define MEDIAPLAYER_SIMPLEFFT_H
 
+#include <cmath>
 #include <complex>
 #include <vector>
 
 namespace mediaplayer {
 
 inline std::vector<float> simpleFFT(const int16_t *samples, size_t count) {
-  size_t n = count;
-  std::vector<float> out(n / 2);
-  const double twoPi = 6.283185307179586476925286766559;
-  for (size_t k = 0; k < out.size(); ++k) {
-    std::complex<double> sum{0.0, 0.0};
-    for (size_t t = 0; t < n; ++t) {
-      double angle = twoPi * k * t / n;
-      std::complex<double> w{std::cos(angle), -std::sin(angle)};
-      sum += static_cast<double>(samples[t]) * w;
+  size_t n = 1;
+  while (n < count)
+    n <<= 1; // next power of two
+
+  std::vector<std::complex<double>> data(n);
+  for (size_t i = 0; i < count; ++i)
+    data[i] = static_cast<double>(samples[i]);
+  for (size_t i = count; i < n; ++i)
+    data[i] = 0.0;
+
+  const double pi = std::acos(-1.0);
+  for (size_t len = 1; len < n; len <<= 1) {
+    double angle = -pi / static_cast<double>(len);
+    std::complex<double> wlen{std::cos(angle), std::sin(angle)};
+    for (size_t i = 0; i < n; i += 2 * len) {
+      std::complex<double> w{1.0, 0.0};
+      for (size_t j = 0; j < len; ++j) {
+        auto u = data[i + j];
+        auto v = data[i + j + len] * w;
+        data[i + j] = u + v;
+        data[i + j + len] = u - v;
+        w *= wlen;
+      }
     }
-    out[k] = static_cast<float>(std::abs(sum));
   }
+
+  std::vector<float> out(n / 2);
+  for (size_t i = 0; i < out.size(); ++i)
+    out[i] = static_cast<float>(std::abs(data[i]));
   return out;
 }
 

--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -2,4 +2,4 @@
 
 This module contains plug-in visualizers that can be attached to the core media player.
 
-`BasicVisualizer` demonstrates how to implement the `Visualizer` interface. It performs a simple FFT on incoming PCM data using the utility `simpleFFT` and stores the latest frequency spectrum.
+`BasicVisualizer` demonstrates how to implement the `Visualizer` interface. It performs a simple FFT on incoming PCM data using the utility `simpleFFT`, which now uses a fast Cooley--Tukey algorithm, and stores the latest frequency spectrum.


### PR DESCRIPTION
## Summary
- use an iterative Cooley–Tukey routine for `simpleFFT`
- note the faster algorithm in the visualization README

## Testing
- `clang-format -i src/core/include/mediaplayer/SimpleFFT.h`

------
https://chatgpt.com/codex/tasks/task_e_68633a0508108331bd0f30ac9627f723