### PR TITLE
Implement cross-device sync module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ add_subdirectory(src/format_conversion)
 
 add_subdirectory(src/desktop)
 
+# Sync module for cross-device playback position sharing
+add_subdirectory(src/sync)
+
 # Optionally add other modules later
 add_subdirectory(src/visualization)
 

--- a/src/sync/CMakeLists.txt
+++ b/src/sync/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(mediaplayer_sync
+    src/SyncService.cpp
+)
+
+set_target_properties(mediaplayer_sync PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+target_include_directories(mediaplayer_sync PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)

--- a/src/sync/README.md
+++ b/src/sync/README.md
@@ -1,1 +1,29 @@
 # Cross-Device Sync
+
+This module provides lightweight discovery and sync of playback position over the local network.
+It uses UDP broadcast for discovery and a simple message protocol for control.
+
+## Usage
+
+Run `SyncService` in each instance of the player:
+
+```cpp
+mediaplayer::SyncService service("DesktopPlayer");
+service.start();
+service.setStatus(currentPath, currentPosition);
+service.setSyncCallback([](const std::string &path, double pos) {
+    // load `path` and seek to `pos`
+});
+```
+
+To discover devices and send them the current status:
+
+```cpp
+mediaplayer::SyncClient client;
+auto devices = client.discover();
+for (const auto &d : devices) {
+    client.sendSync(d, currentPath, currentPosition);
+}
+```
+
+`DeviceInfo` reports the name, address and last advertised media.

--- a/src/sync/include/mediaplayer/SyncService.h
+++ b/src/sync/include/mediaplayer/SyncService.h
@@ -1,0 +1,57 @@
+#ifndef MEDIAPLAYER_SYNCSERVICE_H
+#define MEDIAPLAYER_SYNCSERVICE_H
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace mediaplayer {
+
+struct DeviceInfo {
+  std::string name;
+  std::string address;
+  uint16_t port{0};
+  std::string path;
+  double position{0.0};
+};
+
+class SyncService {
+public:
+  explicit SyncService(const std::string &name, uint16_t port = 56790);
+  ~SyncService();
+
+  bool start();
+  void stop();
+
+  void setStatus(const std::string &path, double position);
+  void setSyncCallback(std::function<void(const std::string &path, double position)> cb);
+
+private:
+  void run();
+  int m_sock{-1};
+  std::string m_name;
+  uint16_t m_port;
+  std::string m_path;
+  double m_position{0.0};
+  std::thread m_thread;
+  std::atomic<bool> m_running{false};
+  std::function<void(const std::string &, double)> m_syncCallback;
+};
+
+class SyncClient {
+public:
+  explicit SyncClient(uint16_t port = 56790);
+  std::vector<DeviceInfo>
+  discover(std::chrono::milliseconds timeout = std::chrono::milliseconds(500));
+  bool sendSync(const DeviceInfo &device, const std::string &path, double position);
+
+private:
+  uint16_t m_port;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_SYNCSERVICE_H

--- a/src/sync/src/SyncService.cpp
+++ b/src/sync/src/SyncService.cpp
@@ -1,0 +1,189 @@
+#include "mediaplayer/SyncService.h"
+
+#include <cstring>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace mediaplayer {
+
+static int closeSocket(int s) {
+#ifdef _WIN32
+  return closesocket(s);
+#else
+  return close(s);
+#endif
+}
+
+SyncService::SyncService(const std::string &name, uint16_t port) : m_name(name), m_port(port) {}
+
+SyncService::~SyncService() { stop(); }
+
+bool SyncService::start() {
+#ifdef _WIN32
+  WSADATA wsaData;
+  WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif
+  m_sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (m_sock < 0)
+    return false;
+  int opt = 1;
+  setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, (char *)&opt, sizeof(opt));
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(m_port);
+  if (bind(m_sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+    closeSocket(m_sock);
+    m_sock = -1;
+    return false;
+  }
+  m_running = true;
+  m_thread = std::thread(&SyncService::run, this);
+  return true;
+}
+
+void SyncService::stop() {
+  m_running = false;
+  if (m_sock >= 0) {
+    closeSocket(m_sock);
+    m_sock = -1;
+  }
+  if (m_thread.joinable())
+    m_thread.join();
+#ifdef _WIN32
+  WSACleanup();
+#endif
+}
+
+void SyncService::setStatus(const std::string &path, double position) {
+  m_path = path;
+  m_position = position;
+}
+
+void SyncService::setSyncCallback(std::function<void(const std::string &, double)> cb) {
+  m_syncCallback = std::move(cb);
+}
+
+void SyncService::run() {
+  char buf[1024];
+  while (m_running) {
+    sockaddr_in src{};
+    socklen_t srclen = sizeof(src);
+    int n = recvfrom(m_sock, buf, sizeof(buf) - 1, 0, reinterpret_cast<sockaddr *>(&src), &srclen);
+    if (n <= 0)
+      continue;
+    buf[n] = '\0';
+    std::string msg(buf);
+    if (msg == "DISCOVER") {
+      char out[1024];
+      snprintf(out, sizeof(out), "DEVICE|%s|%u|%s|%f", m_name.c_str(), m_port, m_path.c_str(),
+               m_position);
+      sendto(m_sock, out, strlen(out), 0, reinterpret_cast<sockaddr *>(&src), srclen);
+    } else if (msg.rfind("PLAY|", 0) == 0) {
+      size_t p1 = msg.find('|', 5);
+      if (p1 == std::string::npos)
+        continue;
+      std::string path = msg.substr(5, p1 - 5);
+      double pos = atof(msg.c_str() + p1 + 1);
+      if (m_syncCallback)
+        m_syncCallback(path, pos);
+    }
+  }
+}
+
+SyncClient::SyncClient(uint16_t port) : m_port(port) {}
+
+std::vector<DeviceInfo> SyncClient::discover(std::chrono::milliseconds timeout) {
+#ifdef _WIN32
+  WSADATA wsaData;
+  WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif
+  int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0)
+    return {};
+  int broadcast = 1;
+  setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (char *)&broadcast, sizeof(broadcast));
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(m_port);
+  addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+
+  const char *req = "DISCOVER";
+  sendto(sock, req, strlen(req), 0, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+
+  struct timeval tv;
+  tv.tv_sec = static_cast<long>(timeout.count() / 1000);
+  tv.tv_usec = static_cast<long>((timeout.count() % 1000) * 1000);
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
+
+  std::vector<DeviceInfo> devices;
+  char buf[1024];
+  while (true) {
+    sockaddr_in src{};
+    socklen_t srclen = sizeof(src);
+    int n = recvfrom(sock, buf, sizeof(buf) - 1, 0, reinterpret_cast<sockaddr *>(&src), &srclen);
+    if (n <= 0)
+      break;
+    buf[n] = '\0';
+    std::string msg(buf);
+    if (msg.rfind("DEVICE|", 0) == 0) {
+      DeviceInfo info;
+      size_t p1 = msg.find('|', 7);
+      size_t p2 = msg.find('|', p1 + 1);
+      size_t p3 = msg.find('|', p2 + 1);
+      if (p1 == std::string::npos || p2 == std::string::npos)
+        continue;
+      info.name = msg.substr(7, p1 - 7);
+      info.port = static_cast<uint16_t>(atoi(msg.c_str() + p1 + 1));
+      if (p3 != std::string::npos) {
+        info.path = msg.substr(p2 + 1, p3 - p2 - 1);
+        info.position = atof(msg.c_str() + p3 + 1);
+      } else {
+        info.path = msg.substr(p2 + 1);
+        info.position = 0.0;
+      }
+      char ip[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, &src.sin_addr, ip, sizeof(ip));
+      info.address = ip;
+      devices.push_back(std::move(info));
+    }
+  }
+  closeSocket(sock);
+#ifdef _WIN32
+  WSACleanup();
+#endif
+  return devices;
+}
+
+bool SyncClient::sendSync(const DeviceInfo &device, const std::string &path, double position) {
+#ifdef _WIN32
+  WSADATA wsaData;
+  WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif
+  int sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0)
+    return false;
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(device.port);
+  inet_pton(AF_INET, device.address.c_str(), &addr.sin_addr);
+  char msg[1024];
+  snprintf(msg, sizeof(msg), "PLAY|%s|%f", path.c_str(), position);
+  int ret = sendto(sock, msg, strlen(msg), 0, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+  closeSocket(sock);
+#ifdef _WIN32
+  WSACleanup();
+#endif
+  return ret >= 0;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `mediaplayer_sync` library providing UDP broadcast discovery and sync
- document module usage
- hook up module in root CMake configuration

## Testing
- `clang-format -i src/sync/include/mediaplayer/SyncService.h src/sync/src/SyncService.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6865761cfbfc8331b2e9b9fa8a3795c3