### PR TITLE
Fix visualization CMake and docs

### DIFF
--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -58,3 +58,11 @@ Item {
 }
 ```
 \nThis example relates to Task #182 in Tasks.MD.
+
+## VisualizerQt
+
+`VisualizerQt` wraps `ProjectMVisualizer` for use with Qt Quick. It exposes a
+texture handle through the `texture` property so you can display the real-time
+visualization inside QML. Call `setEnabled(true)` and invoke `render()` each
+frame to update the texture. Use `nextPreset()` or `previousPreset()` to cycle
+through projectM presets.

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -1,14 +1,24 @@
-add_library(mediaplayer_visualization src / BasicVisualizer.cpp src / ProjectMVisualizer.cpp)
+add_library(mediaplayer_visualization
+    src/BasicVisualizer.cpp
+    src/ProjectMVisualizer.cpp
+)
 
-    find_package(PkgConfig) pkg_check_modules(PROJECTM REQUIRED IMPORTED_TARGET projectM)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROJECTM REQUIRED IMPORTED_TARGET projectM)
 
-        target_include_directories(mediaplayer_visualization PUBLIC
-                                       $<BUILD_INTERFACE : ${CMAKE_CURRENT_SOURCE_DIR} / include>
-                                           $<INSTALL_INTERFACE : include>
-                                               ${CMAKE_SOURCE_DIR} /
-                                   src / core / include ${PROJECTM_INCLUDE_DIRS})
+target_include_directories(mediaplayer_visualization PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${CMAKE_SOURCE_DIR}/src/core/include
+    ${PROJECTM_INCLUDE_DIRS}
+)
 
-            target_link_libraries(mediaplayer_visualization mediaplayer_core PkgConfig::PROJECTM)
+target_link_libraries(mediaplayer_visualization
+    mediaplayer_core
+    PkgConfig::PROJECTM
+)
 
-                set_target_properties(
-                    mediaplayer_visualization PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+set_target_properties(mediaplayer_visualization PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -4,4 +4,8 @@ This module contains plug-in visualizers that can be attached to the core media 
 
 `BasicVisualizer` demonstrates how to implement the `Visualizer` interface. It performs a simple FFT on incoming PCM data using the utility `simpleFFT`, which now uses a fast Cooley--Tukey algorithm, and stores the latest frequency spectrum.
 
-`ProjectMVisualizer` wraps the [projectM](https://github.com/projectM-visualizer/projectm) library. It renders classic MilkDrop-style presets using OpenGL. The constructor accepts a configuration where you can reduce `meshX`, `meshY` or `fps` to lower quality on constrained devices such as mobile phones.
+`ProjectMVisualizer` wraps the [projectM](https://github.com/projectM-visualizer/projectm) library. It renders classic MilkDrop-style presets using OpenGL and outputs
+to an off-screen framebuffer. The resulting texture ID can be retrieved with
+`texture()` for display in the UI. The constructor accepts a configuration where
+you can reduce `meshX`, `meshY` or `fps` to lower quality on constrained devices
+such as mobile phones.


### PR DESCRIPTION
## Summary
- fix `mediaplayer_visualization` build instructions
- document ProjectM texture usage
- describe Qt visualizer wrapper

## Testing
- `clang-format -i src/visualization/src/ProjectMVisualizer.cpp src/visualization/include/mediaplayer/ProjectMVisualizer.h`

------
https://chatgpt.com/codex/tasks/task_e_6867473913e48331a9f1547be8dc0307