### PR TITLE
Add added_date to media library

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -21,6 +21,7 @@ before applying the new schema.
   - `width` INTEGER
   - `height` INTEGER
   - `rating` INTEGER
+  - `added_date` INTEGER UNIX timestamp when the item was first added
   - `play_count` INTEGER
   - `last_played` INTEGER
 - **Playlist** — named playlists.


### PR DESCRIPTION
## Summary
- extend the MediaItem table with an `added_date` column
- set `added_date` when inserting new media
- document the new column in library README

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp src/library/include/mediaplayer/LibraryDB.h`

------
https://chatgpt.com/codex/tasks/task_e_6864a07d09288331b14c90716fb07684