### PR TITLE
Add FTS5 search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A detailed breakdown of planned modules and tasks can be found in [Tasks.MD](Tas
 - FFmpeg development libraries
 - Qt 6 development files
 - OpenGL headers and GLFW 3
+- SQLite3 built with FTS5 support
 
 See [docs/building.md](docs/building.md) for a complete build walkthrough,
 including how to compile the sample test programs.
@@ -42,6 +43,8 @@ convert audio files between formats while the subtitles module parses
 SRT files.
 The SQLite-based library tracks media metadata, including an optional rating
 field, and updates play counts when items are played through the core engine.
+Full text search is powered by SQLite's FTS5 module, so ensure your SQLite
+installation includes this extension.
 
 ## Hardware Decoding
 

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -39,8 +39,8 @@ public:
   // Remove a media item from the database by path.
   bool removeMedia(const std::string &path);
 
-  // Search library for items where title, artist or album contain the query
-  // string. Case-insensitive according to SQLite's LIKE operator.
+  // Search library using full text search over title, artist and album.
+  // Powered by SQLite FTS5 and case-insensitive.
   std::vector<MediaMetadata> search(const std::string &query);
 
   // Increment play count and update last played timestamp for a media item.


### PR DESCRIPTION
## Summary
- use SQLite FTS5 virtual table for LibraryDB search
- keep MediaItemFTS table updated via triggers
- query MediaItemFTS in `LibraryDB::search`
- mention FTS5 requirement in README

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a070effc8331894992487c2ec6f1