### PR TITLE
Fix cascade deletion in LibraryDB

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -63,7 +63,7 @@ bool LibraryDB::initSchema() {
                     "path TEXT,"
                     "position INTEGER,"
                     "FOREIGN KEY(playlist_id) REFERENCES Playlist(id),"
-                    "FOREIGN KEY(path) REFERENCES MediaItem(path),"
+                    "FOREIGN KEY(path) REFERENCES MediaItem(path) ON DELETE CASCADE,"
                     "UNIQUE(playlist_id, path)"
                     ");";
   char *err = nullptr;
@@ -143,7 +143,6 @@ bool LibraryDB::scanDirectory(const std::string &directory) {
         updateMedia(pathStr, title, artist, album);
       }
       avformat_close_input(&ctx);
-
     }
     insertMedia(pathStr, title, artist, album, duration, width, height, 0);
   }


### PR DESCRIPTION
## Summary
- ensure playlist items referencing a media item are removed when the media entry is deleted
- run clang-format

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68648b0ffc288331859d87839d562890