### PR TITLE
Add simple AI recommendation stub

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,28 +1,19 @@
-add_library(mediaplayer_library
-    src/LibraryDB.cpp
-)
+add_library(mediaplayer_library src / LibraryDB.cpp src / RandomAIRecommender.cpp)
 
-find_package(PkgConfig)
-pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
-pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
-pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil)
+    find_package(PkgConfig) pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
+        pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
+            pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil)
 
-target_include_directories(mediaplayer_library PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${SQLITE3_INCLUDE_DIRS}
-    ${TAGLIB_INCLUDE_DIRS}
-    ${FFMPEG_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/src/core/include
-)
+                target_include_directories(
+                    mediaplayer_library PUBLIC
+                        $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
+                            $<INSTALL_INTERFACE : include>
+                                ${SQLITE3_INCLUDE_DIRS} ${TAGLIB_INCLUDE_DIRS} ${
+                                    FFMPEG_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR} /
+                    src / core / include)
 
-target_link_libraries(mediaplayer_library
-    PkgConfig::SQLITE3
-    PkgConfig::TAGLIB
-    PkgConfig::FFMPEG
-)
+                    target_link_libraries(
+                        mediaplayer_library PkgConfig::SQLITE3 PkgConfig::TAGLIB PkgConfig::FFMPEG)
 
-set_target_properties(mediaplayer_library PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-)
+                        set_target_properties(
+                            mediaplayer_library PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/library/README.md
+++ b/src/library/README.md
@@ -78,6 +78,13 @@ re-evaluates all smart playlists whenever metadata changes. Convenience methods
 `recentlyAdded()` and `mostPlayed()` return dynamic lists of recent or popular
 items without storing them as playlists.
 
+### AI recommendations
+
+`LibraryDB` exposes a simple interface to plug in recommendation algorithms via
+`AIRecommender`. The `RandomAIRecommender` implementation included here returns
+a random subset of library items. Applications can set a custom recommender with
+`setRecommender()` and fetch suggestions with `recommendations()`.
+
 ## Dependencies and Building
 
 `LibraryDB` relies on:

--- a/src/library/include/mediaplayer/RandomAIRecommender.h
+++ b/src/library/include/mediaplayer/RandomAIRecommender.h
@@ -1,0 +1,24 @@
+#ifndef MEDIAPLAYER_RANDOMAIRECOMMENDER_H
+#define MEDIAPLAYER_RANDOMAIRECOMMENDER_H
+
+#include "mediaplayer/AIRecommender.h"
+#include "mediaplayer/LibraryDB.h"
+#include <cstddef>
+#include <random>
+
+namespace mediaplayer {
+
+// Simple stub recommender that returns a random subset of media items.
+class RandomAIRecommender : public AIRecommender {
+public:
+  explicit RandomAIRecommender(std::size_t count = 10);
+  std::vector<MediaMetadata> recommend(const LibraryDB &db) override;
+
+private:
+  std::size_t m_count;
+  std::mt19937 m_rng{std::random_device{}()};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_RANDOMAIRECOMMENDER_H

--- a/src/library/src/RandomAIRecommender.cpp
+++ b/src/library/src/RandomAIRecommender.cpp
@@ -1,0 +1,18 @@
+#include "mediaplayer/RandomAIRecommender.h"
+
+namespace mediaplayer {
+
+RandomAIRecommender::RandomAIRecommender(std::size_t count) : m_count(count) {}
+
+std::vector<MediaMetadata> RandomAIRecommender::recommend(const LibraryDB &db) {
+  auto all = db.allMedia();
+  if (all.empty() || m_count == 0)
+    return {};
+  if (all.size() <= m_count)
+    return all;
+  std::shuffle(all.begin(), all.end(), m_rng);
+  all.resize(m_count);
+  return all;
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- implement `RandomAIRecommender` stub
- compile into library
- document the AI recommender interface

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865895a59e48331818405a2507545d7