### PR TITLE
Add library retrieval helpers

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -42,6 +42,8 @@ if (db.open()) {
     for (const auto &m : songs)
         db.addToPlaylist("favorites", m.path);
     db.recordPlayback(songs.front().path);      // update play count
+    auto recent = db.recentlyAdded(5);          // top 5 recently played
+    auto popular = db.mostPlayed(5);            // top 5 most played
     db.close();
 }
 ```
@@ -49,7 +51,9 @@ if (db.open()) {
 `scanDirectory` uses an SQLite UPSERT so rescanning will update metadata for
 existing files automatically.
 
-Other helpers allow updating or removing entries, setting ratings and retrieving the items of a playlist.
+Other helpers allow updating or removing entries, setting ratings and retrieving
+the items of a playlist. You can also fetch recently played or most popular
+tracks via `recentlyAdded()` and `mostPlayed()`.
 
 `LibraryDB` is now thread-safe. All database operations lock an internal mutex,
 so methods such as `search` and playlist management can be called concurrently

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -43,6 +43,14 @@ public:
   // string. Case-insensitive according to SQLite's LIKE operator.
   std::vector<MediaMetadata> search(const std::string &query);
 
+  // Retrieve most recently played items ordered by last_played. Limit results
+  // to the given number of entries.
+  std::vector<MediaMetadata> recentlyAdded(int limit);
+
+  // Retrieve most frequently played items ordered by play_count. Limit results
+  // to the given number of entries.
+  std::vector<MediaMetadata> mostPlayed(int limit);
+
   // Increment play count and update last played timestamp for a media item.
   bool recordPlayback(const std::string &path);
 

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -267,6 +267,74 @@ std::vector<MediaMetadata> LibraryDB::search(const std::string &query) {
   return results;
 }
 
+std::vector<MediaMetadata> LibraryDB::recentlyAdded(int limit) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<MediaMetadata> items;
+  if (!m_db)
+    return items;
+  const char *sql = "SELECT path,title,artist,album,duration,width,height FROM MediaItem "
+                    "ORDER BY last_played DESC LIMIT ?1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return items;
+  sqlite3_bind_int(stmt, 1, limit);
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    MediaMetadata m{};
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      m.path = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 1);
+    if (txt)
+      m.title = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 2);
+    if (txt)
+      m.artist = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 3);
+    if (txt)
+      m.album = reinterpret_cast<const char *>(txt);
+    m.duration = sqlite3_column_int(stmt, 4);
+    m.width = sqlite3_column_int(stmt, 5);
+    m.height = sqlite3_column_int(stmt, 6);
+    items.push_back(std::move(m));
+  }
+  sqlite3_finalize(stmt);
+  return items;
+}
+
+std::vector<MediaMetadata> LibraryDB::mostPlayed(int limit) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<MediaMetadata> items;
+  if (!m_db)
+    return items;
+  const char *sql = "SELECT path,title,artist,album,duration,width,height FROM MediaItem "
+                    "ORDER BY play_count DESC LIMIT ?1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return items;
+  sqlite3_bind_int(stmt, 1, limit);
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    MediaMetadata m{};
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      m.path = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 1);
+    if (txt)
+      m.title = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 2);
+    if (txt)
+      m.artist = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 3);
+    if (txt)
+      m.album = reinterpret_cast<const char *>(txt);
+    m.duration = sqlite3_column_int(stmt, 4);
+    m.width = sqlite3_column_int(stmt, 5);
+    m.height = sqlite3_column_int(stmt, 6);
+    items.push_back(std::move(m));
+  }
+  sqlite3_finalize(stmt);
+  return items;
+}
+
 bool LibraryDB::recordPlayback(const std::string &path) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (!m_db)


### PR DESCRIPTION
## Summary
- add `recentlyAdded` and `mostPlayed` helpers to `LibraryDB`
- document usage in the library README

## Testing
- `cmake ..` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a06248b88331bc868066085d749c