### PR TITLE
Cleanup missing media on scan

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -49,6 +49,10 @@ if (db.open()) {
 `scanDirectory` uses an SQLite UPSERT so rescanning will update metadata for
 existing files automatically.
 
+During a scan, any `MediaItem` rows whose paths are missing on disk are removed
+from the database. Pass `false` to the optional `cleanup` parameter if you wish
+to keep these old entries.
+
 Other helpers allow updating or removing entries, setting ratings and retrieving the items of a playlist.
 
 `LibraryDB` is now thread-safe. All database operations lock an internal mutex,

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -20,13 +20,13 @@ public:
   bool open();
   void close();
   bool initSchema();
-  bool scanDirectory(const std::string &directory);
+  bool scanDirectory(const std::string &directory, bool cleanup = true);
 
   using ProgressCallback = std::function<void(size_t current, size_t total)>;
   // Scan a directory asynchronously. Progress is reported via the callback and
   // scanning can be cancelled by setting cancelFlag to true.
   std::thread scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
-                                 std::atomic<bool> &cancelFlag);
+                                 std::atomic<bool> &cancelFlag, bool cleanup = true);
 
   // Insert a media entry directly. Useful for tests or manual additions.
   bool addMedia(const std::string &path, const std::string &title, const std::string &artist,
@@ -63,7 +63,7 @@ private:
                    int rating = 0);
   int playlistId(const std::string &name) const;
   bool scanDirectoryImpl(const std::string &directory, ProgressCallback progress,
-                         std::atomic<bool> *cancelFlag);
+                         std::atomic<bool> *cancelFlag, bool cleanup);
 
 private:
   std::string m_path;


### PR DESCRIPTION
## Summary
- track scanned file paths in `scanDirectoryImpl`
- remove `MediaItem` rows for files that no longer exist
- allow disabling cleanup with a `cleanup` parameter
- document scan cleanup in library README

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp src/library/include/mediaplayer/LibraryDB.h`
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a072f30083319e57556a38f9ff65