### PR TITLE
Resolve duplicate insert during scan

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -165,7 +165,6 @@ bool LibraryDB::scanDirectoryImpl(const std::string &directory, ProgressCallback
           }
         }
       }
-      insertMedia(pathStr, title, artist, album, duration, width, height, 0);
       avformat_close_input(&ctx);
     }
     insertMedia(pathStr, title, artist, album, duration, width, height, 0);


### PR DESCRIPTION
## Summary
- fix merge conflict PR by retaining improved scanDirectory
- remove duplicate `insertMedia` call so files only insert once

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68648e14bfd0833186c59a795c894586