### PR TITLE
Implement playlist updates on playback

### DIFF
--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -68,8 +68,8 @@ public:
   bool deletePlaylist(const std::string &name);
   bool addToPlaylist(const std::string &name, const std::string &path);
   bool removeFromPlaylist(const std::string &name, const std::string &path);
-  std::vector<MediaMetadata> playlistItems(const std::string &name);
-  Playlist loadPlaylist(const std::string &name);
+  std::vector<MediaMetadata> playlistItems(const std::string &name) const;
+  Playlist loadPlaylist(const std::string &name) const;
   bool savePlaylist(const Playlist &playlist);
 
   // Smart playlists

--- a/src/library/src/MoodAIRecommender.cpp
+++ b/src/library/src/MoodAIRecommender.cpp
@@ -1,4 +1,5 @@
 #include "mediaplayer/MoodAIRecommender.h"
+#include <algorithm>
 
 namespace mediaplayer {
 

--- a/src/library/src/RandomAIRecommender.cpp
+++ b/src/library/src/RandomAIRecommender.cpp
@@ -1,4 +1,5 @@
 #include "mediaplayer/RandomAIRecommender.h"
+#include <algorithm>
 
 namespace mediaplayer {
 

--- a/tests/library_playback_update_test.cpp
+++ b/tests/library_playback_update_test.cpp
@@ -32,6 +32,8 @@ int main() {
     mediaplayer::LibraryDB db(dbPath);
     assert(db.open());
     assert(db.addMedia("song.mp3", "Title", "Artist", "Album"));
+    assert(db.createSmartPlaylist("played", "play_count>0"));
+    assert(db.playlistItems("played").empty());
     db.close();
   }
   sqlite3 *conn = nullptr;
@@ -42,6 +44,8 @@ int main() {
   mediaplayer::LibraryDB db(dbPath);
   assert(db.open());
   assert(db.recordPlayback("song.mp3"));
+  auto items = db.playlistItems("played");
+  assert(items.size() == 1 && items[0].path == "song.mp3");
   db.close();
 
   sqlite3_open(dbPath, &conn);

--- a/tests/library_smartquery_test.cpp
+++ b/tests/library_smartquery_test.cpp
@@ -12,11 +12,14 @@ int main() {
   assert(db.setRating("song1.mp3", 5));
   assert(db.setRating("song2.mp3", 3));
 
-  auto res = db.smartQuery("rating>=4 AND artist='Artist'");
+  auto res = db.smartQuery("rating>=4 aNd artist='Artist'");
   assert(res.size() == 1 && res[0].path == "song1.mp3");
 
   auto res2 = db.smartQuery("artist='O''Connor'");
   assert(res2.size() == 1 && res2[0].path == "song3.mp3");
+
+  auto res3 = db.smartQuery("artist='O''Connor' Or rating>=5");
+  assert(res3.size() == 2);
 
   db.close();
   std::remove(dbPath);


### PR DESCRIPTION
## Summary
- update LibraryDB::open to properly cleanup on failure
- update LibraryDB::recordPlayback to refresh smart playlists
- make playlistItems and loadPlaylist const
- include `<algorithm>` for AI recommenders
- accept case-insensitive AND/OR in smart filters
- adjust playback and smart query tests

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp src/library/src/RandomAIRecommender.cpp src/library/src/MoodAIRecommender.cpp tests/library_playback_update_test.cpp tests/library_smartquery_test.cpp`
- `g++ -std=c++17 -fpermissive tests/library_playback_update_test.cpp src/library/src/LibraryDB.cpp src/library/src/Playlist.cpp src/library/src/RandomAIRecommender.cpp src/library/src/MoodAIRecommender.cpp -I src/library/include -I src/core/include -lsqlite3 -ltag -lavformat -lavcodec -lavutil -lpthread -o /tmp/playback_test` *(fails: undefined reference to `avformat_open_input`)*

------
https://chatgpt.com/codex/tasks/task_e_6865be7f270083319ca213b368e5592e