### PR TITLE
Improve LibraryDB locking and smart query validation

### DIFF
--- a/src/library/README.md
+++ b/src/library/README.md
@@ -7,7 +7,7 @@ before applying the new schema.
 
 `LibraryDB` is a lightweight wrapper around SQLite that stores metadata for media files and manages user playlists. The database is created on first use and filled by scanning directories with TagLib and FFmpeg to read tags, duration and video resolution. It also records playback statistics such as play count and last played time.
 
-By default the database operates in SQLite's WAL (write-ahead logging) mode to allow concurrent reads and writes. The `LibraryDB::close` method cleans up any `*-wal` journal file when the connection is closed.
+By default the database operates in SQLite's WAL (write-ahead logging) mode to allow concurrent reads and writes. The `LibraryDB::close` method cleans up any `*-wal` journal file and the associated `*-shm` shared memory file when the connection is closed.
 
 ## Database Schema
 
@@ -71,7 +71,8 @@ or most popular tracks via `recentlyAdded()` and `mostPlayed()`.
 
 `LibraryDB` is now thread-safe. All database operations lock an internal mutex,
 so methods such as `search` and playlist management can be called concurrently
-from multiple threads without corruption.
+from multiple threads without corruption. Private helpers like `playlistId()`
+assume the mutex is already held by the caller.
 
 ### Asynchronous scanning
 

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -96,6 +96,8 @@ private:
   bool insertMedia(const std::string &path, const std::string &title, const std::string &artist,
                    const std::string &album, const std::string &genre, int duration = 0,
                    int width = 0, int height = 0, int rating = 0);
+  // Helper returning the ID of a playlist. The caller must hold m_mutex
+  // before invoking this function.
   int playlistId(const std::string &name) const;
   bool scanDirectoryImpl(const std::string &directory, ProgressCallback progress,
                          std::atomic<bool> *cancelFlag, bool cleanup);
@@ -106,6 +108,8 @@ private:
 private:
   std::string m_path;
   sqlite3 *m_db{nullptr};
+  // Mutex protecting m_db. Most methods lock it internally. Functions marked
+  // as requiring the caller to lock (e.g. playlistId) expect it to be held.
   mutable std::mutex m_mutex;
   AIRecommender *m_recommender{nullptr};
 };

--- a/tests/library_invalid_filter_test.cpp
+++ b/tests/library_invalid_filter_test.cpp
@@ -1,0 +1,15 @@
+#include "mediaplayer/LibraryDB.h"
+#include <cassert>
+#include <cstdio>
+
+int main() {
+  const char *dbPath = "invalid_filter.db";
+  mediaplayer::LibraryDB db(dbPath);
+  assert(db.open());
+  assert(db.addMedia("song.mp3", "Song", "Artist", "Album"));
+  auto res = db.smartQuery("rating>=foo");
+  assert(res.empty());
+  db.close();
+  std::remove(dbPath);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- avoid locking inside `playlistId` and document mutex expectations
- copy recommender pointer under lock before recommending
- validate numeric values in `smartQuery`
- clean up `-shm` file in `LibraryDB::close`
- document mutex semantics and cleanup behavior
- add regression test for invalid smart query filter

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp tests/library_invalid_filter_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6865ae7c2dd48331a42a8a4de460f071