### PR TITLE
Add LibraryWorker for async DB queries

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_library(mediaplayer_library src / LibraryDB.cpp src / RandomAIRecommender.cpp src /
-            MoodAIRecommender.cpp src / Playlist.cpp src / LibraryScanner.cpp)
+add_library(mediaplayer_library src/LibraryDB.cpp src/RandomAIRecommender.cpp
+            src/MoodAIRecommender.cpp src/Playlist.cpp src/LibraryScanner.cpp
+            src/LibraryWorker.cpp)
 
     find_package(PkgConfig) pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
         pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)

--- a/src/library/include/mediaplayer/LibraryWorker.h
+++ b/src/library/include/mediaplayer/LibraryWorker.h
@@ -1,0 +1,50 @@
+#ifndef MEDIAPLAYER_LIBRARYWORKER_H
+#define MEDIAPLAYER_LIBRARYWORKER_H
+
+#include "mediaplayer/LibraryDB.h"
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace mediaplayer {
+
+class LibraryWorker {
+public:
+  explicit LibraryWorker(LibraryDB &db);
+  ~LibraryWorker();
+
+  LibraryWorker(const LibraryWorker &) = delete;
+  LibraryWorker &operator=(const LibraryWorker &) = delete;
+
+  using MediaListCallback = std::function<void(std::vector<MediaMetadata>)>;
+  using PlaylistListCallback = std::function<void(std::vector<std::string>)>;
+
+  // Queue database operations on the worker thread
+  void asyncAllMedia(MediaListCallback cb);
+  void asyncAllPlaylists(PlaylistListCallback cb);
+  void asyncPlaylistItems(const std::string &name, MediaListCallback cb);
+
+  void stop();
+
+private:
+  struct Task {
+    std::function<void()> func;
+  };
+
+  void threadLoop();
+
+  LibraryDB &m_db;
+  std::thread m_thread;
+  std::mutex m_mutex;
+  std::condition_variable m_cv;
+  bool m_stop{false};
+  std::queue<Task> m_tasks;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_LIBRARYWORKER_H

--- a/src/library/src/LibraryWorker.cpp
+++ b/src/library/src/LibraryWorker.cpp
@@ -1,0 +1,65 @@
+#include "mediaplayer/LibraryWorker.h"
+
+namespace mediaplayer {
+
+LibraryWorker::LibraryWorker(LibraryDB &db) : m_db(db) {
+  m_thread = std::thread(&LibraryWorker::threadLoop, this);
+}
+
+LibraryWorker::~LibraryWorker() { stop(); }
+
+void LibraryWorker::stop() {
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_stop)
+      return;
+    m_stop = true;
+  }
+  m_cv.notify_all();
+  if (m_thread.joinable())
+    m_thread.join();
+}
+
+void LibraryWorker::asyncAllMedia(MediaListCallback cb) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_tasks.push({[this, cb]() {
+    if (cb)
+      cb(m_db.allMedia());
+  }});
+  m_cv.notify_one();
+}
+
+void LibraryWorker::asyncAllPlaylists(PlaylistListCallback cb) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_tasks.push({[this, cb]() {
+    if (cb)
+      cb(m_db.allPlaylists());
+  }});
+  m_cv.notify_one();
+}
+
+void LibraryWorker::asyncPlaylistItems(const std::string &name, MediaListCallback cb) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_tasks.push({[this, name, cb]() {
+    if (cb)
+      cb(m_db.playlistItems(name));
+  }});
+  m_cv.notify_one();
+}
+
+void LibraryWorker::threadLoop() {
+  while (true) {
+    Task task;
+    {
+      std::unique_lock<std::mutex> lock(m_mutex);
+      m_cv.wait(lock, [this]() { return m_stop || !m_tasks.empty(); });
+      if (m_stop && m_tasks.empty())
+        break;
+      task = std::move(m_tasks.front());
+      m_tasks.pop();
+    }
+    task.func();
+  }
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- add `LibraryWorker` class to run library queries on a background thread
- include new file in `mediaplayer_library`

## Testing
- `cmake ..` *(fails: missing FFmpeg packages)*

------
https://chatgpt.com/codex/tasks/task_e_6865eeaf51f88331a75e9c8ce9b53a57