### PR TITLE
Improve case-insensitive search

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -238,7 +238,9 @@ std::vector<MediaMetadata> LibraryDB::search(const std::string &query) {
     return results;
   std::string pattern = "%" + query + "%";
   const char *sql = "SELECT path,title,artist,album,duration,width,height FROM MediaItem "
-                    "WHERE title LIKE ?1 OR artist LIKE ?1 OR album LIKE ?1 ORDER BY title;";
+                    "WHERE title LIKE ?1 COLLATE NOCASE OR artist LIKE ?1 COLLATE NOCASE OR album "
+                    "LIKE ?1 COLLATE NOCASE "
+                    "ORDER BY title;";
   sqlite3_stmt *stmt = nullptr;
   if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
     return results;

--- a/tests/library_search_test.cpp
+++ b/tests/library_search_test.cpp
@@ -9,11 +9,16 @@ int main() {
   assert(db.addMedia("song1.mp3", "Hello World", "Artist1", "Album1"));
   assert(db.addMedia("song2.mp3", "Goodbye", "Artist2", "Album2"));
   assert(db.addMedia("song3.mp3", "Hello Again", "Artist3", "Album3"));
+  assert(db.addMedia("song4.mp3", u8"こんにちは", "Artist4", "Album4"));
 
   auto resHello = db.search("Hello");
   assert(resHello.size() == 2);
+  auto resLower = db.search("hello");
+  assert(resLower.size() == 2);
   auto resArtist = db.search("Artist2");
   assert(resArtist.size() == 1 && resArtist[0].path == "song2.mp3");
+  auto resUnicode = db.search(u8"こんにちは");
+  assert(resUnicode.size() == 1 && resUnicode[0].path == "song4.mp3");
 
   db.close();
   std::remove(dbPath);


### PR DESCRIPTION
## Summary
- append `COLLATE NOCASE` to each `LIKE` clause in `LibraryDB::search`
- test case-insensitive search with mixed case and Unicode queries

## Testing
- `g++ -std=c++17 -I src/library/include -I src/core/include -c tests/library_search_test.cpp && echo "compile success"`

------
https://chatgpt.com/codex/tasks/task_e_6864a081f1a48331938163fb6233ad24