### PR TITLE
Add RandomRecommender stub

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mediaplayer_library
     src/LibraryDB.cpp
+    src/RandomRecommender.cpp
 )
 
 find_package(PkgConfig)

--- a/src/library/README.md
+++ b/src/library/README.md
@@ -78,6 +78,19 @@ re-evaluates all smart playlists whenever metadata changes. Convenience methods
 `recentlyAdded()` and `mostPlayed()` return dynamic lists of recent or popular
 items without storing them as playlists.
 
+### AI recommendations
+
+`LibraryDB` can accept custom recommendation algorithms through the
+`AIRecommender` interface. Use `setRecommender()` to attach an implementation.
+The provided `RandomRecommender` selects a random subset of the library and is
+useful as a lightweight example.
+
+```cpp
+mediaplayer::RandomRecommender rec(5);
+db.setRecommender(&rec);
+auto picks = db.recommendations();
+```
+
 ## Dependencies and Building
 
 `LibraryDB` relies on:

--- a/src/library/include/mediaplayer/RandomRecommender.h
+++ b/src/library/include/mediaplayer/RandomRecommender.h
@@ -1,0 +1,21 @@
+#ifndef MEDIAPLAYER_RANDOMRECOMMENDER_H
+#define MEDIAPLAYER_RANDOMRECOMMENDER_H
+
+#include "mediaplayer/AIRecommender.h"
+#include <random>
+
+namespace mediaplayer {
+
+class RandomRecommender : public AIRecommender {
+public:
+  explicit RandomRecommender(size_t count = 10);
+  std::vector<MediaMetadata> recommend(const LibraryDB &db) override;
+
+private:
+  size_t m_count;
+  std::mt19937 m_rng{std::random_device{}()};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_RANDOMRECOMMENDER_H

--- a/src/library/src/RandomRecommender.cpp
+++ b/src/library/src/RandomRecommender.cpp
@@ -1,0 +1,18 @@
+#include "mediaplayer/RandomRecommender.h"
+#include "mediaplayer/LibraryDB.h"
+#include <algorithm>
+
+namespace mediaplayer {
+
+RandomRecommender::RandomRecommender(size_t count) : m_count(count) {}
+
+std::vector<MediaMetadata> RandomRecommender::recommend(const LibraryDB &db) {
+  auto all = db.allMedia();
+  if (all.size() <= m_count)
+    return all;
+  std::shuffle(all.begin(), all.end(), m_rng);
+  all.resize(m_count);
+  return all;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add a `RandomRecommender` class implementing `AIRecommender`
- compile the stub in `mediaplayer_library`
- document attaching a recommender in library README

## Testing
- `clang-format -i include/mediaplayer/RandomRecommender.h src/RandomRecommender.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6865895a59e48331818405a2507545d7