### PR TITLE
Clean scanDirectory upsert logic

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -46,6 +46,9 @@ if (db.open()) {
 }
 ```
 
+`scanDirectory` uses an SQLite UPSERT so rescanning will update metadata for
+existing files automatically.
+
 Other helpers allow updating or removing entries, setting ratings and retrieving the items of a playlist.
 
 ## Dependencies and Building

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -75,6 +75,9 @@ bool LibraryDB::initSchema() {
   return true;
 }
 
+// Insert a media item or update the existing row if the path already exists.
+// The SQLite UPSERT ensures rescanning refreshes metadata without a separate
+// update step.
 bool LibraryDB::insertMedia(const std::string &path, const std::string &title,
                             const std::string &artist, const std::string &album, int duration,
                             int width, int height, int rating) {
@@ -139,11 +142,7 @@ bool LibraryDB::scanDirectory(const std::string &directory) {
         }
       }
       insertMedia(pathStr, title, artist, album, duration, width, height, 0);
-      if (sqlite3_changes(m_db) == 0) {
-        updateMedia(pathStr, title, artist, album);
-      }
       avformat_close_input(&ctx);
-
     }
     insertMedia(pathStr, title, artist, album, duration, width, height, 0);
   }


### PR DESCRIPTION
## Summary
- update `insertMedia` comment about UPSERT behavior
- rely solely on insertMedia in `scanDirectory`
- document automatic metadata updates in library README

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp src/library/include/mediaplayer/LibraryDB.h`

------
https://chatgpt.com/codex/tasks/task_e_68648b0d7fa483319e881e920ac95527