### PR TITLE
Refactor media insertion logic

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -139,13 +139,8 @@ bool LibraryDB::scanDirectory(const std::string &directory) {
         }
       }
       insertMedia(pathStr, title, artist, album, duration, width, height, 0);
-      if (sqlite3_changes(m_db) == 0) {
-        updateMedia(pathStr, title, artist, album);
-      }
       avformat_close_input(&ctx);
-
     }
-    insertMedia(pathStr, title, artist, album, duration, width, height, 0);
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- dedupe insertMedia calls during library scan
- rely on upsert in insertMedia for updates

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68648b0d88f88331b77b3848e1edaf1c