### PR TITLE
Clarify async library scan usage

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -49,6 +49,10 @@ if (db.open()) {
 `scanDirectory` uses an SQLite UPSERT so rescanning will update metadata for
 existing files automatically.
 
+When scanning in the background with `scanDirectoryAsync` the function returns a
+`std::thread`. Join this thread before destroying the `LibraryDB` object to
+avoid the scan accessing a destroyed instance.
+
 Other helpers allow updating or removing entries, setting ratings and retrieving the items of a playlist.
 
 `LibraryDB` is now thread-safe. All database operations lock an internal mutex,

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -24,7 +24,9 @@ public:
 
   using ProgressCallback = std::function<void(size_t current, size_t total)>;
   // Scan a directory asynchronously. Progress is reported via the callback and
-  // scanning can be cancelled by setting cancelFlag to true.
+  // scanning can be cancelled by setting cancelFlag to true. Callers must join
+  // the returned thread before destroying the LibraryDB object to avoid
+  // accessing it from a dangling background task.
   std::thread scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
                                  std::atomic<bool> &cancelFlag);
 


### PR DESCRIPTION
## Summary
- document that scanDirectoryAsync's thread must be joined before destroying LibraryDB
- add README note about joining the thread in Typical Usage

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h`

------
https://chatgpt.com/codex/tasks/task_e_6864a08122ac8331a86a2a94877f2897