### PR TITLE
Finish visualization module cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ A detailed breakdown of planned modules and tasks can be found in [Tasks.MD](Tas
 - Qt 6 development files
 - OpenGL headers and GLFW 3
 - SQLite3 built with FTS5 support
-- projectM development headers (`libprojectM-dev`) or initialize the projectM submodule
-
-If using the submodule, run `git submodule update --init --recursive` after cloning.
+- projectM development headers (`libprojectM-dev`)
 
 See [docs/building.md](docs/building.md) for a complete build walkthrough,
 including how to compile the sample test programs.

--- a/docs/building.md
+++ b/docs/building.md
@@ -13,7 +13,7 @@ Ensure the following packages are installed:
 - **TagLib** development headers
 - **PulseAudio** (`libpulse` and `libpulse-simple`)
 - **SQLite** development library
-- **projectM** development headers (`libprojectM-dev`) or the bundled submodule
+- **projectM** development headers (`libprojectM-dev`)
 - Optional: Qt 6, OpenGL and GLFW for the desktop UI
 
 On Ubuntu the packages can be installed with:
@@ -26,11 +26,7 @@ sudo apt-get install -y build-essential cmake git \
     libprojectM-dev
 ```
 
-If you prefer using the bundled projectM sources, initialize the submodule with:
 
-```bash
-git submodule update --init --recursive
-```
 
 ## Audio Output Backends
 

--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -77,16 +77,16 @@
 
 | # | Task | Status | Notes |
 |-:|------|--------|-------|
-| 64 | Include projectM Library | open | relevant |
-| 65 | Initialize projectM Instance | open | relevant |
-| 66 | PCM Data Feeding | open | relevant |
-| 67 | OpenGL Context Sharing | open | relevant |
-| 68 | Render Visualization Frame | open | relevant |
-| 69 | Offscreen Rendering (Optional) | open | relevant |
-| 70 | Switch Visualization Presets | open | relevant |
-| 71 | Performance Optimization | open | relevant |
-| 72 | Expose Visualizer to UI | open | relevant |
-| 73 | Control Interface | open | relevant |
+| 64 | Include projectM Library | done | relevant |
+| 65 | Initialize projectM Instance | done | relevant |
+| 66 | PCM Data Feeding | done | relevant |
+| 67 | OpenGL Context Sharing | done | relevant |
+| 68 | Render Visualization Frame | done | relevant |
+| 69 | Offscreen Rendering (Optional) | done | relevant |
+| 70 | Switch Visualization Presets | done | relevant |
+| 71 | Performance Optimization | done | relevant |
+| 72 | Expose Visualizer to UI | done | relevant |
+| 73 | Control Interface | done | relevant |
 
 ## Desktop GUI (Qt/QML, C++) ([Tasks.MD](Tasks.MD#desktop-gui-qtqml,-c))
 

--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -76,6 +76,17 @@ frame and update the texture on screen.
 
 ```qml
 VisualizerQt { id: vis }
-VisualizerItem { anchors.fill: parent; visualizer: vis }
+VisualizerItem {
+    id: canvas
+    anchors.fill: parent
+    visualizer: vis
+}
+Timer {
+    interval: 16; running: true; repeat: true
+    onTriggered: canvas.update()
+}
 ```
+
+The `VisualizerView.qml` file in this directory contains a complete example with
+buttons to switch presets.
 

--- a/src/desktop/VisualizerView.qml
+++ b/src/desktop/VisualizerView.qml
@@ -1,0 +1,39 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import MediaPlayer 1.0
+
+Item {
+    id: root
+    width: 640
+    height: 480
+
+    VisualizerQt { id: vis }
+    VisualizerItem {
+        id: canvas
+        anchors.fill: parent
+        visualizer: vis
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: canvas.update()
+    }
+
+    Row {
+        spacing: 10
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        Button {
+            text: "Prev"
+            onClicked: vis.previousPreset()
+        }
+        Button {
+            text: "Next"
+            onClicked: vis.nextPreset()
+        }
+    }
+
+    Component.onCompleted: vis.setEnabled(true)
+}

--- a/src/visualization/include/mediaplayer/BasicVisualizer.h
+++ b/src/visualization/include/mediaplayer/BasicVisualizer.h
@@ -14,7 +14,7 @@ public:
   BasicVisualizer() = default;
   void onAudioPCM(const int16_t *samples, size_t count, int sampleRate, int channels) override;
 
-  const std::vector<float> &spectrum() const;
+  std::vector<float> spectrum() const;
 
 private:
   std::vector<float> m_spectrum;

--- a/src/visualization/include/mediaplayer/ProjectMVisualizer.h
+++ b/src/visualization/include/mediaplayer/ProjectMVisualizer.h
@@ -23,7 +23,6 @@ public:
 
   void onAudioPCM(const int16_t *samples, size_t count, int sampleRate, int channels) override;
 
-  void setGLContext(void *ctx);
   void render();
   void nextPreset();
   void previousPreset();
@@ -37,7 +36,6 @@ private:
 
   Config m_config;
   std::unique_ptr<projectM> m_pm;
-  void *m_glContext{nullptr};
   unsigned m_texture{0};
 };
 

--- a/src/visualization/src/BasicVisualizer.cpp
+++ b/src/visualization/src/BasicVisualizer.cpp
@@ -23,6 +23,9 @@ void BasicVisualizer::onAudioPCM(const int16_t *samples, size_t count, int /*sam
   }
 }
 
-const std::vector<float> &BasicVisualizer::spectrum() const { return m_spectrum; }
+std::vector<float> BasicVisualizer::spectrum() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_spectrum;
+}
 
 } // namespace mediaplayer

--- a/src/visualization/src/ProjectMVisualizer.cpp
+++ b/src/visualization/src/ProjectMVisualizer.cpp
@@ -36,8 +36,6 @@ void ProjectMVisualizer::onAudioPCM(const int16_t *samples, size_t count, int /*
     m_pm->pcm()->addPCM16Data(samples, static_cast<short>(count));
 }
 
-void ProjectMVisualizer::setGLContext(void *ctx) { m_glContext = ctx; }
-
 void ProjectMVisualizer::render() {
   if (m_pm)
     m_pm->renderFrame();


### PR DESCRIPTION
## Summary
- document projectM as a package dependency only
- remove unused OpenGL context pointer from `ProjectMVisualizer`
- make `BasicVisualizer::spectrum()` thread-safe
- add a QML example for the visualizer and update docs
- mark visualization tasks as done

## Testing
- `clang-format -i src/visualization/include/mediaplayer/BasicVisualizer.h src/visualization/include/mediaplayer/ProjectMVisualizer.h src/visualization/src/BasicVisualizer.cpp src/visualization/src/ProjectMVisualizer.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68674b9fec208331ae359fc4e4ca17c7