### PR TITLE
Fix case-insensitive smart filter

### DIFF
--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -564,7 +564,9 @@ bool LibraryDB::parseSmartFilter(const std::string &filter, std::string &sql,
       if (pos + len > filter.size())
         return false;
       for (size_t i = 0; i < len; ++i) {
-        if (std::toupper(static_cast<unsigned char>(filter[pos + i])) != kw[i])
+        char c1 = std::toupper(static_cast<unsigned char>(filter[pos + i]));
+        char c2 = std::toupper(static_cast<unsigned char>(kw[i]));
+        if (c1 != c2)
           return false;
       }
       return true;

--- a/tests/library_smartquery_test.cpp
+++ b/tests/library_smartquery_test.cpp
@@ -21,6 +21,13 @@ int main() {
   auto res3 = db.smartQuery("artist='O''Connor' Or rating>=5");
   assert(res3.size() == 2);
 
+  // verify lowercase logical operators
+  auto res4 = db.smartQuery("rating>=5 and artist='Artist'");
+  assert(res4.size() == 1 && res4[0].path == "song1.mp3");
+
+  auto res5 = db.smartQuery("artist='Artist' or rating>=5");
+  assert(res5.size() == 2);
+
   db.close();
   std::remove(dbPath);
   return 0;


### PR DESCRIPTION
## Summary
- accept mixed-case AND/OR in `parseSmartFilter`
- test lowercase logical operators for smart queries

## Testing
- `clang-format -i src/library/src/LibraryDB.cpp tests/library_smartquery_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6865c04994988331ab296de025d592d4