### PR TITLE
Add autoplaylist and playlist persistence tests

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -114,7 +114,8 @@ See [docs/building.md](../../docs/building.md) for full details, including how t
 
 Several example tests under `tests/` exercise the library:
 
-- `library_playlist_test.cpp` – playlist management
+- `library_playlist_test.cpp` – playlist management and persistence
+- `library_autoplaylist_test.cpp` – automatic "recent" and "popular" lists
 - `library_db_update_test.cpp` – adding, updating and removing entries
 - `library_playback_update_test.cpp` – recording play counts
 - `library_rating_test.cpp` – rating values

--- a/tests/library_autoplaylist_test.cpp
+++ b/tests/library_autoplaylist_test.cpp
@@ -1,0 +1,43 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+#include <sqlite3.h>
+
+int main() {
+  const char *dbPath = "autoplaylist.db";
+  {
+    mediaplayer::LibraryDB db(dbPath);
+    assert(db.open());
+    assert(db.addMedia("one.mp3", "One", "A", "Al"));
+    assert(db.addMedia("two.mp3", "Two", "A", "Al"));
+    assert(db.addMedia("three.mp3", "Three", "A", "Al"));
+    db.close();
+  }
+
+  sqlite3 *conn = nullptr;
+  sqlite3_open(dbPath, &conn);
+  sqlite3_exec(conn, "UPDATE MediaItem SET added_date=100, play_count=5 WHERE path='one.mp3';",
+               nullptr, nullptr, nullptr);
+  sqlite3_exec(conn, "UPDATE MediaItem SET added_date=200, play_count=2 WHERE path='two.mp3';",
+               nullptr, nullptr, nullptr);
+  sqlite3_exec(conn, "UPDATE MediaItem SET added_date=300, play_count=10 WHERE path='three.mp3';",
+               nullptr, nullptr, nullptr);
+  sqlite3_close(conn);
+
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  auto recent = db.recentlyAdded(3);
+  assert(recent.size() == 3);
+  assert(recent[0].path == "three.mp3");
+  assert(recent[1].path == "two.mp3");
+  assert(recent[2].path == "one.mp3");
+
+  auto popular = db.mostPlayed(2);
+  assert(popular.size() == 2);
+  assert(popular[0].path == "three.mp3");
+  assert(popular[1].path == "one.mp3");
+
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}

--- a/tests/library_playlist_test.cpp
+++ b/tests/library_playlist_test.cpp
@@ -1,4 +1,5 @@
 #include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/Playlist.h"
 #include "mediaplayer/PlaylistManager.h"
 #include <cassert>
 #include <cstdio>
@@ -19,6 +20,16 @@ int main() {
   items = db.playlistItems("fav");
   assert(items.size() == 1 && items[0].path == "song2.mp3");
   assert(db.deletePlaylist("fav"));
+
+  mediaplayer::Playlist pl("ordered");
+  pl.addItem("song1.mp3");
+  pl.addItem("song2.mp3");
+  assert(pl.save(db));
+  auto loaded = mediaplayer::Playlist::load(db, "ordered");
+  assert(loaded.size() == 2);
+  assert(loaded.items()[0] == "song1.mp3");
+  assert(loaded.items()[1] == "song2.mp3");
+  assert(db.deletePlaylist("ordered"));
   db.close();
   std::remove(dbPath);
 


### PR DESCRIPTION
## Summary
- add `library_autoplaylist_test.cpp` covering recentlyAdded/mostPlayed
- extend playlist tests with `Playlist` save/load
- document new tests in `src/library/README.md`

## Testing
- `clang-format -i tests/library_autoplaylist_test.cpp tests/library_playlist_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6865a77d45bc8331816fa8246f3bded0