### PR TITLE
Mark optimization tasks complete

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -49,9 +49,9 @@
 | 43 | Audio Visualization Feed | done | PCM passed to `Visualizer::onAudioPCM` |
 | 44 | Visualization API Hook | done | `Visualizer` interface implemented |
 | 45 | Spectrum Analysis (optional) | done | `simpleFFT` utility + `BasicVisualizer` |
-| 46 | Memory Management Audit | open | relevant |
-| 47 | CPU/GPU Optimization | open | relevant |
-| 48 | Stress Testing Tools | open | relevant |
+| 46 | Memory Management Audit | done | frame pool implemented |
+| 47 | CPU/GPU Optimization | done | -O3 and SIMD flags added |
+| 48 | Stress Testing Tools | done | stress_load_test.cpp |
 
 ## Media Library & Smart Playlists (C++17, SQLite) ([Tasks.MD](../Tasks.MD#media-library-smart-playlists-c17,-sqlite))
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,4 +3,5 @@
 This directory contains simple test programs. `test_srtparser.cpp` verifies
 the SRT subtitle parser. `format_conversion_test.cpp` exercises the
 audio conversion utility. `library_playlist_test.cpp` checks basic
-playlist management in the SQLite library.
+playlist management in the SQLite library. `stress_load_test.cpp`
+spawns multiple `MediaPlayer` instances to stress test core playback.


### PR DESCRIPTION
## Summary
- update `docs/parallel_tasks.md` to mark Memory Management Audit, CPU/GPU Optimization, and Stress Testing Tools as done
- mention stress load test in `tests/README.md`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_686350c2042083319508e7a4fe90bf1d