### PR TITLE
Implement library scanFile API

### DIFF
--- a/src/desktop/LibraryQt.h
+++ b/src/desktop/LibraryQt.h
@@ -4,6 +4,7 @@
 #include "mediaplayer/LibraryDB.h"
 #include "mediaplayer/LibraryScanner.h"
 #include <QObject>
+#include <atomic>
 #include <memory>
 #include <thread>
 
@@ -18,6 +19,7 @@ public:
   void setLibrary(LibraryDB *db);
 
   Q_INVOKABLE void startScan(const QString &directory, bool cleanup = true);
+  Q_INVOKABLE void scanFile(const QString &file);
   Q_INVOKABLE void cancelScan();
   Q_INVOKABLE bool scanRunning() const;
   Q_INVOKABLE int current() const;
@@ -35,6 +37,7 @@ private:
   LibraryDB *m_db{nullptr};
   std::unique_ptr<LibraryScanner> m_scanner;
   std::thread m_waitThread;
+  std::atomic<bool> m_fileScan{false};
 };
 
 } // namespace mediaplayer

--- a/src/library/README.md
+++ b/src/library/README.md
@@ -48,8 +48,9 @@ structure. This now includes a `rating` field corresponding to the column in
 ```cpp
 mediaplayer::LibraryDB db("library.db");
 if (db.open()) {
-  db.scanDirectory("/path/to/music"); // populate from files
-  auto songs = db.search("Beatles");  // simple text search
+  db.scanDirectory("/path/to/music");   // populate from files
+  db.scanFile("/path/to/new/song.mp3"); // add a single track
+  auto songs = db.search("Beatles");    // simple text search
   db.createPlaylist("favorites");
   for (const auto &m : songs)
     db.addToPlaylist("favorites", m.path);
@@ -83,11 +84,15 @@ object fall out of scope.
 ```cpp
 mediaplayer::LibraryDB db("library.db");
 mediaplayer::LibraryScanner scanner(db);
-scanner.start("/path/to/music", [&](size_t c, size_t t) {
-  std::printf("%zu/%zu\n", c, t);
-});
+scanner.start("/path/to/music", [&](size_t c, size_t t) { std::printf("%zu/%zu\n", c, t); });
 // ... later
 scanner.wait();
+```
+For a single file you can call `scanFileAsync(path)` which internally invokes
+`scanFile` on a worker thread:
+
+```cpp
+db.scanFileAsync("/some/song.mp3").join();
 ```
 
 Call `scanner.cancel()` to stop early or `scanner.wait()` to block until the

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -25,12 +25,20 @@ public:
   bool initSchema();
   bool scanDirectory(const std::string &directory, bool cleanup = true);
 
+  // Scan a single file and insert or update its metadata. Returns true on
+  // success. This is useful when adding an individual track from the UI.
+  bool scanFile(const std::string &path);
+
   using ProgressCallback = std::function<void(size_t current, size_t total)>;
   // Scan a directory asynchronously. Progress is reported via the callback and
   // scanning can be cancelled by setting cancelFlag to true. Callers must join
   // the returned thread before destroying the LibraryDB object.
   std::thread scanDirectoryAsync(const std::string &directory, ProgressCallback progress,
                                  std::atomic<bool> &cancelFlag, bool cleanup = true);
+
+  // Asynchronous wrapper for scanFile. The returned thread runs scanFile and
+  // terminates when the operation completes.
+  std::thread scanFileAsync(const std::string &path);
 
   // Insert a media entry directly. Useful for tests or manual additions.
   bool addMedia(const std::string &path, const std::string &title, const std::string &artist,


### PR DESCRIPTION
## Summary
- add `LibraryDB::scanFile` and asynchronous wrapper
- update smart playlist evaluation at end of scanning
- expose file scanning in `LibraryQt`
- document single file scan and async example

## Testing
- `clang-format`

------
https://chatgpt.com/codex/tasks/task_e_6865e17958d48331923088410f1d6deb