### PR TITLE
Add projectM visualizer and Qt wrapper

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -54,6 +54,9 @@ public:
   void setCallbacks(PlaybackCallbacks callbacks);
   void setLibrary(LibraryDB *db);
   void setVisualizer(std::shared_ptr<Visualizer> vis);
+  void enableVisualization(bool enable);
+  bool visualizationEnabled() const;
+  void cycleVisualizationPreset();
   void addAudioEffect(std::shared_ptr<AudioEffect> effect);
   void removeAudioEffect(std::shared_ptr<AudioEffect> effect);
   void setVolume(double volume); // 0.0 - 1.0
@@ -128,6 +131,7 @@ private:
   SubtitleDecoder m_subtitleDecoder;
   std::thread m_subtitleThread;
   std::shared_ptr<Visualizer> m_visualizer;
+  bool m_visualizationEnabled{true};
 };
 
 } // namespace mediaplayer

--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -1,16 +1,28 @@
 set(CMAKE_AUTOMOC ON)
 
-    add_library(mediaplayer_desktop FormatConverterQt.cpp LibraryQt.cpp)
+add_library(mediaplayer_desktop
+    FormatConverterQt.cpp
+    LibraryQt.cpp
+    VisualizerQt.cpp
+)
 
-        find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
-            target_include_directories(mediaplayer_desktop PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${
-                                           CMAKE_SOURCE_DIR} /
-                                       src / format_conversion / include ${CMAKE_SOURCE_DIR} / src /
-                                       library / include)
+target_include_directories(mediaplayer_desktop PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src/format_conversion/include
+    ${CMAKE_SOURCE_DIR}/src/library/include
+    ${CMAKE_SOURCE_DIR}/src/visualization/include
+)
 
-                target_link_libraries(
-                    mediaplayer_desktop PUBLIC Qt6::Core mediaplayer_conversion mediaplayer_library)
+target_link_libraries(mediaplayer_desktop PUBLIC
+    Qt6::Core Qt6::Qml
+    mediaplayer_conversion
+    mediaplayer_library
+    mediaplayer_visualization
+)
 
