### PR TITLE
Improve frame pool preallocation

### DIFF
--- a/src/core/include/mediaplayer/FramePool.h
+++ b/src/core/include/mediaplayer/FramePool.h
@@ -14,6 +14,7 @@ public:
 
   VideoFrame *acquire(int width, int height, const int linesize[3]);
   void release(VideoFrame *frame);
+  void preallocate(int width, int height, const int linesize[3], size_t count);
   void clear();
 
 private:

--- a/src/core/src/FramePool.cpp
+++ b/src/core/src/FramePool.cpp
@@ -24,6 +24,13 @@ VideoFrame *FramePool::createFrame(int width, int height, const int linesize[3])
   return f;
 }
 
+void FramePool::preallocate(int width, int height, const int linesize[3], size_t count) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  for (size_t i = m_freeFrames.size(); i < count && i < m_maxFrames; ++i) {
+    m_freeFrames.push_back(createFrame(width, height, linesize));
+  }
+}
+
 VideoFrame *FramePool::acquire(int width, int height, const int linesize[3]) {
   std::lock_guard<std::mutex> lock(m_mutex);
   for (auto it = m_freeFrames.begin(); it != m_freeFrames.end(); ++it) {

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -100,6 +100,8 @@ bool MediaPlayer::open(const std::string &path) {
       std::cerr << "Failed to init video output\n";
       return false;
     }
+    int lines[3] = {m_videoDecoder.width(), m_videoDecoder.width() / 2, m_videoDecoder.width() / 2};
+    m_framePool.preallocate(m_videoDecoder.width(), m_videoDecoder.height(), lines, 2);
   }
   if (m_demuxer.subtitleStream() >= 0) {
     m_subtitleDecoder.open(fmtCtx, m_demuxer.subtitleStream());


### PR DESCRIPTION
## Summary
- add preallocation support to `FramePool`
- preallocate a couple of frames when opening video streams

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_686344aa55c083319bad03f7ae4059aa