### PR TITLE
Add unique constraint for playlist items

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -1,1 +1,6 @@
 # Media Library & Playlists
+
+The library database creates `MediaItem`, `Playlist` and `PlaylistItem` tables.
+The `PlaylistItem` table now enforces a `UNIQUE(playlist_id, path)` constraint.
+If updating an existing database, remove duplicate entries from `PlaylistItem`
+before applying the new schema.

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -54,7 +54,8 @@ bool LibraryDB::initSchema() {
                     "path TEXT,"
                     "position INTEGER,"
                     "FOREIGN KEY(playlist_id) REFERENCES Playlist(id),"
-                    "FOREIGN KEY(path) REFERENCES MediaItem(path)"
+                    "FOREIGN KEY(path) REFERENCES MediaItem(path),"
+                    "UNIQUE(playlist_id, path)"
                     ");";
   char *err = nullptr;
   if (sqlite3_exec(m_db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
@@ -270,7 +271,7 @@ bool LibraryDB::addToPlaylist(const std::string &name, const std::string &path) 
   int id = playlistId(name);
   if (id < 0)
     return false;
-  const char *sql = "INSERT INTO PlaylistItem (playlist_id, path, position) "
+  const char *sql = "INSERT OR IGNORE INTO PlaylistItem (playlist_id, path, position) "
                     "VALUES (?1, ?2, COALESCE((SELECT MAX(position)+1 FROM PlaylistItem WHERE "
                     "playlist_id=?1), 0));";
   sqlite3_stmt *stmt = nullptr;
@@ -278,7 +279,11 @@ bool LibraryDB::addToPlaylist(const std::string &name, const std::string &path) 
     return false;
   sqlite3_bind_int(stmt, 1, id);
   sqlite3_bind_text(stmt, 2, path.c_str(), -1, SQLITE_TRANSIENT);
-  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  int rc = sqlite3_step(stmt);
+  bool ok = false;
+  if (rc == SQLITE_DONE) {
+    ok = sqlite3_changes(m_db) > 0;
+  }
   sqlite3_finalize(stmt);
   return ok;
 }


### PR DESCRIPTION
## Summary
- enforce unique `(playlist_id, path)` pairs in `PlaylistItem`
- return `false` from `addToPlaylist()` when item already exists
- document migration note

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648532793c8331946782e6c15baeac