### PR TITLE
Add LibraryQt helper for QML

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -1,19 +1,16 @@
 set(CMAKE_AUTOMOC ON)
 
-add_library(mediaplayer_desktop
-    FormatConverterQt.cpp
-)
+    add_library(mediaplayer_desktop FormatConverterQt.cpp LibraryQt.cpp)
 
-find_package(Qt6 REQUIRED COMPONENTS Core)
+        find_package(Qt6 REQUIRED COMPONENTS Core)
 
-target_include_directories(mediaplayer_desktop PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/src/format_conversion/include
-)
+            target_include_directories(mediaplayer_desktop PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${
+                                           CMAKE_SOURCE_DIR} /
+                                       src / format_conversion / include ${CMAKE_SOURCE_DIR} / src /
+                                       library / include)
 
-target_link_libraries(mediaplayer_desktop PUBLIC Qt6::Core mediaplayer_conversion)
+                target_link_libraries(
+                    mediaplayer_desktop PUBLIC Qt6::Core mediaplayer_conversion mediaplayer_library)
 
-set_target_properties(mediaplayer_desktop PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-)
+                    set_target_properties(
+                        mediaplayer_desktop PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/desktop/LibraryQt.cpp
+++ b/src/desktop/LibraryQt.cpp
@@ -1,0 +1,93 @@
+#include "LibraryQt.h"
+#include <QVariant>
+
+using namespace mediaplayer;
+
+LibraryQt::LibraryQt(QObject *parent) : QObject(parent) {}
+
+LibraryQt::~LibraryQt() {
+  cancelScan();
+  if (m_waitThread.joinable())
+    m_waitThread.join();
+}
+
+void LibraryQt::setLibrary(LibraryDB *db) { m_db = db; }
+
+void LibraryQt::startScan(const QString &directory, bool cleanup) {
+  if (!m_db)
+    return;
+  cancelScan();
+  m_scanner = std::make_unique<LibraryScanner>(*m_db);
+  m_scanner->start(
+      directory.toStdString(),
+      [this](size_t c, size_t t) { emit scanProgress(static_cast<int>(c), static_cast<int>(t)); },
+      cleanup);
+  m_waitThread = std::thread([this]() {
+    if (m_scanner)
+      m_scanner->wait();
+    emit scanFinished();
+  });
+}
+
+void LibraryQt::cancelScan() {
+  if (m_scanner)
+    m_scanner->cancel();
+  if (m_waitThread.joinable())
+    m_waitThread.join();
+  m_scanner.reset();
+}
+
+bool LibraryQt::scanRunning() const { return m_scanner && m_scanner->isRunning(); }
+
+int LibraryQt::current() const {
+  if (m_scanner)
+    return static_cast<int>(m_scanner->current());
+  return 0;
+}
+
+int LibraryQt::total() const {
+  if (m_scanner)
+    return static_cast<int>(m_scanner->total());
+  return 0;
+}
+
+static QVariantMap toMap(const MediaMetadata &m) {
+  QVariantMap v;
+  v["path"] = QString::fromStdString(m.path);
+  v["title"] = QString::fromStdString(m.title);
+  v["artist"] = QString::fromStdString(m.artist);
+  v["album"] = QString::fromStdString(m.album);
+  v["genre"] = QString::fromStdString(m.genre);
+  v["duration"] = m.duration;
+  v["width"] = m.width;
+  v["height"] = m.height;
+  v["rating"] = m.rating;
+  return v;
+}
+
+QList<QVariantMap> LibraryQt::allMedia() const {
+  QList<QVariantMap> list;
+  if (!m_db)
+    return list;
+  for (const auto &m : m_db->allMedia())
+    list.append(toMap(m));
+  return list;
+}
+
+QStringList LibraryQt::allPlaylists() const {
+  QStringList list;
+  if (!m_db)
+    return list;
+  for (const auto &p : m_db->allPlaylists())
+    list.append(QString::fromStdString(p));
+  return list;
+}
+
+QList<QVariantMap> LibraryQt::playlistItems(const QString &name) const {
+  QList<QVariantMap> list;
+  if (!m_db)
+    return list;
+  for (const auto &m : m_db->playlistItems(name.toStdString()))
+    list.append(toMap(m));
+  return list;
+}

--- a/src/desktop/LibraryQt.h
+++ b/src/desktop/LibraryQt.h
@@ -1,0 +1,42 @@
+#ifndef MEDIAPLAYER_LIBRARYQT_H
+#define MEDIAPLAYER_LIBRARYQT_H
+
+#include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/LibraryScanner.h"
+#include <QObject>
+#include <memory>
+#include <thread>
+
+namespace mediaplayer {
+
+class LibraryQt : public QObject {
+  Q_OBJECT
+public:
+  explicit LibraryQt(QObject *parent = nullptr);
+  ~LibraryQt();
+
+  void setLibrary(LibraryDB *db);
+
+  Q_INVOKABLE void startScan(const QString &directory, bool cleanup = true);
+  Q_INVOKABLE void cancelScan();
+  Q_INVOKABLE bool scanRunning() const;
+  Q_INVOKABLE int current() const;
+  Q_INVOKABLE int total() const;
+
+  Q_INVOKABLE QList<QVariantMap> allMedia() const;
+  Q_INVOKABLE QStringList allPlaylists() const;
+  Q_INVOKABLE QList<QVariantMap> playlistItems(const QString &name) const;
+
+signals:
+  void scanProgress(int current, int total);
+  void scanFinished();
+
+private:
+  LibraryDB *m_db{nullptr};
+  std::unique_ptr<LibraryScanner> m_scanner;
+  std::thread m_waitThread;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_LIBRARYQT_H

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -11,12 +11,22 @@ FormatConverterQt conv;
 conv.convertAudio("input.wav", "output.mp3");
 ```
 
+## LibraryQt
+
+`LibraryQt` wraps the media library for QML. It allows running a background scan and exposes convenient methods to fetch media and playlist information.
+
+```
+LibraryQt lib;
+lib.setLibrary(&db);
+lib.startScan("/music");
+```
+
 In QML it can be used as:
 
 ```qml
-FormatConverterQt {
-    id: conv
-    onProgressChanged: progressBar.value = progress
-    onConversionFinished: console.log("done", success)
+LibraryQt {
+    id: lib
+    onScanProgress: console.log(current, total)
+    onScanFinished: console.log("scan done")
 }
 ```


### PR DESCRIPTION
## Summary
- expose LibraryDB via Qt helper `LibraryQt`
- integrate helper in desktop module build
- document new helper

## Testing
- `cmake ..` *(fails: libavformat/libavcodec not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5fe9d688331af26a9a798806b5b