### PR TITLE
Implement genre and playlist helper

### DIFF
--- a/src/core/include/mediaplayer/MediaMetadata.h
+++ b/src/core/include/mediaplayer/MediaMetadata.h
@@ -10,6 +10,7 @@ struct MediaMetadata {
   std::string title;    // Title (from tags or file name)
   std::string artist;   // Artist if available
   std::string album;    // Album if available
+  std::string genre;    // Genre if available
   double duration{0.0}; // In seconds
   int width{0};         // Video width, 0 for audio-only
   int height{0};        // Video height

--- a/src/library/README.md
+++ b/src/library/README.md
@@ -1,4 +1,4 @@
-# Media Library & Playlists
+#Media Library &Playlists
 
 The library database creates `MediaItem`, `Playlist` and `PlaylistItem` tables.
 The `PlaylistItem` table now enforces a `UNIQUE(playlist_id, path)` constraint.
@@ -19,6 +19,7 @@ By default the database operates in SQLite's WAL (write-ahead logging) mode to a
   - `title` TEXT
   - `artist` TEXT
   - `album` TEXT
+  - `genre` TEXT
   - `duration` INTEGER
   - `width` INTEGER
   - `height` INTEGER
@@ -39,15 +40,15 @@ By default the database operates in SQLite's WAL (write-ahead logging) mode to a
 ```cpp
 mediaplayer::LibraryDB db("library.db");
 if (db.open()) {
-    db.scanDirectory("/path/to/music"); // populate from files
-    auto songs = db.search("Beatles");  // simple text search
-    db.createPlaylist("favorites");
-    for (const auto &m : songs)
-        db.addToPlaylist("favorites", m.path);
-    db.recordPlayback(songs.front().path); // update play count
-    auto recent = db.recentlyAdded(5);    // top 5 recently played
-    auto popular = db.mostPlayed(5);      // top 5 most played
-    db.close();
+  db.scanDirectory("/path/to/music"); // populate from files
+  auto songs = db.search("Beatles");  // simple text search
+  db.createPlaylist("favorites");
+  for (const auto &m : songs)
+    db.addToPlaylist("favorites", m.path);
+  db.recordPlayback(songs.front().path); // update play count
+  auto recent = db.recentlyAdded(5);     // top 5 recently played
+  auto popular = db.mostPlayed(5);       // top 5 most played
+  db.close();
 }
 ```
 
@@ -107,4 +108,3 @@ Several example tests under `tests/` exercise the library:
 - `library_video_metadata_test.cpp` – scanning duration and resolution
 
 Enable tests with `-DBUILD_TESTS=ON` when running CMake to build these executables.
-

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_LIBRARYDB_H
 
 #include "mediaplayer/MediaMetadata.h"
+#include "mediaplayer/Playlist.h"
 #include <atomic>
 #include <functional>
 #include <mutex>
@@ -33,11 +34,11 @@ public:
 
   // Insert a media entry directly. Useful for tests or manual additions.
   bool addMedia(const std::string &path, const std::string &title, const std::string &artist,
-                const std::string &album);
+                const std::string &album, const std::string &genre = "");
 
   // Update metadata for an existing media entry identified by path.
   bool updateMedia(const std::string &path, const std::string &title, const std::string &artist,
-                   const std::string &album);
+                   const std::string &album, const std::string &genre = "");
 
   // Remove a media item from the database by path.
   bool removeMedia(const std::string &path);
@@ -64,6 +65,8 @@ public:
   bool addToPlaylist(const std::string &name, const std::string &path);
   bool removeFromPlaylist(const std::string &name, const std::string &path);
   std::vector<MediaMetadata> playlistItems(const std::string &name);
+  Playlist loadPlaylist(const std::string &name);
+  bool savePlaylist(const Playlist &playlist);
 
   // Smart playlists
   bool createSmartPlaylist(const std::string &name, const std::string &filter);
@@ -87,8 +90,8 @@ public:
 
 private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
-                   const std::string &album, int duration = 0, int width = 0, int height = 0,
-                   int rating = 0);
+                   const std::string &album, const std::string &genre, int duration = 0,
+                   int width = 0, int height = 0, int rating = 0);
   int playlistId(const std::string &name) const;
   bool scanDirectoryImpl(const std::string &directory, ProgressCallback progress,
                          std::atomic<bool> *cancelFlag, bool cleanup);

--- a/src/library/include/mediaplayer/Playlist.h
+++ b/src/library/include/mediaplayer/Playlist.h
@@ -1,0 +1,17 @@
+#ifndef MEDIAPLAYER_PLAYLIST_H
+#define MEDIAPLAYER_PLAYLIST_H
+
+#include "mediaplayer/MediaMetadata.h"
+#include <string>
+#include <vector>
+
+namespace mediaplayer {
+
+struct Playlist {
+  std::string name;
+  std::vector<MediaMetadata> items;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_PLAYLIST_H


### PR DESCRIPTION
## Summary
- extend `MediaMetadata` with a `genre` field
- support `genre` column in LibraryDB schema and queries
- fix `recentlyAdded` ordering by `added_date`
- add `Playlist` struct and load/save helpers
- document new `genre` field in library README

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_686586dca4b48331b1174a49d0e68374