### PR TITLE
Add QML LibraryView example

### DIFF
--- a/src/desktop/LibraryView.qml
+++ b/src/desktop/LibraryView.qml
@@ -1,0 +1,14 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    LibraryQt {
+        id: lib
+    }
+
+    ListView {
+        anchors.fill: parent
+        model: lib.allMedia()
+        delegate: Text { text: modelData["title"] }
+    }
+}

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -34,3 +34,25 @@ LibraryQt {
     onScanFinished: console.log("scan done")
 }
 ```
+
+### LibraryView Example
+
+The `LibraryView.qml` file demonstrates how to call `LibraryQt.allMedia()` and display
+results in a `ListView`. Include it in your Qt Quick project after registering the
+`mediaplayer_desktop` library.
+
+```qml
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    LibraryQt { id: lib }
+
+    ListView {
+        anchors.fill: parent
+        model: lib.allMedia()
+        delegate: Text { text: modelData["title"] }
+    }
+}
+```
+\nThis example relates to Task #182 in Tasks.MD.


### PR DESCRIPTION
## Summary
- add `LibraryView.qml` demonstrating how to call `LibraryQt.allMedia()`
- document example usage in `src/desktop/README.md`
- note relation to task #182

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866d6723e748331bd925e111cdfd9f7