### PR TITLE
Add Playlist class and hook into LibraryDB

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,19 +1,30 @@
-add_library(mediaplayer_library src / LibraryDB.cpp src / RandomAIRecommender.cpp)
+add_library(mediaplayer_library
+    src/LibraryDB.cpp
+    src/RandomAIRecommender.cpp
+    src/Playlist.cpp
+)
 
-    find_package(PkgConfig) pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
-        pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
-            pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil)
+find_package(PkgConfig)
+pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
+pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil)
 
-                target_include_directories(
-                    mediaplayer_library PUBLIC
-                        $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
-                            $<INSTALL_INTERFACE : include>
-                                ${SQLITE3_INCLUDE_DIRS} ${TAGLIB_INCLUDE_DIRS} ${
-                                    FFMPEG_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR} /
-                    src / core / include)
+target_include_directories(mediaplayer_library PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${SQLITE3_INCLUDE_DIRS}
+    ${TAGLIB_INCLUDE_DIRS}
+    ${FFMPEG_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/src/core/include
+)
 
-                    target_link_libraries(
-                        mediaplayer_library PkgConfig::SQLITE3 PkgConfig::TAGLIB PkgConfig::FFMPEG)
+target_link_libraries(mediaplayer_library
+    PkgConfig::SQLITE3
+    PkgConfig::TAGLIB
+    PkgConfig::FFMPEG
+)
 
-                        set_target_properties(
-                            mediaplayer_library PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaplayer_library PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/library/include/mediaplayer/Playlist.h
+++ b/src/library/include/mediaplayer/Playlist.h
@@ -1,15 +1,32 @@
 #ifndef MEDIAPLAYER_PLAYLIST_H
 #define MEDIAPLAYER_PLAYLIST_H
 
-#include "mediaplayer/MediaMetadata.h"
 #include <string>
 #include <vector>
 
 namespace mediaplayer {
 
-struct Playlist {
-  std::string name;
-  std::vector<MediaMetadata> items;
+class LibraryDB;
+
+class Playlist {
+public:
+  explicit Playlist(std::string name = "");
+
+  const std::string &name() const;
+  void setName(const std::string &name);
+
+  const std::vector<std::string> &items() const;
+  void addItem(const std::string &path);
+  bool removeItem(const std::string &path);
+  void clear();
+  std::size_t size() const;
+
+  bool save(LibraryDB &db) const;
+  static Playlist load(LibraryDB &db, const std::string &name);
+
+private:
+  std::string m_name;
+  std::vector<std::string> m_items;
 };
 
 } // namespace mediaplayer

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -1,5 +1,6 @@
 #include "mediaplayer/LibraryDB.h"
 #include "mediaplayer/AIRecommender.h"
+#include <cstring>
 #include <ctime>
 #include <filesystem>
 #include <iostream>
@@ -769,17 +770,18 @@ std::vector<MediaMetadata> LibraryDB::playlistItems(const std::string &name) {
 }
 
 Playlist LibraryDB::loadPlaylist(const std::string &name) {
-  Playlist pl;
-  pl.name = name;
-  pl.items = playlistItems(name);
+  Playlist pl(name);
+  auto items = playlistItems(name);
+  for (const auto &m : items)
+    pl.addItem(m.path);
   return pl;
 }
 
 bool LibraryDB::savePlaylist(const Playlist &playlist) {
-  if (!deletePlaylist(playlist.name))
-    createPlaylist(playlist.name);
-  for (const auto &m : playlist.items)
-    addToPlaylist(playlist.name, m.path);
+  if (!deletePlaylist(playlist.name()))
+    createPlaylist(playlist.name());
+  for (const auto &p : playlist.items())
+    addToPlaylist(playlist.name(), p);
   return true;
 }
 

--- a/src/library/src/Playlist.cpp
+++ b/src/library/src/Playlist.cpp
@@ -1,0 +1,33 @@
+#include "mediaplayer/Playlist.h"
+#include "mediaplayer/LibraryDB.h"
+#include <algorithm>
+
+namespace mediaplayer {
+
+Playlist::Playlist(std::string name) : m_name(std::move(name)) {}
+
+const std::string &Playlist::name() const { return m_name; }
+
+void Playlist::setName(const std::string &name) { m_name = name; }
+
+const std::vector<std::string> &Playlist::items() const { return m_items; }
+
+void Playlist::addItem(const std::string &path) { m_items.push_back(path); }
+
+bool Playlist::removeItem(const std::string &path) {
+  auto it = std::find(m_items.begin(), m_items.end(), path);
+  if (it == m_items.end())
+    return false;
+  m_items.erase(it);
+  return true;
+}
+
+void Playlist::clear() { m_items.clear(); }
+
+std::size_t Playlist::size() const { return m_items.size(); }
+
+bool Playlist::save(LibraryDB &db) const { return db.savePlaylist(*this); }
+
+Playlist Playlist::load(LibraryDB &db, const std::string &name) { return db.loadPlaylist(name); }
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `Playlist` class with basic operations
- update `LibraryDB` to load and save the new playlist object
- include playlist source in build system

## Testing
- `clang-format -i src/library/include/mediaplayer/Playlist.h src/library/src/Playlist.cpp src/library/src/LibraryDB.cpp`
- `g++ -std=c++17 tests/library_playlist_test.cpp src/library/src/LibraryDB.cpp src/library/src/RandomAIRecommender.cpp src/library/src/Playlist.cpp -I src/library/include -I src/core/include -lsqlite3 -ltag -lavformat -lavcodec -lavutil -lswresample -lswscale -o /tmp/test_playlist` *(failed: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_68658d9f42388331988bdf63aa43b91f