### PR TITLE
Add AI recommendation hook in LibraryDB

### DIFF
--- a/src/library/include/mediaplayer/AIRecommender.h
+++ b/src/library/include/mediaplayer/AIRecommender.h
@@ -1,0 +1,19 @@
+#ifndef MEDIAPLAYER_AIRECOMMENDER_H
+#define MEDIAPLAYER_AIRECOMMENDER_H
+
+#include <vector>
+
+namespace mediaplayer {
+
+struct MediaMetadata;
+class LibraryDB;
+
+class AIRecommender {
+public:
+  virtual ~AIRecommender() = default;
+  virtual std::vector<MediaMetadata> recommend(const LibraryDB &db) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AIRECOMMENDER_H

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_LIBRARYDB_H
 
 #include "mediaplayer/MediaMetadata.h"
+
 #include <atomic>
 #include <functional>
 #include <mutex>
@@ -11,6 +12,8 @@
 #include <vector>
 
 namespace mediaplayer {
+
+class AIRecommender;
 
 class LibraryDB {
 public:
@@ -57,6 +60,9 @@ public:
   bool removeFromPlaylist(const std::string &name, const std::string &path);
   std::vector<MediaMetadata> playlistItems(const std::string &name);
 
+  void setRecommender(AIRecommender *recommender);
+  std::vector<MediaMetadata> recommendations();
+
 private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
                    const std::string &album, int duration = 0, int width = 0, int height = 0,
@@ -69,6 +75,7 @@ private:
   std::string m_path;
   sqlite3 *m_db{nullptr};
   mutable std::mutex m_mutex;
+  AIRecommender *m_recommender{nullptr};
 };
 
 } // namespace mediaplayer

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -1,4 +1,5 @@
 #include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/AIRecommender.h"
 #include <ctime>
 #include <filesystem>
 #include <iostream>
@@ -447,6 +448,18 @@ int LibraryDB::rating(const std::string &path) const {
     r = sqlite3_column_int(stmt, 0);
   sqlite3_finalize(stmt);
   return r;
+}
+
+void LibraryDB::setRecommender(AIRecommender *recommender) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_recommender = recommender;
+}
+
+std::vector<MediaMetadata> LibraryDB::recommendations() {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_recommender)
+    return m_recommender->recommend(*this);
+  return {};
 }
 
 } // namespace mediaplayer


### PR DESCRIPTION
## Summary
- define new `AIRecommender` interface for future recommendation features
- allow `LibraryDB` to register an `AIRecommender`
- implement `recommendations()` stub that forwards to the AI module

## Testing
- `clang-format -i src/library/include/mediaplayer/AIRecommender.h`
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h`
- `clang-format -i src/library/src/LibraryDB.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6864a0644114833180f3439ef707ab93