### PR TITLE
Add FTS search test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -7,3 +7,5 @@ playlist management in the SQLite library. `library_smartplaylist_test.cpp`
 demonstrates smart playlist creation and `library_recommender_test.cpp`
 shows the AI recommendation hook. `stress_load_test.cpp` spawns
 multiple `MediaPlayer` instances to stress test core playback.
+`library_ftssearch_test.cpp` checks full text search queries using SQLite's
+FTS5 module.

--- a/tests/library_ftssearch_test.cpp
+++ b/tests/library_ftssearch_test.cpp
@@ -1,0 +1,23 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "fts_search_test.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("foo.mp3", "Hello World", "Artist1", "Album"));
+  assert(db.addMedia("bar.mp3", "Another Song", "Artist2", "Album"));
+  assert(db.addMedia("baz.mp3", "Nothing", "Artist3", "Album"));
+
+  auto res = db.searchFts("hello");
+  assert(res.size() == 1 && res[0].path == "foo.mp3");
+
+  // FTS supports prefix query with *
+  auto res2 = db.searchFts("arti* AND song");
+  assert(res2.size() == 1 && res2[0].path == "bar.mp3");
+
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a missing test for LibraryDB::searchFts
- document the new test in `tests/README.md`

## Testing
- `cmake ..` *(fails: libavformat libavcodec libavutil libswresample libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_686599e816148331aec9a5d5d72f5192