### PR TITLE
Integrate remaining library features

### DIFF
--- a/docs/parallel_tasks.md
+++ b/docs/parallel_tasks.md
@@ -69,7 +69,7 @@
 | 58 | Search Functionality | done | relevant |
 | 59 | Rating System | done | relevant |
 | 60 | Library-Core Integration | done | relevant |
-| 61 | Expose Library API to UI | open | relevant |
+| 61 | Expose Library API to UI | done | LibraryDB access via MediaPlayer |
 | 62 | Threading for DB | done | relevant |
 | 63 | Smart Playlist Evaluation | open | relevant |
 

--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -83,6 +83,11 @@ public:
   void cancelConversion();
   bool conversionCancelled() const { return m_converter.isCancelled(); }
 
+  // Library access helpers
+  std::vector<MediaMetadata> allMedia() const;
+  std::vector<std::string> allPlaylists() const;
+  std::vector<MediaMetadata> playlistItems(const std::string &name) const;
+
 private:
   void demuxLoop();
   void audioLoop();

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -198,6 +198,27 @@ bool MediaPlayer::conversionRunning() const { return m_converter.isRunning(); }
 
 void MediaPlayer::cancelConversion() { m_converter.cancel(); }
 
+std::vector<MediaMetadata> MediaPlayer::allMedia() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_library)
+    return m_library->allMedia();
+  return {};
+}
+
+std::vector<std::string> MediaPlayer::allPlaylists() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_library)
+    return m_library->allPlaylists();
+  return {};
+}
+
+std::vector<MediaMetadata> MediaPlayer::playlistItems(const std::string &name) const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_library)
+    return m_library->playlistItems(name);
+  return {};
+}
+
 void MediaPlayer::setAudioOutput(std::unique_ptr<AudioOutput> output) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_output) {

--- a/src/library/include/mediaplayer/AIRecommender.h
+++ b/src/library/include/mediaplayer/AIRecommender.h
@@ -1,0 +1,19 @@
+#ifndef MEDIAPLAYER_AIRECOMMENDER_H
+#define MEDIAPLAYER_AIRECOMMENDER_H
+
+#include <vector>
+
+namespace mediaplayer {
+
+struct MediaMetadata;
+class LibraryDB;
+
+class AIRecommender {
+public:
+  virtual ~AIRecommender() = default;
+  virtual std::vector<MediaMetadata> recommend(const LibraryDB &db) = 0;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AIRECOMMENDER_H

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -1,4 +1,5 @@
 #include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/AIRecommender.h"
 #include <ctime>
 #include <filesystem>
 #include <iostream>
@@ -12,11 +13,7 @@ namespace mediaplayer {
 
 LibraryDB::LibraryDB(const std::string &path) : m_path(path) {}
 
-LibraryDB::~LibraryDB() {
-  if (m_scanThread.joinable())
-    m_scanThread.join();
-  close();
-}
+LibraryDB::~LibraryDB() { close(); }
 
 bool LibraryDB::open() {
   if (sqlite3_open(m_path.c_str(), &m_db) != SQLITE_OK) {
@@ -66,6 +63,7 @@ bool LibraryDB::initSchema() {
                     "width INTEGER DEFAULT 0,"
                     "height INTEGER DEFAULT 0,"
                     "rating INTEGER DEFAULT 0,"
+                    "added_date INTEGER DEFAULT 0,"
                     "play_count INTEGER DEFAULT 0,"
                     "last_played INTEGER"
                     ");"
@@ -102,6 +100,17 @@ bool LibraryDB::initSchema() {
     return false;
   }
 
+  const char *alterSql = "ALTER TABLE MediaItem ADD COLUMN added_date INTEGER DEFAULT 0;";
+  if (sqlite3_exec(m_db, alterSql, nullptr, nullptr, &err) != SQLITE_OK) {
+    std::string msg = err ? err : "";
+    if (msg.find("duplicate column name") == std::string::npos) {
+      std::cerr << "Failed to alter table: " << msg << '\n';
+      sqlite3_free(err);
+      return false;
+    }
+    sqlite3_free(err);
+  }
+
   const char *ftsSql =
       "CREATE VIRTUAL TABLE IF NOT EXISTS MediaItemFTS USING fts5(path,title,artist,album);"
       "CREATE TRIGGER IF NOT EXISTS mediaitem_ai AFTER INSERT ON MediaItem BEGIN "
@@ -130,12 +139,12 @@ bool LibraryDB::insertMedia(const std::string &path, const std::string &title,
                             const std::string &artist, const std::string &album, int duration,
                             int width, int height, int rating) {
   std::lock_guard<std::mutex> lock(m_mutex);
-  const char *sql =
-      "INSERT INTO MediaItem (path, title, artist, album, duration, width, height, rating) "
-      "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) "
-      "ON CONFLICT(path) DO UPDATE SET "
-      "title=excluded.title, artist=excluded.artist, album=excluded.album, "
-      "duration=excluded.duration, width=excluded.width, height=excluded.height;";
+  const char *sql = "INSERT INTO MediaItem (path, title, artist, album, duration, width, height, "
+                    "rating, added_date) "
+                    "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) "
+                    "ON CONFLICT(path) DO UPDATE SET "
+                    "title=excluded.title, artist=excluded.artist, album=excluded.album, "
+                    "duration=excluded.duration, width=excluded.width, height=excluded.height;";
   sqlite3_stmt *stmt = nullptr;
   if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
     return false;
@@ -148,123 +157,147 @@ bool LibraryDB::insertMedia(const std::string &path, const std::string &title,
   sqlite3_bind_int(stmt, 6, width);
   sqlite3_bind_int(stmt, 7, height);
   sqlite3_bind_int(stmt, 8, rating);
+  sqlite3_bind_int64(stmt, 9, static_cast<sqlite3_int64>(time(nullptr)));
   bool ok = sqlite3_step(stmt) == SQLITE_DONE;
   sqlite3_finalize(stmt);
   return ok;
 }
 
-bool LibraryDB::scanDirectory(const std::string &directory) {
-  return scanDirectoryImpl(directory, nullptr, nullptr);
+bool LibraryDB::scanDirectory(const std::string &directory, bool cleanup) {
+  return scanDirectoryImpl(directory, nullptr, nullptr, cleanup);
 }
 
 bool LibraryDB::scanDirectoryImpl(const std::string &directory, ProgressCallback progress,
-                                  std::atomic<bool> *cancelFlag) {
+                                  std::atomic<bool> *cancelFlag, bool cleanup) {
   namespace fs = std::filesystem;
   if (!m_db)
     return false;
 
-  std::unordered_set<std::string> found;
+  std::unordered_set<std::string> seen;
 
   size_t total = 0;
-  for (auto const &entry : fs::recursive_directory_iterator(directory)) {
-    if (entry.is_regular_file())
-      ++total;
+  try {
+    std::error_code ec;
+    fs::recursive_directory_iterator it(directory, fs::directory_options::skip_permission_denied,
+                                        ec);
+    fs::recursive_directory_iterator end;
+    for (; it != end; it.increment(ec)) {
+      if (ec) {
+        std::cerr << "Directory iteration error: " << ec.message() << '\n';
+        ec.clear();
+        continue;
+      }
+      try {
+        if (it->is_regular_file())
+          ++total;
+      } catch (const fs::filesystem_error &e) {
+        std::cerr << "Filesystem error: " << e.what() << '\n';
+      }
+    }
+  } catch (const fs::filesystem_error &e) {
+    std::cerr << "Filesystem error: " << e.what() << '\n';
   }
 
   size_t processed = 0;
-  for (auto const &entry : fs::recursive_directory_iterator(directory)) {
-    if (cancelFlag && cancelFlag->load())
-      break;
-    if (!entry.is_regular_file())
-      continue;
-    auto pathStr = entry.path().string();
-    TagLib::FileRef f(pathStr.c_str());
-    std::string title;
-    std::string artist;
-    std::string album;
-    bool tagOk = false;
-    if (!f.isNull()) {
-      tagOk = f.tag() || f.audioProperties();
-      if (f.tag()) {
-        title = f.tag()->title().to8Bit(true);
-        artist = f.tag()->artist().to8Bit(true);
-        album = f.tag()->album().to8Bit(true);
+  try {
+    std::error_code ec;
+    fs::recursive_directory_iterator it(directory, fs::directory_options::skip_permission_denied,
+                                        ec);
+    fs::recursive_directory_iterator end;
+    for (; it != end; it.increment(ec)) {
+      if (ec) {
+        std::cerr << "Directory iteration error: " << ec.message() << '\n';
+        ec.clear();
+        continue;
       }
-    }
-    if (title.empty())
-      title = entry.path().filename().string();
+      if (cancelFlag && cancelFlag->load())
+        break;
+      try {
+        if (!it->is_regular_file())
+          continue;
+      } catch (const fs::filesystem_error &e) {
+        std::cerr << "Filesystem error: " << e.what() << '\n';
+        continue;
+      }
 
-    int duration = 0;
-    int width = 0;
-    int height = 0;
-    AVFormatContext *ctx = nullptr;
-    bool ffOk = false;
-    if (avformat_open_input(&ctx, pathStr.c_str(), nullptr, nullptr) == 0) {
-      if (avformat_find_stream_info(ctx, nullptr) >= 0) {
-        ffOk = true;
-        if (ctx->duration > 0)
-          duration = static_cast<int>(ctx->duration / AV_TIME_BASE);
-        for (unsigned i = 0; i < ctx->nb_streams; ++i) {
-          AVStream *st = ctx->streams[i];
-          if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
-            width = st->codecpar->width;
-            height = st->codecpar->height;
-            break;
-          }
+      auto pathStr = it->path().string();
+      seen.insert(pathStr);
+      TagLib::FileRef f(pathStr.c_str());
+      std::string title;
+      std::string artist;
+      std::string album;
+      bool tagOk = false;
+      if (!f.isNull()) {
+        tagOk = f.tag() || f.audioProperties();
+        if (f.tag()) {
+          title = f.tag()->title().to8Bit(true);
+          artist = f.tag()->artist().to8Bit(true);
+          album = f.tag()->album().to8Bit(true);
         }
       }
-      avformat_close_input(&ctx);
+      if (title.empty())
+        title = it->path().filename().string();
+
+      int duration = 0;
+      int width = 0;
+      int height = 0;
+      AVFormatContext *ctx = nullptr;
+      bool ffOk = false;
+      if (avformat_open_input(&ctx, pathStr.c_str(), nullptr, nullptr) == 0) {
+        if (avformat_find_stream_info(ctx, nullptr) >= 0) {
+          ffOk = true;
+          if (ctx->duration > 0)
+            duration = static_cast<int>(ctx->duration / AV_TIME_BASE);
+          for (unsigned i = 0; i < ctx->nb_streams; ++i) {
+            AVStream *st = ctx->streams[i];
+            if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
+              width = st->codecpar->width;
+              height = st->codecpar->height;
+              break;
+            }
+          }
+        }
+        avformat_close_input(&ctx);
+      }
+      if (tagOk || ffOk)
+        insertMedia(pathStr, title, artist, album, duration, width, height, 0);
+      ++processed;
+      if (progress)
+        progress(processed, total);
     }
-    if (tagOk || ffOk) {
-      insertMedia(pathStr, title, artist, album, duration, width, height, 0);
-      found.insert(pathStr);
-    }
-    ++processed;
-    if (progress)
-      progress(processed, total);
+  } catch (const fs::filesystem_error &e) {
+    std::cerr << "Filesystem error: " << e.what() << '\n';
   }
 
-  bool cancelled = cancelFlag && cancelFlag->load();
-  if (!cancelled) {
-    std::vector<std::string> toDelete;
+  if (cleanup) {
+    std::vector<std::string> dbPaths;
     {
       std::lock_guard<std::mutex> lock(m_mutex);
-      std::string prefix = directory;
-      if (prefix == ".")
-        prefix.clear();
-      if (!prefix.empty() && prefix.back() != '/' && prefix.back() != '\\')
-        prefix += '/';
-      std::string likeArg = prefix + "%";
-      const char *sql = "SELECT path FROM MediaItem WHERE path LIKE ?1;";
+      const char *sql = "SELECT path FROM MediaItem;";
       sqlite3_stmt *stmt = nullptr;
       if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) == SQLITE_OK) {
-        sqlite3_bind_text(stmt, 1, likeArg.c_str(), -1, SQLITE_TRANSIENT);
         while (sqlite3_step(stmt) == SQLITE_ROW) {
           const unsigned char *txt = sqlite3_column_text(stmt, 0);
-          if (txt) {
-            std::string p = reinterpret_cast<const char *>(txt);
-            if (!found.count(p))
-              toDelete.push_back(p);
-          }
+          if (txt)
+            dbPaths.emplace_back(reinterpret_cast<const char *>(txt));
         }
         sqlite3_finalize(stmt);
       }
     }
-    for (const auto &p : toDelete)
-      removeMedia(p);
+    for (const auto &p : dbPaths) {
+      if (seen.find(p) == seen.end())
+        removeMedia(p);
+    }
   }
 
   return true;
 }
 
-std::thread &LibraryDB::scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
-                                           std::atomic<bool> &cancelFlag) {
-  if (m_scanThread.joinable())
-    m_scanThread.join();
-  m_scanThread = std::thread([this, directory, progress, &cancelFlag]() {
-    scanDirectoryImpl(directory, progress, &cancelFlag);
+std::thread LibraryDB::scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
+                                          std::atomic<bool> &cancelFlag, bool cleanup) {
+  return std::thread([this, directory, progress, &cancelFlag, cleanup]() {
+    scanDirectoryImpl(directory, progress, &cancelFlag, cleanup);
   });
-  return m_scanThread;
 }
 
 bool LibraryDB::addMedia(const std::string &path, const std::string &title,
@@ -324,13 +357,15 @@ std::vector<MediaMetadata> LibraryDB::search(const std::string &query) {
   std::vector<MediaMetadata> results;
   if (!m_db)
     return results;
-  const char *sql = "SELECT m.path,m.title,m.artist,m.album,m.duration,m.width,m.height "
-                    "FROM MediaItem m JOIN MediaItemFTS f ON m.id=f.rowid "
-                    "WHERE f MATCH ?1 ORDER BY m.title;";
+  std::string pattern = "%" + query + "%";
+  const char *sql = "SELECT path,title,artist,album,duration,width,height FROM MediaItem "
+                    "WHERE title LIKE ?1 COLLATE NOCASE OR artist LIKE ?1 COLLATE NOCASE OR album "
+                    "LIKE ?1 COLLATE NOCASE "
+                    "ORDER BY title;";
   sqlite3_stmt *stmt = nullptr;
   if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
     return results;
-  sqlite3_bind_text(stmt, 1, query.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 1, pattern.c_str(), -1, SQLITE_TRANSIENT);
   while (sqlite3_step(stmt) == SQLITE_ROW) {
     MediaMetadata m{};
     const unsigned char *txt = nullptr;
@@ -632,6 +667,137 @@ std::vector<MediaMetadata> LibraryDB::playlistItems(const std::string &name) {
   }
   sqlite3_finalize(stmt);
   return items;
+}
+
+std::vector<MediaMetadata> LibraryDB::allMedia() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<MediaMetadata> items;
+  if (!m_db)
+    return items;
+  const char *sql =
+      "SELECT path,title,artist,album,duration,width,height FROM MediaItem ORDER BY title;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return items;
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    MediaMetadata m{};
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      m.path = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 1);
+    if (txt)
+      m.title = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 2);
+    if (txt)
+      m.artist = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 3);
+    if (txt)
+      m.album = reinterpret_cast<const char *>(txt);
+    m.duration = sqlite3_column_int(stmt, 4);
+    m.width = sqlite3_column_int(stmt, 5);
+    m.height = sqlite3_column_int(stmt, 6);
+    items.push_back(std::move(m));
+  }
+  sqlite3_finalize(stmt);
+  return items;
+}
+
+std::vector<std::string> LibraryDB::allPlaylists() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<std::string> names;
+  if (!m_db)
+    return names;
+  const char *sql = "SELECT name FROM Playlist ORDER BY name;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return names;
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      names.emplace_back(reinterpret_cast<const char *>(txt));
+  }
+  sqlite3_finalize(stmt);
+  return names;
+}
+
+std::vector<MediaMetadata> LibraryDB::recentlyAdded(int limit) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<MediaMetadata> items;
+  if (!m_db)
+    return items;
+  const char *sql = "SELECT path,title,artist,album,duration,width,height FROM MediaItem ORDER BY "
+                    "last_played DESC LIMIT ?1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return items;
+  sqlite3_bind_int(stmt, 1, limit);
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    MediaMetadata m{};
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      m.path = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 1);
+    if (txt)
+      m.title = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 2);
+    if (txt)
+      m.artist = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 3);
+    if (txt)
+      m.album = reinterpret_cast<const char *>(txt);
+    m.duration = sqlite3_column_int(stmt, 4);
+    m.width = sqlite3_column_int(stmt, 5);
+    m.height = sqlite3_column_int(stmt, 6);
+    items.push_back(std::move(m));
+  }
+  sqlite3_finalize(stmt);
+  return items;
+}
+
+std::vector<MediaMetadata> LibraryDB::mostPlayed(int limit) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  std::vector<MediaMetadata> items;
+  if (!m_db)
+    return items;
+  const char *sql = "SELECT path,title,artist,album,duration,width,height FROM MediaItem ORDER BY "
+                    "play_count DESC LIMIT ?1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return items;
+  sqlite3_bind_int(stmt, 1, limit);
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    MediaMetadata m{};
+    const unsigned char *txt = sqlite3_column_text(stmt, 0);
+    if (txt)
+      m.path = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 1);
+    if (txt)
+      m.title = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 2);
+    if (txt)
+      m.artist = reinterpret_cast<const char *>(txt);
+    txt = sqlite3_column_text(stmt, 3);
+    if (txt)
+      m.album = reinterpret_cast<const char *>(txt);
+    m.duration = sqlite3_column_int(stmt, 4);
+    m.width = sqlite3_column_int(stmt, 5);
+    m.height = sqlite3_column_int(stmt, 6);
+    items.push_back(std::move(m));
+  }
+  sqlite3_finalize(stmt);
+  return items;
+}
+
+void LibraryDB::setRecommender(AIRecommender *recommender) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_recommender = recommender;
+}
+
+std::vector<MediaMetadata> LibraryDB::recommendations() {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_recommender)
+    return m_recommender->recommend(*this);
+  return {};
 }
 
 bool LibraryDB::setRating(const std::string &path, int rating) {

--- a/tests/library_cleanup_test.cpp
+++ b/tests/library_cleanup_test.cpp
@@ -1,0 +1,36 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+#include <sqlite3.h>
+
+static int countRows(sqlite3 *db) {
+  sqlite3_stmt *stmt = nullptr;
+  sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM MediaItem;", -1, &stmt, nullptr);
+  int count = 0;
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    count = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+  return count;
+}
+
+int main() {
+  const char *dbPath = "cleanup.db";
+  {
+    mediaplayer::LibraryDB db(dbPath);
+    assert(db.open());
+    assert(db.addMedia("ghost.mp3", "Ghost", "", ""));
+    db.close();
+  }
+
+  mediaplayer::LibraryDB db2(dbPath);
+  assert(db2.open());
+  db2.scanDirectory(".");
+  db2.close();
+
+  sqlite3 *conn = nullptr;
+  sqlite3_open(dbPath, &conn);
+  assert(countRows(conn) == 0);
+  sqlite3_close(conn);
+  std::remove(dbPath);
+  return 0;
+}

--- a/tests/library_search_test.cpp
+++ b/tests/library_search_test.cpp
@@ -9,11 +9,16 @@ int main() {
   assert(db.addMedia("song1.mp3", "Hello World", "Artist1", "Album1"));
   assert(db.addMedia("song2.mp3", "Goodbye", "Artist2", "Album2"));
   assert(db.addMedia("song3.mp3", "Hello Again", "Artist3", "Album3"));
+  assert(db.addMedia("song4.mp3", u8"こんにちは", "Artist4", "Album4"));
 
   auto resHello = db.search("Hello");
   assert(resHello.size() == 2);
+  auto resLower = db.search("hello");
+  assert(resLower.size() == 2);
   auto resArtist = db.search("Artist2");
   assert(resArtist.size() == 1 && resArtist[0].path == "song2.mp3");
+  auto resUnicode = db.search(u8"こんにちは");
+  assert(resUnicode.size() == 1 && resUnicode[0].path == "song4.mp3");
 
   db.close();
   std::remove(dbPath);


### PR DESCRIPTION
## Summary
- add AIRecommender interface
- expose library queries via MediaPlayer
- extend LibraryDB API and schema (cleanup, added_date, helper queries)
- improve scanning and search behaviour
- update docs and tests

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp src/library/include/mediaplayer/LibraryDB.h src/library/include/mediaplayer/AIRecommender.h tests/library_cleanup_test.cpp tests/library_search_test.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68656eb4259c8331b576352ea883a360