### PR TITLE
Mark LibraryDB threading as done

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -70,7 +70,7 @@
 | 59 | Rating System | done | relevant |
 | 60 | Library-Core Integration | done | relevant |
 | 61 | Expose Library API to UI | open | relevant |
-| 62 | Threading for DB | open | relevant |
+| 62 | Threading for DB | done | relevant |
 | 63 | Smart Playlist Evaluation | open | relevant |
 
 ## Visualization Module (C++17 OpenGL) ([Tasks.MD](../Tasks.MD#visualization-module-c17-opengl))


### PR DESCRIPTION
## Summary
- update docs to mark threading improvements in LibraryDB as complete

## Testing
- `sed -n '72,74p' docs/parallel_tasks.md`

------
https://chatgpt.com/codex/tasks/task_e_6864a05e9e288331afe40b3b485de698