### PR TITLE
Implement cleanup of stale library entries

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -1,4 +1,4 @@
-# Media Library & Playlists
+#Media Library &Playlists
 
 The library database creates `MediaItem`, `Playlist` and `PlaylistItem` tables.
 The `PlaylistItem` table now enforces a `UNIQUE(playlist_id, path)` constraint.
@@ -36,18 +36,19 @@ before applying the new schema.
 ```cpp
 mediaplayer::LibraryDB db("library.db");
 if (db.open()) {
-    db.scanDirectory("/path/to/music");         // populate from files
-    auto songs = db.search("Beatles");          // simple text search
-    db.createPlaylist("favorites");
-    for (const auto &m : songs)
-        db.addToPlaylist("favorites", m.path);
-    db.recordPlayback(songs.front().path);      // update play count
-    db.close();
+  db.scanDirectory("/path/to/music"); // populate from files
+  auto songs = db.search("Beatles");  // simple text search
+  db.createPlaylist("favorites");
+  for (const auto &m : songs)
+    db.addToPlaylist("favorites", m.path);
+  db.recordPlayback(songs.front().path); // update play count
+  db.close();
 }
 ```
 
 `scanDirectory` uses an SQLite UPSERT so rescanning will update metadata for
-existing files automatically.
+existing files automatically. Entries whose files are missing are removed from
+`MediaItem` unless cleanup is disabled.
 
 Other helpers allow updating or removing entries, setting ratings and retrieving the items of a playlist.
 
@@ -83,6 +84,6 @@ Several example tests under `tests/` exercise the library:
 - `library_rating_test.cpp` – rating values
 - `library_search_test.cpp` – search queries
 - `library_video_metadata_test.cpp` – scanning duration and resolution
+- `library_cleanup_test.cpp` – removes stale entries after scanning
 
 Enable tests with `-DBUILD_TESTS=ON` when running CMake to build these executables.
-

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -20,13 +20,13 @@ public:
   bool open();
   void close();
   bool initSchema();
-  bool scanDirectory(const std::string &directory);
+  bool scanDirectory(const std::string &directory, bool cleanup = true);
 
   using ProgressCallback = std::function<void(size_t current, size_t total)>;
   // Scan a directory asynchronously. Progress is reported via the callback and
   // scanning can be cancelled by setting cancelFlag to true.
   std::thread scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
-                                 std::atomic<bool> &cancelFlag);
+                                 std::atomic<bool> &cancelFlag, bool cleanup = true);
 
   // Insert a media entry directly. Useful for tests or manual additions.
   bool addMedia(const std::string &path, const std::string &title, const std::string &artist,
@@ -63,7 +63,7 @@ private:
                    int rating = 0);
   int playlistId(const std::string &name) const;
   bool scanDirectoryImpl(const std::string &directory, ProgressCallback progress,
-                         std::atomic<bool> *cancelFlag);
+                         std::atomic<bool> *cancelFlag, bool cleanup);
 
 private:
   std::string m_path;

--- a/tests/library_cleanup_test.cpp
+++ b/tests/library_cleanup_test.cpp
@@ -1,0 +1,36 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+#include <sqlite3.h>
+
+static int countRows(sqlite3 *db) {
+  sqlite3_stmt *stmt = nullptr;
+  sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM MediaItem;", -1, &stmt, nullptr);
+  int count = 0;
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    count = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+  return count;
+}
+
+int main() {
+  const char *dbPath = "cleanup.db";
+  {
+    mediaplayer::LibraryDB db(dbPath);
+    assert(db.open());
+    assert(db.addMedia("ghost.mp3", "Ghost", "", ""));
+    db.close();
+  }
+
+  mediaplayer::LibraryDB db2(dbPath);
+  assert(db2.open());
+  db2.scanDirectory(".");
+  db2.close();
+
+  sqlite3 *conn = nullptr;
+  sqlite3_open(dbPath, &conn);
+  assert(countRows(conn) == 0);
+  sqlite3_close(conn);
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- track scanned paths in `scanDirectoryImpl`
- remove `MediaItem` rows for files that no longer exist
- allow disabling cleanup via a new parameter
- document the behavior in the library README
- add a small test covering cleanup

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp tests/library_cleanup_test.cpp`
- `g++ -std=c++17 -I./src/library/include -I./src/core/include -c src/library/src/LibraryDB.cpp -o /tmp/db.o` *(fails: libavformat/avformat.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686567a7c0288331bbd08a198e098d75