### PR TITLE
Add QML VisualizerItem

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -4,9 +4,10 @@ add_library(mediaplayer_desktop
     FormatConverterQt.cpp
     LibraryQt.cpp
     VisualizerQt.cpp
+    VisualizerItem.cpp
 )
 
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick)
 
 target_include_directories(mediaplayer_desktop PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16,7 +17,7 @@ target_include_directories(mediaplayer_desktop PUBLIC
 )
 
 target_link_libraries(mediaplayer_desktop PUBLIC
-    Qt6::Core Qt6::Qml
+    Qt6::Core Qt6::Qml Qt6::Quick
     mediaplayer_conversion
     mediaplayer_library
     mediaplayer_visualization

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -66,3 +66,16 @@ texture handle through the `texture` property so you can display the real-time
 visualization inside QML. Call `setEnabled(true)` and invoke `render()` each
 frame to update the texture. Use `nextPreset()` or `previousPreset()` to cycle
 through projectM presets.
+
+## VisualizerItem
+
+`VisualizerItem` is a `QQuickItem` that displays the texture produced by
+`VisualizerQt`. Assign a `VisualizerQt` instance via the `visualizer`
+property and set `running` to true. The item will call `render()` each
+frame and update the texture on screen.
+
+```qml
+VisualizerQt { id: vis }
+VisualizerItem { anchors.fill: parent; visualizer: vis }
+```
+

--- a/src/desktop/VisualizerItem.cpp
+++ b/src/desktop/VisualizerItem.cpp
@@ -1,0 +1,50 @@
+#include "VisualizerItem.h"
+#include <QQuickWindow>
+#include <QSGSimpleTextureNode>
+
+using namespace mediaplayer;
+
+VisualizerItem::VisualizerItem(QQuickItem *parent) : QQuickItem(parent) {
+  setFlag(ItemHasContents, true);
+}
+
+void VisualizerItem::setVisualizer(VisualizerQt *vis) {
+  if (m_visualizer == vis)
+    return;
+  m_visualizer = vis;
+  emit visualizerChanged();
+  update();
+}
+
+void VisualizerItem::setRunning(bool r) {
+  if (m_running == r)
+    return;
+  m_running = r;
+  emit runningChanged();
+  update();
+}
+
+QSGNode *VisualizerItem::updatePaintNode(QSGNode *node, UpdatePaintNodeData *) {
+  auto *n = static_cast<QSGSimpleTextureNode *>(node);
+  if (!n)
+    n = new QSGSimpleTextureNode();
+
+  if (m_visualizer && m_running) {
+    m_visualizer->render();
+    auto texId = m_visualizer->texture();
+    if (texId) {
+      int size = m_visualizer->textureSize();
+      QSGTexture *texture =
+          window()->createTextureFromId(texId, QSize(size, size), QQuickWindow::TextureIsExternal);
+      n->setTexture(texture);
+      n->setRect(boundingRect());
+    }
+  }
+  return n;
+}
+
+void VisualizerItem::releaseResources() {}
+
+void mediaplayer::registerVisualizerItemQmlType() {
+  qmlRegisterType<VisualizerItem>("MediaPlayer", 1, 0, "VisualizerItem");
+}

--- a/src/desktop/VisualizerItem.h
+++ b/src/desktop/VisualizerItem.h
@@ -1,0 +1,40 @@
+#ifndef MEDIAPLAYER_VISUALIZERITEM_H
+#define MEDIAPLAYER_VISUALIZERITEM_H
+
+#include "VisualizerQt.h"
+#include <QQuickItem>
+
+namespace mediaplayer {
+
+class VisualizerItem : public QQuickItem {
+  Q_OBJECT
+  Q_PROPERTY(VisualizerQt *visualizer READ visualizer WRITE setVisualizer NOTIFY visualizerChanged)
+  Q_PROPERTY(bool running READ running WRITE setRunning NOTIFY runningChanged)
+
+public:
+  explicit VisualizerItem(QQuickItem *parent = nullptr);
+
+  VisualizerQt *visualizer() const { return m_visualizer; }
+  void setVisualizer(VisualizerQt *vis);
+
+  bool running() const { return m_running; }
+  void setRunning(bool r);
+
+signals:
+  void visualizerChanged();
+  void runningChanged();
+
+protected:
+  QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *) override;
+  void releaseResources() override;
+
+private:
+  VisualizerQt *m_visualizer{nullptr};
+  bool m_running{true};
+};
+
+void registerVisualizerItemQmlType();
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VISUALIZERITEM_H

--- a/src/desktop/VisualizerQt.cpp
+++ b/src/desktop/VisualizerQt.cpp
@@ -21,6 +21,8 @@ void VisualizerQt::render() {
 
 unsigned VisualizerQt::texture() const { return m_vis ? m_vis->texture() : 0; }
 
+int VisualizerQt::textureSize() const { return m_vis ? m_vis->textureSize() : 0; }
+
 void VisualizerQt::nextPreset() {
   if (m_vis)
     m_vis->nextPreset();

--- a/src/desktop/VisualizerQt.h
+++ b/src/desktop/VisualizerQt.h
@@ -22,6 +22,7 @@ public:
   Q_INVOKABLE void previousPreset();
 
   unsigned texture() const;
+  int textureSize() const;
 
 signals:
   void textureChanged();

--- a/src/visualization/include/mediaplayer/ProjectMVisualizer.h
+++ b/src/visualization/include/mediaplayer/ProjectMVisualizer.h
@@ -28,6 +28,7 @@ public:
   void nextPreset();
   void previousPreset();
   unsigned texture() const { return m_texture; }
+  int textureSize() const { return m_config.textureSize; }
   void setMeshSize(int x, int y);
   void setFPS(int fps);
 


### PR DESCRIPTION
## Summary
- support rendering projectM output in Qt Quick
- expose texture size through `VisualizerQt`
- export `VisualizerItem` as `MediaPlayer.VisualizerItem`

## Testing
- `clang-format -i src/desktop/VisualizerItem.h src/desktop/VisualizerItem.cpp src/desktop/VisualizerQt.h src/desktop/VisualizerQt.cpp src/visualization/include/mediaplayer/ProjectMVisualizer.h`


------
https://chatgpt.com/codex/tasks/task_e_6867495dcab88331910b42fde2084188