### PR TITLE
Validate smart playlist filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Full text search is powered by SQLite's FTS5 module, so ensure your SQLite
 installation includes this extension.
 Use `LibraryDB::searchFts()` for token-based queries or `search()` for simple
 substring matching.
+Smart playlists are defined using the same filter syntax as `LibraryDB::smartQuery`,
+so filters like `rating>=4 AND artist='Queen'` work for both queries and playlists.
 
 ## Hardware Decoding
 

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -100,6 +100,9 @@ private:
   bool scanDirectoryImpl(const std::string &directory, ProgressCallback progress,
                          std::atomic<bool> *cancelFlag, bool cleanup);
 
+  bool parseSmartFilter(const std::string &filter, std::string &sql,
+                        std::vector<std::string> &values, std::vector<bool> &textField) const;
+
 private:
   std::string m_path;
   sqlite3 *m_db{nullptr};


### PR DESCRIPTION
## Summary
- check smart playlist filters with smartQuery parser
- refuse invalid filters when creating or updating
- document smart playlist filter syntax

## Testing
- `cmake -S . -B build` *(fails: libavformat/libavcodec missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865a7737cb48331b2709d215e69dcc8