### PR TITLE
Implement async scan thread management

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -55,6 +55,13 @@ Other helpers allow updating or removing entries, setting ratings and retrieving
 so methods such as `search` and playlist management can be called concurrently
 from multiple threads without corruption.
 
+### Asynchronous scanning
+
+The `scanDirectoryAsync` method starts a background thread that scans files and
+updates the database. The thread handle is stored by the `LibraryDB` instance
+and joined automatically in the destructor. Ensure any outstanding scan is
+finished or cancelled before destroying the object.
+
 ## Dependencies and Building
 
 `LibraryDB` relies on:

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -23,10 +23,11 @@ public:
   bool scanDirectory(const std::string &directory);
 
   using ProgressCallback = std::function<void(size_t current, size_t total)>;
-  // Scan a directory asynchronously. Progress is reported via the callback and
+  // Scan a directory asynchronously. The thread handle is stored internally
+  // and returned by reference. Progress is reported via the callback and
   // scanning can be cancelled by setting cancelFlag to true.
-  std::thread scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
-                                 std::atomic<bool> &cancelFlag);
+  std::thread &scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
+                                  std::atomic<bool> &cancelFlag);
 
   // Insert a media entry directly. Useful for tests or manual additions.
   bool addMedia(const std::string &path, const std::string &title, const std::string &artist,
@@ -69,6 +70,7 @@ private:
   std::string m_path;
   sqlite3 *m_db{nullptr};
   mutable std::mutex m_mutex;
+  std::thread m_scanThread;
 };
 
 } // namespace mediaplayer

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -11,7 +11,11 @@ namespace mediaplayer {
 
 LibraryDB::LibraryDB(const std::string &path) : m_path(path) {}
 
-LibraryDB::~LibraryDB() { close(); }
+LibraryDB::~LibraryDB() {
+  if (m_scanThread.joinable())
+    m_scanThread.join();
+  close();
+}
 
 bool LibraryDB::open() {
   if (sqlite3_open(m_path.c_str(), &m_db) != SQLITE_OK) {
@@ -184,11 +188,14 @@ bool LibraryDB::scanDirectoryImpl(const std::string &directory, ProgressCallback
   return true;
 }
 
-std::thread LibraryDB::scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
-                                          std::atomic<bool> &cancelFlag) {
-  return std::thread([this, directory, progress, &cancelFlag]() {
+std::thread &LibraryDB::scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
+                                           std::atomic<bool> &cancelFlag) {
+  if (m_scanThread.joinable())
+    m_scanThread.join();
+  m_scanThread = std::thread([this, directory, progress, &cancelFlag]() {
     scanDirectoryImpl(directory, progress, &cancelFlag);
   });
+  return m_scanThread;
 }
 
 bool LibraryDB::addMedia(const std::string &path, const std::string &title,


### PR DESCRIPTION
## Summary
- add `m_scanThread` to `LibraryDB` and expose it via `scanDirectoryAsync`
- join running scan thread in `LibraryDB` destructor
- describe asynchronous scanning in library README

## Testing
- `g++ -std=c++17 -I src/library/include -I src/core/include -I/usr/include/taglib -I/usr/include -c src/library/src/LibraryDB.cpp -o /tmp/LibraryDB.o`


------
https://chatgpt.com/codex/tasks/task_e_6864a077d34883318ff1b0b2a02238b9