### PR TITLE
Improve LibraryDB thread safety

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -51,6 +51,10 @@ existing files automatically.
 
 Other helpers allow updating or removing entries, setting ratings and retrieving the items of a playlist.
 
+`LibraryDB` is now thread-safe. All database operations lock an internal mutex,
+so methods such as `search` and playlist management can be called concurrently
+from multiple threads without corruption.
+
 ## Dependencies and Building
 
 `LibraryDB` relies on:

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -4,6 +4,7 @@
 #include "mediaplayer/MediaMetadata.h"
 #include <atomic>
 #include <functional>
+#include <mutex>
 #include <sqlite3.h>
 #include <string>
 #include <thread>
@@ -67,6 +68,7 @@ private:
 private:
   std::string m_path;
   sqlite3 *m_db{nullptr};
+  mutable std::mutex m_mutex;
 };
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add a mutex member to `LibraryDB`
- protect SQLite operations with `std::lock_guard`
- note thread safety in the library README

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686495f23c108331bee9951326d41b36