-                    set_target_properties(
-                        mediaplayer_desktop PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaplayer_desktop PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/desktop/VisualizerQt.cpp
+++ b/src/desktop/VisualizerQt.cpp
@@ -1,0 +1,36 @@
+#include "VisualizerQt.h"
+#include <QtQml/qqml.h>
+
+using namespace mediaplayer;
+
+VisualizerQt::VisualizerQt(QObject *parent) : QObject(parent) {}
+
+void VisualizerQt::setVisualizer(std::shared_ptr<ProjectMVisualizer> vis) {
+  m_vis = std::move(vis);
+  emit textureChanged();
+}
+
+void VisualizerQt::setEnabled(bool enabled) { m_enabled = enabled; }
+
+void VisualizerQt::render() {
+  if (m_enabled && m_vis) {
+    m_vis->render();
+    emit textureChanged();
+  }
+}
+
+unsigned VisualizerQt::texture() const { return m_vis ? m_vis->texture() : 0; }
+
+void VisualizerQt::nextPreset() {
+  if (m_vis)
+    m_vis->nextPreset();
+}
+
+void VisualizerQt::previousPreset() {
+  if (m_vis)
+    m_vis->previousPreset();
+}
+
+void mediaplayer::registerVisualizerQtQmlType() {
+  qmlRegisterType<VisualizerQt>("MediaPlayer", 1, 0, "VisualizerQt");
+}

--- a/src/desktop/VisualizerQt.h
+++ b/src/desktop/VisualizerQt.h
@@ -1,0 +1,38 @@
+#ifndef MEDIAPLAYER_VISUALIZERQT_H
+#define MEDIAPLAYER_VISUALIZERQT_H
+
+#include "mediaplayer/ProjectMVisualizer.h"
+#include <QObject>
+#include <memory>
+
+namespace mediaplayer {
+
+class VisualizerQt : public QObject {
+  Q_OBJECT
+  Q_PROPERTY(unsigned texture READ texture NOTIFY textureChanged)
+
+public:
+  explicit VisualizerQt(QObject *parent = nullptr);
+
+  void setVisualizer(std::shared_ptr<ProjectMVisualizer> vis);
+
+  Q_INVOKABLE void setEnabled(bool enabled);
+  Q_INVOKABLE void render();
+  Q_INVOKABLE void nextPreset();
+  Q_INVOKABLE void previousPreset();
+
+  unsigned texture() const;
+
+signals:
+  void textureChanged();
+
+private:
+  std::shared_ptr<ProjectMVisualizer> m_vis;
+  bool m_enabled{false};
+};
+
+void registerVisualizerQtQmlType();
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VISUALIZERQT_H

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -1,23 +1,14 @@
-add_library(mediaplayer_visualization
-    src/BasicVisualizer.cpp
-)
+add_library(mediaplayer_visualization src / BasicVisualizer.cpp src / ProjectMVisualizer.cpp)
 
-find_package(PkgConfig)
-pkg_check_modules(PROJECTM REQUIRED IMPORTED_TARGET projectM)
+    find_package(PkgConfig) pkg_check_modules(PROJECTM REQUIRED IMPORTED_TARGET projectM)
 
-target_include_directories(mediaplayer_visualization PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${CMAKE_SOURCE_DIR}/src/core/include
-    ${PROJECTM_INCLUDE_DIRS}
-)
+        target_include_directories(mediaplayer_visualization PUBLIC
+                                       $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
+                                           $<INSTALL_INTERFACE : include>
+                                               ${CMAKE_SOURCE_DIR} /
+                                   src / core / include ${PROJECTM_INCLUDE_DIRS})
 
-target_link_libraries(mediaplayer_visualization
-    mediaplayer_core
-    PkgConfig::PROJECTM
-)
+            target_link_libraries(mediaplayer_visualization mediaplayer_core PkgConfig::PROJECTM)
 
-set_target_properties(mediaplayer_visualization PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
-)
+                set_target_properties(
+                    mediaplayer_visualization PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -1,5 +1,7 @@
-# Visualization Module
+#Visualization Module
 
 This module contains plug-in visualizers that can be attached to the core media player.
 
 `BasicVisualizer` demonstrates how to implement the `Visualizer` interface. It performs a simple FFT on incoming PCM data using the utility `simpleFFT`, which now uses a fast Cooley--Tukey algorithm, and stores the latest frequency spectrum.
+
+`ProjectMVisualizer` wraps the [projectM](https://github.com/projectM-visualizer/projectm) library. It renders classic MilkDrop-style presets using OpenGL. The constructor accepts a configuration where you can reduce `meshX`, `meshY` or `fps` to lower quality on constrained devices such as mobile phones.

--- a/src/visualization/include/mediaplayer/ProjectMVisualizer.h
+++ b/src/visualization/include/mediaplayer/ProjectMVisualizer.h
@@ -1,0 +1,45 @@
+#ifndef MEDIAPLAYER_PROJECTMVISUALIZER_H
+#define MEDIAPLAYER_PROJECTMVISUALIZER_H
+
+#include "mediaplayer/Visualizer.h"
+#include <memory>
+#include <projectM.hpp>
+
+namespace mediaplayer {
+
+class ProjectMVisualizer : public Visualizer {
+public:
+  struct Config {
+    int width{800};
+    int height{600};
+    int meshX{32};
+    int meshY{24};
+    int fps{60};
+    int textureSize{512};
+  };
+
+  explicit ProjectMVisualizer(const Config &cfg = {});
+  ~ProjectMVisualizer() override;
+
+  void onAudioPCM(const int16_t *samples, size_t count, int sampleRate, int channels) override;
+
+  void setGLContext(void *ctx);
+  void render();
+  void nextPreset();
+  void previousPreset();
+  unsigned texture() const { return m_texture; }
+  void setMeshSize(int x, int y);
+  void setFPS(int fps);
+
+private:
+  void init();
+
+  Config m_config;
+  std::unique_ptr<projectM> m_pm;
+  void *m_glContext{nullptr};
+  unsigned m_texture{0};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_PROJECTMVISUALIZER_H

--- a/src/visualization/src/ProjectMVisualizer.cpp
+++ b/src/visualization/src/ProjectMVisualizer.cpp
@@ -1,0 +1,69 @@
+#include "mediaplayer/ProjectMVisualizer.h"
+
+using namespace mediaplayer;
+
+ProjectMVisualizer::ProjectMVisualizer(const Config &cfg) : m_config(cfg) { init(); }
+
+ProjectMVisualizer::~ProjectMVisualizer() = default;
+
+void ProjectMVisualizer::init() {
+  projectM::Settings s{};
+  s.meshX = m_config.meshX;
+  s.meshY = m_config.meshY;
+  s.fps = m_config.fps;
+  s.textureSize = m_config.textureSize;
+  s.windowWidth = m_config.width;
+  s.windowHeight = m_config.height;
+  s.presetURL = "";
+  s.titleFontURL = "";
+  s.menuFontURL = "";
+  s.smoothPresetDuration = 5;
+  s.presetDuration = 30;
+  s.beatSensitivity = 0.0f;
+  s.aspectCorrection = true;
+  s.easterEgg = 0.0f;
+  s.shuffleEnabled = true;
+  s.softCutRatingsEnabled = false;
+  m_pm = std::make_unique<projectM>(s);
+  m_texture = m_pm->initRenderToTexture();
+}
+
+void ProjectMVisualizer::onAudioPCM(const int16_t *samples, size_t count, int /*sampleRate*/,
+                                    int /*channels*/) {
+  if (!m_pm || !samples || count == 0)
+    return;
+  if (count > 0)
+    m_pm->pcm()->addPCM16Data(samples, static_cast<short>(count));
+}
+
+void ProjectMVisualizer::setGLContext(void *ctx) { m_glContext = ctx; }
+
+void ProjectMVisualizer::render() {
+  if (m_pm)
+    m_pm->renderFrame();
+}
+
+void ProjectMVisualizer::nextPreset() {
+  if (m_pm)
+    m_pm->selectNext(true);
+}
+
+void ProjectMVisualizer::previousPreset() {
+  if (m_pm)
+    m_pm->selectPrevious(true);
+}
+
+void ProjectMVisualizer::setMeshSize(int x, int y) {
+  if (m_config.meshX == x && m_config.meshY == y)
+    return;
+  m_config.meshX = x;
+  m_config.meshY = y;
+  init();
+}
+
+void ProjectMVisualizer::setFPS(int fps) {
+  if (m_config.fps == fps)
+    return;
+  m_config.fps = fps;
+  init();
+}


### PR DESCRIPTION
## Summary
- introduce `ProjectMVisualizer` wrapping the projectM library
- expose render, preset switching and config setters
- add `VisualizerQt` helper and hook it into desktop CMake
- extend `MediaPlayer` with visualization control
- document projectM options in visualization README

## Testing
- `clang-format -i src/desktop/CMakeLists.txt src/visualization/CMakeLists.txt src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp src/desktop/VisualizerQt.h src/desktop/VisualizerQt.cpp src/visualization/include/mediaplayer/ProjectMVisualizer.h src/visualization/src/ProjectMVisualizer.cpp src/visualization/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6867448b15208331a4bab3ec02eb1ab0