### PR TITLE
Implement smartQuery filter for LibraryDB

### DIFF
--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -43,6 +43,11 @@ public:
   // string. Case-insensitive according to SQLite's LIKE operator.
   std::vector<MediaMetadata> search(const std::string &query);
 
+  // Execute a simple filter expression against MediaItem fields. Supported
+  // operators are =, !=, <, >, <= and >= combined with AND/OR. Example:
+  //   "rating>=4 AND artist='Queen'".
+  std::vector<MediaMetadata> smartQuery(const std::string &filter);
+
   // Increment play count and update last played timestamp for a media item.
   bool recordPlayback(const std::string &path);
 

--- a/tests/library_smartquery_test.cpp
+++ b/tests/library_smartquery_test.cpp
@@ -1,0 +1,20 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "smart_query.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("song1.mp3", "Title1", "Artist", "Album"));
+  assert(db.addMedia("song2.mp3", "Title2", "Artist", "Album"));
+  assert(db.setRating("song1.mp3", 5));
+  assert(db.setRating("song2.mp3", 3));
+
+  auto res = db.smartQuery("rating>=4 AND artist='Artist'");
+  assert(res.size() == 1 && res[0].path == "song1.mp3");
+
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add smartQuery method to `LibraryDB`
- implement parser converting simple filter expressions to SQL
- add regression test for smartQuery behaviour

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp tests/library_smartquery_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6864a060735083319145492b32538c61