### PR TITLE
Fix library CMake and cleanup startup

### DIFF
--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -80,10 +80,14 @@ bool MediaPlayer::open(const std::string &path) {
   if (m_demuxer.audioStream() >= 0) {
     if (!m_audioDecoder.open(fmtCtx, m_demuxer.audioStream())) {
       std::cerr << "Failed to open audio decoder\n";
+      m_demuxer.close();
+      m_audioDecoder = AudioDecoder();
       return false;
     }
     if (m_output && !m_output->init(m_audioDecoder.sampleRate(), m_audioDecoder.channels())) {
       std::cerr << "Failed to init audio output\n";
+      m_demuxer.close();
+      m_audioDecoder = AudioDecoder();
       return false;
     }
   }
@@ -94,10 +98,16 @@ bool MediaPlayer::open(const std::string &path) {
     if (!m_videoDecoder.open(fmtCtx, m_demuxer.videoStream())) {
 #endif
       std::cerr << "Failed to open video decoder\n";
+      m_demuxer.close();
+      m_audioDecoder = AudioDecoder();
+      m_videoDecoder = VideoDecoder();
       return false;
     }
     if (m_videoOutput && !m_videoOutput->init(m_videoDecoder.width(), m_videoDecoder.height())) {
       std::cerr << "Failed to init video output\n";
+      m_demuxer.close();
+      m_audioDecoder = AudioDecoder();
+      m_videoDecoder = VideoDecoder();
       return false;
     }
     int lines[3] = {m_videoDecoder.width(), m_videoDecoder.width() / 2, m_videoDecoder.width() / 2};

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -1,27 +1,34 @@
 add_library(mediaplayer_library
-  src/LibraryDB.cpp
-  src/RandomAIRecommender.cpp
-  src/MoodAIRecommender.cpp
-  src/Playlist.cpp
-  src/LibraryScanner.cpp
-  src/LibraryWorker.cpp
-  src/LibraryFacade.cpp
+    src/LibraryDB.cpp
+    src/RandomAIRecommender.cpp
+    src/MoodAIRecommender.cpp
+    src/Playlist.cpp
+    src/LibraryScanner.cpp
+    src/LibraryWorker.cpp
+    src/LibraryFacade.cpp
 )
 
-    find_package(PkgConfig) pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
-        pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
-            pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil)
+find_package(PkgConfig)
+pkg_check_modules(SQLITE3 REQUIRED IMPORTED_TARGET sqlite3)
+pkg_check_modules(TAGLIB REQUIRED IMPORTED_TARGET taglib)
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavformat libavcodec libavutil)
 
-                target_include_directories(
-                    mediaplayer_library PUBLIC
-                        $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
-                            $<INSTALL_INTERFACE : include>
-                                ${SQLITE3_INCLUDE_DIRS} ${TAGLIB_INCLUDE_DIRS} ${
-                                    FFMPEG_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR} /
-                    src / core / include)
+target_include_directories(mediaplayer_library PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${SQLITE3_INCLUDE_DIRS}
+    ${TAGLIB_INCLUDE_DIRS}
+    ${FFMPEG_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/src/core/include
+)
 
-                    target_link_libraries(
-                        mediaplayer_library PkgConfig::SQLITE3 PkgConfig::TAGLIB PkgConfig::FFMPEG)
+target_link_libraries(mediaplayer_library
+    PkgConfig::SQLITE3
+    PkgConfig::TAGLIB
+    PkgConfig::FFMPEG
+)
 
-                        set_target_properties(
-                            mediaplayer_library PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaplayer_library PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/library/src/LibraryFacade.cpp
+++ b/src/library/src/LibraryFacade.cpp
@@ -8,8 +8,6 @@ LibraryFacade::LibraryFacade() = default;
 
 LibraryFacade::~LibraryFacade() {
   cancelScan();
-  if (m_waitThread.joinable())
-    m_waitThread.join();
   if (m_worker)
     m_worker->stop();
 }


### PR DESCRIPTION
## Summary
- tidy up malformed library `CMakeLists.txt`
- avoid double join in `LibraryFacade` destructor
- close demuxer and reset decoders when `MediaPlayer::open` fails

## Testing
- `clang-format -i src/library/CMakeLists.txt`
- `clang-format -i src/library/src/LibraryFacade.cpp`
- `clang-format -i src/core/src/MediaPlayer.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6865fef6cad08331b8b62261a7806abe