### PR TITLE
Enable foreign key pragma

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -16,6 +16,14 @@ bool LibraryDB::open() {
     std::cerr << "Failed to open DB: " << sqlite3_errmsg(m_db) << '\n';
     return false;
   }
+  char *err = nullptr;
+  if (sqlite3_exec(m_db, "PRAGMA foreign_keys = ON;", nullptr, nullptr, &err) != SQLITE_OK) {
+    std::cerr << "Failed to enable foreign keys: " << err << '\n';
+    sqlite3_free(err);
+    sqlite3_close(m_db);
+    m_db = nullptr;
+    return false;
+  }
   if (!initSchema()) {
     sqlite3_close(m_db);
     m_db = nullptr;


### PR DESCRIPTION
## Summary
- enable SQLite foreign key enforcement when opening the library database
- log pragma errors and abort opening when enabling fails

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp`
- `cmake ..` *(fails: required packages not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864852c18348331be1d4f4c605a0369