### PR TITLE
Add LibraryFacade and refactor LibraryQt

### DIFF
--- a/src/desktop/LibraryQt.h
+++ b/src/desktop/LibraryQt.h
@@ -2,12 +2,8 @@
 #define MEDIAPLAYER_LIBRARYQT_H
 
 #include "mediaplayer/LibraryDB.h"
-#include "mediaplayer/LibraryScanner.h"
-#include "mediaplayer/LibraryWorker.h"
+#include "mediaplayer/LibraryFacade.h"
 #include <QObject>
-#include <atomic>
-#include <memory>
-#include <thread>
 
 namespace mediaplayer {
 
@@ -43,10 +39,7 @@ signals:
 
 private:
   LibraryDB *m_db{nullptr};
-  std::unique_ptr<LibraryScanner> m_scanner;
-  std::unique_ptr<LibraryWorker> m_worker;
-  std::thread m_waitThread;
-  std::atomic<bool> m_fileScan{false};
+  LibraryFacade m_facade;
 };
 
 } // namespace mediaplayer

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,6 +1,12 @@
-add_library(mediaplayer_library src/LibraryDB.cpp src/RandomAIRecommender.cpp
-            src/MoodAIRecommender.cpp src/Playlist.cpp src/LibraryScanner.cpp
-            src/LibraryWorker.cpp)
+add_library(mediaplayer_library
+  src/LibraryDB.cpp
+  src/RandomAIRecommender.cpp
+  src/MoodAIRecommender.cpp
+  src/Playlist.cpp
+  src/LibraryScanner.cpp
+  src/LibraryWorker.cpp
+  src/LibraryFacade.cpp
+)
 
     find_package(PkgConfig) pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
         pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)

--- a/src/library/README.md
+++ b/src/library/README.md
@@ -115,6 +115,21 @@ a random subset of library items. A slightly smarter stub,
 Applications can set any recommender with `setRecommender()` and fetch
 suggestions with `recommendations()`.
 
+### LibraryFacade
+
+`LibraryFacade` wraps `LibraryWorker` to provide asynchronous access to library
+queries without depending on Qt. It exposes callbacks for operations like
+`asyncAllMedia` and `asyncPlaylistItems` and manages the worker thread
+internally.
+
+```cpp
+mediaplayer::LibraryFacade facade;
+facade.setLibrary(&db);
+facade.asyncAllMedia([](std::vector<mediaplayer::MediaMetadata> items) {
+  std::printf("%zu media files\n", items.size());
+});
+```
+
 ## Dependencies and Building
 
 `LibraryDB` relies on:

--- a/src/library/include/mediaplayer/LibraryFacade.h
+++ b/src/library/include/mediaplayer/LibraryFacade.h
@@ -1,0 +1,48 @@
+#ifndef MEDIAPLAYER_LIBRARYFACADE_H
+#define MEDIAPLAYER_LIBRARYFACADE_H
+
+#include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/LibraryScanner.h"
+#include "mediaplayer/LibraryWorker.h"
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace mediaplayer {
+
+class LibraryFacade {
+public:
+  using MediaListCallback = LibraryWorker::MediaListCallback;
+  using PlaylistListCallback = LibraryWorker::PlaylistListCallback;
+  using ProgressCallback = LibraryDB::ProgressCallback;
+
+  LibraryFacade();
+  ~LibraryFacade();
+
+  void setLibrary(LibraryDB *db);
+
+  void startScan(const std::string &directory, ProgressCallback progress = {},
+                 std::function<void()> done = {}, bool cleanup = true);
+  void scanFile(const std::string &file, std::function<void()> done = {});
+  void cancelScan();
+  bool scanRunning() const;
+  size_t current() const;
+  size_t total() const;
+
+  void asyncAllMedia(MediaListCallback cb);
+  void asyncAllPlaylists(PlaylistListCallback cb);
+  void asyncPlaylistItems(const std::string &name, MediaListCallback cb);
+
+private:
+  LibraryDB *m_db{nullptr};
+  std::unique_ptr<LibraryScanner> m_scanner;
+  std::unique_ptr<LibraryWorker> m_worker;
+  std::thread m_waitThread;
+  std::atomic<bool> m_fileScan{false};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_LIBRARYFACADE_H

--- a/src/library/src/LibraryFacade.cpp
+++ b/src/library/src/LibraryFacade.cpp
@@ -1,0 +1,97 @@
+#include "mediaplayer/LibraryFacade.h"
+
+#include <utility>
+
+namespace mediaplayer {
+
+LibraryFacade::LibraryFacade() = default;
+
+LibraryFacade::~LibraryFacade() {
+  cancelScan();
+  if (m_waitThread.joinable())
+    m_waitThread.join();
+  if (m_worker)
+    m_worker->stop();
+}
+
+void LibraryFacade::setLibrary(LibraryDB *db) {
+  m_db = db;
+  if (m_worker)
+    m_worker->stop();
+  if (m_db)
+    m_worker = std::make_unique<LibraryWorker>(*m_db);
+  else
+    m_worker.reset();
+}
+
+void LibraryFacade::startScan(const std::string &directory, ProgressCallback progress,
+                              std::function<void()> done, bool cleanup) {
+  if (!m_db)
+    return;
+  cancelScan();
+  m_scanner = std::make_unique<LibraryScanner>(*m_db);
+  m_scanner->start(directory, progress, cleanup);
+  m_waitThread = std::thread([this, done = std::move(done)]() {
+    if (m_scanner)
+      m_scanner->wait();
+    if (done)
+      done();
+  });
+}
+
+void LibraryFacade::scanFile(const std::string &file, std::function<void()> done) {
+  if (!m_db)
+    return;
+  cancelScan();
+  m_fileScan.store(true);
+  m_waitThread = std::thread([this, path = file, done = std::move(done)]() {
+    m_db->scanFile(path);
+    m_fileScan.store(false);
+    if (done)
+      done();
+  });
+}
+
+void LibraryFacade::cancelScan() {
+  if (m_scanner)
+    m_scanner->cancel();
+  if (m_waitThread.joinable())
+    m_waitThread.join();
+  m_scanner.reset();
+  m_fileScan.store(false);
+}
+
+bool LibraryFacade::scanRunning() const {
+  if (m_scanner && m_scanner->isRunning())
+    return true;
+  return m_fileScan.load();
+}
+
+size_t LibraryFacade::current() const {
+  if (m_scanner)
+    return m_scanner->current();
+  return 0;
+}
+
+size_t LibraryFacade::total() const {
+  if (m_scanner)
+    return m_scanner->total();
+  return 0;
+}
+
+void LibraryFacade::asyncAllMedia(MediaListCallback cb) {
+  if (m_worker)
+    m_worker->asyncAllMedia(std::move(cb));
+}
+
+void LibraryFacade::asyncAllPlaylists(PlaylistListCallback cb) {
+  if (m_worker)
+    m_worker->asyncAllPlaylists(std::move(cb));
+}
+
+void LibraryFacade::asyncPlaylistItems(const std::string &name, MediaListCallback cb) {
+  if (m_worker)
+    m_worker->asyncPlaylistItems(name, std::move(cb));
+}
+
+} // namespace mediaplayer


### PR DESCRIPTION
## Summary
- introduce `LibraryFacade` for thread-based async library queries without Qt
- use `LibraryFacade` inside `LibraryQt`
- document `LibraryFacade` usage
- update library build files

## Testing
- `clang-format -i src/desktop/LibraryQt.cpp src/desktop/LibraryQt.h src/library/include/mediaplayer/LibraryFacade.h src/library/src/LibraryFacade.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6865fd22d02c83319d6e2ee836988a4f