### PR TITLE
Add video indexing without tag data

### DIFF
--- a/tests/library_video_notag_index_test.cpp
+++ b/tests/library_video_notag_index_test.cpp
@@ -1,0 +1,87 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+#include <sqlite3.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+}
+
+static void createTestVideo(const std::string &path) {
+  AVFormatContext *ctx = nullptr;
+  avformat_alloc_output_context2(&ctx, nullptr, nullptr, path.c_str());
+  const AVCodec *codec = avcodec_find_encoder(ctx->oformat->video_codec);
+  AVStream *st = avformat_new_stream(ctx, codec);
+  AVCodecContext *c = avcodec_alloc_context3(codec);
+  c->width = 16;
+  c->height = 16;
+  c->pix_fmt = codec->pix_fmts ? codec->pix_fmts[0] : AV_PIX_FMT_YUV420P;
+  c->time_base = {1, 25};
+  if (ctx->oformat->flags & AVFMT_GLOBALHEADER)
+    c->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  avcodec_open2(c, codec, nullptr);
+  avcodec_parameters_from_context(st->codecpar, c);
+  st->time_base = c->time_base;
+  if (!(ctx->oformat->flags & AVFMT_NOFILE))
+    avio_open(&ctx->pb, path.c_str(), AVIO_FLAG_WRITE);
+  avformat_write_header(ctx, nullptr);
+  AVFrame *frame = av_frame_alloc();
+  frame->format = c->pix_fmt;
+  frame->width = c->width;
+  frame->height = c->height;
+  av_frame_get_buffer(frame, 0);
+  for (int i = 0; i < 5; ++i) {
+    av_frame_make_writable(frame);
+    memset(frame->data[0], i, c->width * c->height);
+    memset(frame->data[1], 128, c->width * c->height / 4);
+    memset(frame->data[2], 128, c->width * c->height / 4);
+    frame->pts = i;
+    avcodec_send_frame(c, frame);
+    AVPacket pkt{};
+    while (avcodec_receive_packet(c, &pkt) == 0) {
+      pkt.stream_index = st->index;
+      av_interleaved_write_frame(ctx, &pkt);
+      av_packet_unref(&pkt);
+    }
+  }
+  avcodec_send_frame(c, nullptr);
+  AVPacket pkt{};
+  while (avcodec_receive_packet(c, &pkt) == 0) {
+    pkt.stream_index = st->index;
+    av_interleaved_write_frame(ctx, &pkt);
+    av_packet_unref(&pkt);
+  }
+  av_write_trailer(ctx);
+  av_frame_free(&frame);
+  if (!(ctx->oformat->flags & AVFMT_NOFILE))
+    avio_closep(&ctx->pb);
+  avcodec_free_context(&c);
+  avformat_free_context(ctx);
+}
+
+int main() {
+  const char *dbPath = "video_index.db";
+  const std::string video = "no_tag_video.mkv";
+  createTestVideo(video);
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  db.scanDirectory(".");
+  db.close();
+
+  sqlite3 *conn = nullptr;
+  sqlite3_open(dbPath, &conn);
+  sqlite3_stmt *stmt = nullptr;
+  sqlite3_prepare_v2(conn, "SELECT COUNT(*) FROM MediaItem WHERE path=?1;", -1, &stmt, nullptr);
+  sqlite3_bind_text(stmt, 1, video.c_str(), -1, SQLITE_TRANSIENT);
+  bool found = false;
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    found = sqlite3_column_int(stmt, 0) == 1;
+  sqlite3_finalize(stmt);
+  sqlite3_close(conn);
+  std::remove(video.c_str());
+  std::remove(dbPath);
+  assert(found && "video should be indexed");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- handle media files that lack TagLib tags in `scanDirectory`
- always use FFmpeg to get metadata
- insert or update records for all media paths
- add a unit test that ensures videos without tags are indexed

## Testing
- `clang++ -std=c++17 -I./src/library/include -I./src/core/include -I/usr/include/taglib -I/usr/include/libavformat -I/usr/include/libavcodec -I/usr/include/libavutil -I/usr/include/sqlite3 -fsyntax-only src/library/src/LibraryDB.cpp` *(fails: 'libavformat/avformat.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686485301d38833186fe4002b56243ca