### PR TITLE
Add mood-based AI playlist recommender

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -77,10 +77,10 @@ The test programs in `tests/` can also be built with CMake. Configure the projec
 
 ```bash
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
-cmake --build . --target test_srtparser format_conversion_test library_playlist_test \
+    cmake --build . --target test_srtparser format_conversion_test library_playlist_test \
     library_db_update_test library_playback_update_test library_rating_test \
     library_search_test library_video_metadata_test subtitle_provider_test \
-    video_conversion_test
+    library_recommender_test video_conversion_test
 ```
 
 Each test target corresponds to a source file in the `tests/` directory.

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(mediaplayer_library
     src/LibraryDB.cpp
     src/RandomAIRecommender.cpp
+    src/MoodAIRecommender.cpp
     src/Playlist.cpp
 )
 

--- a/src/library/README.md
+++ b/src/library/README.md
@@ -87,8 +87,10 @@ items without storing them as playlists.
 
 `LibraryDB` exposes a simple interface to plug in recommendation algorithms via
 `AIRecommender`. The `RandomAIRecommender` implementation included here returns
-a random subset of library items. Applications can set a custom recommender with
-`setRecommender()` and fetch suggestions with `recommendations()`.
+a random subset of library items. A slightly smarter stub,
+`MoodAIRecommender`, picks tracks whose genre matches a given mood string.
+Applications can set any recommender with `setRecommender()` and fetch
+suggestions with `recommendations()`.
 
 ## Dependencies and Building
 

--- a/src/library/include/mediaplayer/MoodAIRecommender.h
+++ b/src/library/include/mediaplayer/MoodAIRecommender.h
@@ -1,0 +1,30 @@
+#ifndef MEDIAPLAYER_MOODAIRECOMMENDER_H
+#define MEDIAPLAYER_MOODAIRECOMMENDER_H
+
+#include "mediaplayer/AIRecommender.h"
+#include "mediaplayer/LibraryDB.h"
+#include <cstddef>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace mediaplayer {
+
+// Stub recommender that selects tracks matching a given mood string.
+// Currently it performs a simple text search over genre and shuffles
+// the results.
+class MoodAIRecommender : public AIRecommender {
+public:
+  MoodAIRecommender(std::string mood = "", std::size_t count = 10);
+  void setMood(const std::string &mood);
+  std::vector<MediaMetadata> recommend(const LibraryDB &db) override;
+
+private:
+  std::string m_mood;
+  std::size_t m_count;
+  std::mt19937 m_rng{std::random_device{}()};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_MOODAIRECOMMENDER_H

--- a/src/library/src/MoodAIRecommender.cpp
+++ b/src/library/src/MoodAIRecommender.cpp
@@ -1,0 +1,26 @@
+#include "mediaplayer/MoodAIRecommender.h"
+
+namespace mediaplayer {
+
+MoodAIRecommender::MoodAIRecommender(std::string mood, std::size_t count)
+    : m_mood(std::move(mood)), m_count(count) {}
+
+void MoodAIRecommender::setMood(const std::string &mood) { m_mood = mood; }
+
+std::vector<MediaMetadata> MoodAIRecommender::recommend(const LibraryDB &db) {
+  std::vector<MediaMetadata> items;
+  if (!m_mood.empty()) {
+    items = db.search(m_mood);
+  } else {
+    items = db.allMedia();
+  }
+  if (items.empty())
+    return items;
+  if (items.size() > m_count) {
+    std::shuffle(items.begin(), items.end(), m_rng);
+    items.resize(m_count);
+  }
+  return items;
+}
+
+} // namespace mediaplayer

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,5 +4,6 @@ This directory contains simple test programs. `test_srtparser.cpp` verifies
 the SRT subtitle parser. `format_conversion_test.cpp` exercises the
 audio conversion utility. `library_playlist_test.cpp` checks basic
 playlist management in the SQLite library. `library_smartplaylist_test.cpp`
-demonstrates smart playlist creation. `stress_load_test.cpp` spawns
+demonstrates smart playlist creation and `library_recommender_test.cpp`
+shows the AI recommendation hook. `stress_load_test.cpp` spawns
 multiple `MediaPlayer` instances to stress test core playback.

--- a/tests/library_recommender_test.cpp
+++ b/tests/library_recommender_test.cpp
@@ -1,0 +1,21 @@
+#include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/MoodAIRecommender.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "recommender.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("happy1.mp3", "Happy Song", "Band", "Hits", "Pop"));
+  assert(db.addMedia("sad1.mp3", "Sad Tune", "Band", "Hits", "Blues"));
+
+  mediaplayer::MoodAIRecommender rec("Pop", 1);
+  db.setRecommender(&rec);
+  auto list = db.recommendations();
+  assert(list.size() == 1 && list[0].genre == "Pop");
+
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement `MoodAIRecommender` for mood-based suggestions
- document new recommender in library README
- compile mood recommender in library build
- add test example
- document new build target

## Testing
- `cmake ..`

------
https://chatgpt.com/codex/tasks/task_e_6865959b69a08331938df78f21cf6e98