### PR TITLE
Add full-text search helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The SQLite-based library tracks media metadata, including an optional rating
 field, and updates play counts when items are played through the core engine.
 Full text search is powered by SQLite's FTS5 module, so ensure your SQLite
 installation includes this extension.
+Use `LibraryDB::searchFts()` for token-based queries or `search()` for simple
+substring matching.
 
 ## Hardware Decoding
 

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -47,6 +47,10 @@ public:
   // Powered by SQLite FTS5 and case-insensitive.
   std::vector<MediaMetadata> search(const std::string &query);
 
+  // Search using the FTS5 virtual table for more advanced matching. The query
+  // should be in FTS syntax.
+  std::vector<MediaMetadata> searchFts(const std::string &query);
+
   // Execute a simple filter expression against MediaItem fields. Supported
   // operators are =, !=, <, >, <= and >= combined with AND/OR. Example:
   //   "rating>=4 AND artist='Queen'".


### PR DESCRIPTION
## Summary
- expose an FTS-based search method in `LibraryDB`
- implement `LibraryDB::searchFts` to query the FTS5 table
- document the new method in README

## Testing
- `cmake ..` *(fails: required FFmpeg packages not found)*

------
https://chatgpt.com/codex/tasks/task_e_68658f992d8c8331ba6c2b962faa4bcf