### PR TITLE
Support asynchronous library queries during scans

### DIFF
--- a/src/desktop/LibraryQt.cpp
+++ b/src/desktop/LibraryQt.cpp
@@ -82,6 +82,7 @@ void LibraryQt::asyncAllMedia() {
     for (const auto &m : media)
       list.append(toMap(m));
     emit mediaListReady(list);
+    emit asyncAllMediaReady(list);
   });
 }
 
@@ -91,6 +92,7 @@ void LibraryQt::asyncAllPlaylists() {
     for (const auto &n : names)
       list.append(QString::fromStdString(n));
     emit playlistListReady(list);
+    emit asyncAllPlaylistsReady(list);
   });
 }
 
@@ -101,5 +103,6 @@ void LibraryQt::asyncPlaylistItems(const QString &name) {
     for (const auto &m : items)
       list.append(toMap(m));
     emit playlistItemsReady(name, list);
+    emit asyncPlaylistItemsReady(name, list);
   });
 }

--- a/src/desktop/LibraryQt.h
+++ b/src/desktop/LibraryQt.h
@@ -36,6 +36,9 @@ signals:
   void mediaListReady(const QList<QVariantMap> &media);
   void playlistListReady(const QStringList &playlists);
   void playlistItemsReady(const QString &name, const QList<QVariantMap> &items);
+  void asyncAllMediaReady(const QList<QVariantMap> &media);
+  void asyncAllPlaylistsReady(const QStringList &playlists);
+  void asyncPlaylistItemsReady(const QString &name, const QList<QVariantMap> &items);
 
 private:
   LibraryDB *m_db{nullptr};

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -32,5 +32,7 @@ LibraryQt {
     id: lib
     onScanProgress: console.log(current, total)
     onScanFinished: console.log("scan done")
+    onAsyncAllMediaReady: console.log("loaded", media.length, "tracks")
+    Component.onCompleted: lib.asyncAllMedia()
 }
 ```

--- a/src/library/include/mediaplayer/LibraryWorker.h
+++ b/src/library/include/mediaplayer/LibraryWorker.h
@@ -28,6 +28,9 @@ public:
   void asyncAllPlaylists(PlaylistListCallback cb);
   void asyncPlaylistItems(const std::string &name, MediaListCallback cb);
 
+  // Queue an arbitrary task on the worker thread
+  void post(std::function<void()> task);
+
   void stop();
 
 private:

--- a/src/library/src/LibraryWorker.cpp
+++ b/src/library/src/LibraryWorker.cpp
@@ -47,6 +47,12 @@ void LibraryWorker::asyncPlaylistItems(const std::string &name, MediaListCallbac
   m_cv.notify_one();
 }
 
+void LibraryWorker::post(std::function<void()> task) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_tasks.push({std::move(task)});
+  m_cv.notify_one();
+}
+
 void LibraryWorker::threadLoop() {
   while (true) {
     Task task;


### PR DESCRIPTION
## Summary
- allow background scans to queue on the library worker thread
- add generic `post` helper to `LibraryWorker`
- expose `asyncAllMediaReady`, `asyncAllPlaylistsReady` and `asyncPlaylistItemsReady` signals
- document asynchronous QML usage

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryWorker.h src/library/src/LibraryWorker.cpp src/library/src/LibraryFacade.cpp src/desktop/LibraryQt.h src/desktop/LibraryQt.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6866d67434b88331b9fd1912d959aa15