### PR TITLE
Add indexes on MediaItem added_date and play_count

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -31,9 +31,13 @@ By default the database operates in SQLite's WAL (write-ahead logging) mode to a
   - `id` INTEGER PRIMARY KEY
   - `name` TEXT UNIQUE
 - **PlaylistItem** — items belonging to a playlist.
-  - `playlist_id` INTEGER REFERENCES `Playlist(id)`
+- `playlist_id` INTEGER REFERENCES `Playlist(id)`
   - `path` TEXT REFERENCES `MediaItem(path)`
   - `position` INTEGER
+
+The library creates indexes on `MediaItem(title)`, `MediaItem(artist)`,
+`MediaItem(album)`, `MediaItem(genre)`, `MediaItem(added_date)` and
+`MediaItem(play_count)` to speed up search and sorting queries.
 
 Query functions such as `search` and `playlistItems` return a `MediaMetadata`
 structure. This now includes a `rating` field corresponding to the column in

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -93,10 +93,13 @@ bool LibraryDB::initSchema() {
     return false;
   }
 
-  const char *indexSql = "CREATE INDEX IF NOT EXISTS idx_media_title ON MediaItem(title);"
-                         "CREATE INDEX IF NOT EXISTS idx_media_artist ON MediaItem(artist);"
-                         "CREATE INDEX IF NOT EXISTS idx_media_album ON MediaItem(album);"
-                         "CREATE INDEX IF NOT EXISTS idx_media_genre ON MediaItem(genre);";
+  const char *indexSql =
+      "CREATE INDEX IF NOT EXISTS idx_media_title ON MediaItem(title);"
+      "CREATE INDEX IF NOT EXISTS idx_media_artist ON MediaItem(artist);"
+      "CREATE INDEX IF NOT EXISTS idx_media_album ON MediaItem(album);"
+      "CREATE INDEX IF NOT EXISTS idx_media_genre ON MediaItem(genre);"
+      "CREATE INDEX IF NOT EXISTS idx_media_added_date ON MediaItem(added_date);"
+      "CREATE INDEX IF NOT EXISTS idx_media_play_count ON MediaItem(play_count);";
   if (sqlite3_exec(m_db, indexSql, nullptr, nullptr, &err) != SQLITE_OK) {
     std::cerr << "Failed to create indexes: " << err << '\n';
     sqlite3_free(err);


### PR DESCRIPTION
## Summary
- index MediaItem added_date and play_count columns
- document the new indexes

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a76157108331aa37166fab266f80