### PR TITLE
Add projectM dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ A detailed breakdown of planned modules and tasks can be found in [Tasks.MD](Tas
 - Qt 6 development files
 - OpenGL headers and GLFW 3
 - SQLite3 built with FTS5 support
+- projectM development headers (`libprojectM-dev`) or initialize the projectM submodule
+
+If using the submodule, run `git submodule update --init --recursive` after cloning.
 
 See [docs/building.md](docs/building.md) for a complete build walkthrough,
 including how to compile the sample test programs.

--- a/docs/building.md
+++ b/docs/building.md
@@ -13,6 +13,7 @@ Ensure the following packages are installed:
 - **TagLib** development headers
 - **PulseAudio** (`libpulse` and `libpulse-simple`)
 - **SQLite** development library
+- **projectM** development headers (`libprojectM-dev`) or the bundled submodule
 - Optional: Qt 6, OpenGL and GLFW for the desktop UI
 
 On Ubuntu the packages can be installed with:
@@ -21,7 +22,14 @@ On Ubuntu the packages can be installed with:
 sudo apt-get install -y build-essential cmake git \
     libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
     libcurl4-openssl-dev \
-    libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev
+    libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev \
+    libprojectM-dev
+```
+
+If you prefer using the bundled projectM sources, initialize the submodule with:
+
+```bash
+git submodule update --init --recursive
 ```
 
 ## Audio Output Backends

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -2,14 +2,19 @@ add_library(mediaplayer_visualization
     src/BasicVisualizer.cpp
 )
 
+find_package(PkgConfig)
+pkg_check_modules(PROJECTM REQUIRED IMPORTED_TARGET projectM)
+
 target_include_directories(mediaplayer_visualization PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${CMAKE_SOURCE_DIR}/src/core/include
+    ${PROJECTM_INCLUDE_DIRS}
 )
 
 target_link_libraries(mediaplayer_visualization
     mediaplayer_core
+    PkgConfig::PROJECTM
 )
 
 set_target_properties(mediaplayer_visualization PROPERTIES


### PR DESCRIPTION
## Summary
- link the visualization module with projectM
- document installing `libprojectM-dev` or using the submodule

## Testing
- `clang-format -i src/visualization/src/BasicVisualizer.cpp src/visualization/include/mediaplayer/BasicVisualizer.h`

------
https://chatgpt.com/codex/tasks/task_e_68673253cf1c83319df2b16333d0a8b1