### PR TITLE
Handle escaped quotes in smartQuery

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -525,12 +525,18 @@ std::vector<MediaMetadata> LibraryDB::smartQuery(const std::string &filter) {
     if (pos < filter.size() && filter[pos] == '\'') {
       quoted = true;
       ++pos;
-      size_t start = pos;
-      while (pos < filter.size() && filter[pos] != '\'')
-        ++pos;
-      value = filter.substr(start, pos - start);
-      if (pos < filter.size() && filter[pos] == '\'')
-        ++pos;
+      while (pos < filter.size()) {
+        if (filter[pos] == '\'') {
+          if (pos + 1 < filter.size() && filter[pos + 1] == '\'') {
+            value += '\'';
+            pos += 2;
+            continue;
+          }
+          ++pos;
+          break;
+        }
+        value += filter[pos++];
+      }
     } else {
       size_t start = pos;
       while (pos < filter.size() && !std::isspace(static_cast<unsigned char>(filter[pos])))

--- a/tests/library_smartquery_test.cpp
+++ b/tests/library_smartquery_test.cpp
@@ -8,11 +8,15 @@ int main() {
   assert(db.open());
   assert(db.addMedia("song1.mp3", "Title1", "Artist", "Album"));
   assert(db.addMedia("song2.mp3", "Title2", "Artist", "Album"));
+  assert(db.addMedia("song3.mp3", "Title3", "O'Connor", "Album"));
   assert(db.setRating("song1.mp3", 5));
   assert(db.setRating("song2.mp3", 3));
 
   auto res = db.smartQuery("rating>=4 AND artist='Artist'");
   assert(res.size() == 1 && res[0].path == "song1.mp3");
+
+  auto res2 = db.smartQuery("artist='O''Connor'");
+  assert(res2.size() == 1 && res2[0].path == "song3.mp3");
 
   db.close();
   std::remove(dbPath);


### PR DESCRIPTION
## Summary
- support doubled single quotes in `LibraryDB::smartQuery`
- test querying a value containing a single quote

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp tests/library_smartquery_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6865a7705ad0833186cc3044e837899c