### PR TITLE
Add database check and async scanning when opening media

### DIFF
--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -157,6 +157,13 @@ bool MediaPlayer::open(const std::string &path) {
   m_audioPackets.clear();
   m_videoPackets.clear();
   m_playRecorded = false;
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_library && !isUrl(path) && !m_library->mediaExists(path)) {
+      std::thread t = m_library->scanFileAsync(path);
+      t.detach();
+    }
+  }
   std::cout << "Opened " << path << '\n';
   return true;
 }

--- a/src/library/include/mediaplayer/LibraryDB.h
+++ b/src/library/include/mediaplayer/LibraryDB.h
@@ -40,6 +40,9 @@ public:
   // terminates when the operation completes.
   std::thread scanFileAsync(const std::string &path);
 
+  // Check if a media item with the given path already exists in the database.
+  bool mediaExists(const std::string &path) const;
+
   // Insert a media entry directly. Useful for tests or manual additions.
   bool addMedia(const std::string &path, const std::string &title, const std::string &artist,
                 const std::string &album, const std::string &genre = "");

--- a/src/library/src/LibraryDB.cpp
+++ b/src/library/src/LibraryDB.cpp
@@ -1157,6 +1157,20 @@ int LibraryDB::rating(const std::string &path) const {
   return r;
 }
 
+bool LibraryDB::mediaExists(const std::string &path) const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (!m_db)
+    return false;
+  const char *sql = "SELECT 1 FROM MediaItem WHERE path=?1 LIMIT 1;";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+    return false;
+  sqlite3_bind_text(stmt, 1, path.c_str(), -1, SQLITE_TRANSIENT);
+  bool exists = sqlite3_step(stmt) == SQLITE_ROW;
+  sqlite3_finalize(stmt);
+  return exists;
+}
+
 bool LibraryDB::updateSmartPlaylists() {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (!m_db)


### PR DESCRIPTION
## Summary
- expose `LibraryDB::mediaExists` for checking if a track is stored
- when opening a file in `MediaPlayer`, scan it in the background if not yet in the library

## Testing
- `clang-format -i src/library/include/mediaplayer/LibraryDB.h src/library/src/LibraryDB.cpp src/core/src/MediaPlayer.cpp`
- `cmake -S . -B build` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d670271c8331baf80cda252cd218