### PR TITLE
Add indexes to media library schema

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -72,6 +72,15 @@ bool LibraryDB::initSchema() {
     sqlite3_free(err);
     return false;
   }
+
+  const char *indexSql = "CREATE INDEX IF NOT EXISTS idx_media_title ON MediaItem(title);"
+                         "CREATE INDEX IF NOT EXISTS idx_media_artist ON MediaItem(artist);"
+                         "CREATE INDEX IF NOT EXISTS idx_media_album ON MediaItem(album);";
+  if (sqlite3_exec(m_db, indexSql, nullptr, nullptr, &err) != SQLITE_OK) {
+    std::cerr << "Failed to create indexes: " << err << '\n';
+    sqlite3_free(err);
+    return false;
+  }
   return true;
 }
 
@@ -143,7 +152,6 @@ bool LibraryDB::scanDirectory(const std::string &directory) {
         updateMedia(pathStr, title, artist, album);
       }
       avformat_close_input(&ctx);
-
     }
     insertMedia(pathStr, title, artist, album, duration, width, height, 0);
   }


### PR DESCRIPTION
## Summary
- add SQLite indexes for title, artist and album in `LibraryDB::initSchema`

## Testing
- `clang++ -std=c++17 -I src/library/include -I src/core/include -c src/library/src/LibraryDB.cpp` *(fails: 'libavformat/avformat.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648b0fda30833182f20bc522f87a29