### PR TITLE
Enable WAL journal mode for library DB

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -7,6 +7,8 @@ before applying the new schema.
 
 `LibraryDB` is a lightweight wrapper around SQLite that stores metadata for media files and manages user playlists. The database is created on first use and filled by scanning directories with TagLib and FFmpeg to read tags, duration and video resolution. It also records playback statistics such as play count and last played time.
 
+By default the database operates in SQLite's WAL (write-ahead logging) mode to allow concurrent reads and writes. The `LibraryDB::close` method cleans up any `*-wal` journal file when the connection is closed.
+
 ## Database Schema
 
 `LibraryDB` creates three tables:

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -26,6 +26,13 @@ bool LibraryDB::open() {
     m_db = nullptr;
     return false;
   }
+  if (sqlite3_exec(m_db, "PRAGMA journal_mode=WAL;", nullptr, nullptr, &err) != SQLITE_OK) {
+    std::cerr << "Failed to set WAL mode: " << err << '\n';
+    sqlite3_free(err);
+    sqlite3_close(m_db);
+    m_db = nullptr;
+    return false;
+  }
   if (!initSchema()) {
     sqlite3_close(m_db);
     m_db = nullptr;
@@ -38,6 +45,8 @@ void LibraryDB::close() {
   if (m_db) {
     sqlite3_close(m_db);
     m_db = nullptr;
+    std::error_code ec;
+    std::filesystem::remove(m_path + "-wal", ec);
   }
 }
 


### PR DESCRIPTION
## Summary
- set SQLite `journal_mode=WAL` when opening `LibraryDB`
- delete `*-wal` file on close
- document WAL mode usage and cleanup

## Testing
- `cmake -S . -B build && cmake --build build --target mediaplayer_library` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a07227d08331817a7318fac5d459