### PR TITLE
Add visualizer configuration for projectM

### DIFF
--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -67,6 +67,10 @@ visualization inside QML. Call `setEnabled(true)` and invoke `render()` each
 frame to update the texture. Use `nextPreset()` or `previousPreset()` to cycle
 through projectM presets.
 
+`ProjectMVisualizer` now accepts paths for presets and fonts so the desktop UI
+can load custom collections. Expose these via `setPresetPath()` or
+`setFonts()` before starting rendering.
+
 ## VisualizerItem
 
 `VisualizerItem` is a `QQuickItem` that displays the texture produced by

--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -9,3 +9,8 @@ to an off-screen framebuffer. The resulting texture ID can be retrieved with
 `texture()` for display in the UI. The constructor accepts a configuration where
 you can reduce `meshX`, `meshY` or `fps` to lower quality on constrained devices
 such as mobile phones.
+
+Additional configuration options include `presetPath`, `titleFont` and
+`menuFont` to point projectM to custom preset directories or font files. You can
+change these at runtime using `setPresetPath()` or `setFonts()` which will
+reinitialize the projectM context with the new settings.

--- a/src/visualization/include/mediaplayer/ProjectMVisualizer.h
+++ b/src/visualization/include/mediaplayer/ProjectMVisualizer.h
@@ -4,6 +4,7 @@
 #include "mediaplayer/Visualizer.h"
 #include <memory>
 #include <projectM.hpp>
+#include <string>
 
 namespace mediaplayer {
 
@@ -16,6 +17,13 @@ public:
     int meshY{24};
     int fps{60};
     int textureSize{512};
+    std::string presetPath{};
+    std::string titleFont{};
+    std::string menuFont{};
+    int smoothPresetDuration{5};
+    int presetDuration{30};
+    float beatSensitivity{0.0f};
+    bool shuffle{true};
   };
 
   explicit ProjectMVisualizer(const Config &cfg = {});
@@ -26,10 +34,13 @@ public:
   void render();
   void nextPreset();
   void previousPreset();
+  void loadPreset(const std::string &file);
   unsigned texture() const { return m_texture; }
   int textureSize() const { return m_config.textureSize; }
   void setMeshSize(int x, int y);
   void setFPS(int fps);
+  void setPresetPath(const std::string &path);
+  void setFonts(const std::string &title, const std::string &menu);
 
 private:
   void init();

--- a/src/visualization/src/ProjectMVisualizer.cpp
+++ b/src/visualization/src/ProjectMVisualizer.cpp
@@ -1,5 +1,8 @@
 #include "mediaplayer/ProjectMVisualizer.h"
 
+#include <libprojectM/Common.hpp>
+#include <utility>
+
 using namespace mediaplayer;
 
 ProjectMVisualizer::ProjectMVisualizer(const Config &cfg) : m_config(cfg) { init(); }
@@ -7,6 +10,8 @@ ProjectMVisualizer::ProjectMVisualizer(const Config &cfg) : m_config(cfg) { init
 ProjectMVisualizer::~ProjectMVisualizer() = default;
 
 void ProjectMVisualizer::init() {
+  if (m_pm)
+    m_pm.reset();
   projectM::Settings s{};
   s.meshX = m_config.meshX;
   s.meshY = m_config.meshY;
@@ -14,15 +19,15 @@ void ProjectMVisualizer::init() {
   s.textureSize = m_config.textureSize;
   s.windowWidth = m_config.width;
   s.windowHeight = m_config.height;
-  s.presetURL = "";
-  s.titleFontURL = "";
-  s.menuFontURL = "";
-  s.smoothPresetDuration = 5;
-  s.presetDuration = 30;
-  s.beatSensitivity = 0.0f;
+  s.presetURL = m_config.presetPath;
+  s.titleFontURL = m_config.titleFont;
+  s.menuFontURL = m_config.menuFont;
+  s.smoothPresetDuration = m_config.smoothPresetDuration;
+  s.presetDuration = m_config.presetDuration;
+  s.beatSensitivity = m_config.beatSensitivity;
   s.aspectCorrection = true;
   s.easterEgg = 0.0f;
-  s.shuffleEnabled = true;
+  s.shuffleEnabled = m_config.shuffle;
   s.softCutRatingsEnabled = false;
   m_pm = std::make_unique<projectM>(s);
   m_texture = m_pm->initRenderToTexture();
@@ -51,6 +56,14 @@ void ProjectMVisualizer::previousPreset() {
     m_pm->selectPrevious(true);
 }
 
+void ProjectMVisualizer::loadPreset(const std::string &file) {
+  if (!m_pm)
+    return;
+  projectM::RatingList ratings;
+  unsigned idx = m_pm->addPresetURL(file, file, ratings);
+  m_pm->selectPreset(idx, true);
+}
+
 void ProjectMVisualizer::setMeshSize(int x, int y) {
   if (m_config.meshX == x && m_config.meshY == y)
     return;
@@ -63,5 +76,20 @@ void ProjectMVisualizer::setFPS(int fps) {
   if (m_config.fps == fps)
     return;
   m_config.fps = fps;
+  init();
+}
+
+void ProjectMVisualizer::setPresetPath(const std::string &path) {
+  if (m_config.presetPath == path)
+    return;
+  m_config.presetPath = path;
+  init();
+}
+
+void ProjectMVisualizer::setFonts(const std::string &title, const std::string &menu) {
+  if (m_config.titleFont == title && m_config.menuFont == menu)
+    return;
+  m_config.titleFont = title;
+  m_config.menuFont = menu;
   init();
 }


### PR DESCRIPTION
## Summary
- extend `ProjectMVisualizer` configuration structure with preset path and font options
- support loading single preset files and updating paths at runtime
- document new options in visualization and desktop README

## Testing
- `apt-get install -y libprojectm-dev`
- `cmake -S . -B build` *(fails: required packages libavformat, libavcodec, libavutil, libswresample, libswscale not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674e16b9448331aaf543e4f064fed8