### PR TITLE
Fix projectM sample cast and make visualizer thread-safe

### DIFF
--- a/src/visualization/README.md
+++ b/src/visualization/README.md
@@ -14,3 +14,7 @@ Additional configuration options include `presetPath`, `titleFont` and
 `menuFont` to point projectM to custom preset directories or font files. You can
 change these at runtime using `setPresetPath()` or `setFonts()` which will
 reinitialize the projectM context with the new settings.
+
+`ProjectMVisualizer` is thread-safe. All access to the internal projectM
+instance is synchronized, allowing audio callbacks and rendering code to call
+its methods from different threads.

--- a/src/visualization/include/mediaplayer/ProjectMVisualizer.h
+++ b/src/visualization/include/mediaplayer/ProjectMVisualizer.h
@@ -3,6 +3,7 @@
 
 #include "mediaplayer/Visualizer.h"
 #include <memory>
+#include <mutex>
 #include <projectM.hpp>
 #include <string>
 
@@ -44,10 +45,12 @@ public:
 
 private:
   void init();
+  void initLocked();
 
   Config m_config;
   std::unique_ptr<projectM> m_pm;
   unsigned m_texture{0};
+  mutable std::mutex m_mutex;
 };
 
 } // namespace mediaplayer

--- a/src/visualization/src/ProjectMVisualizer.cpp
+++ b/src/visualization/src/ProjectMVisualizer.cpp
@@ -5,11 +5,19 @@
 
 using namespace mediaplayer;
 
-ProjectMVisualizer::ProjectMVisualizer(const Config &cfg) : m_config(cfg) { init(); }
+ProjectMVisualizer::ProjectMVisualizer(const Config &cfg) : m_config(cfg) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  initLocked();
+}
 
 ProjectMVisualizer::~ProjectMVisualizer() = default;
 
 void ProjectMVisualizer::init() {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  initLocked();
+}
+
+void ProjectMVisualizer::initLocked() {
   if (m_pm)
     m_pm.reset();
   projectM::Settings s{};
@@ -35,28 +43,33 @@ void ProjectMVisualizer::init() {
 
 void ProjectMVisualizer::onAudioPCM(const int16_t *samples, size_t count, int /*sampleRate*/,
                                     int /*channels*/) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (!m_pm || !samples || count == 0)
     return;
   if (count > 0)
-    m_pm->pcm()->addPCM16Data(samples, static_cast<short>(count));
+    m_pm->pcm()->addPCM16Data(samples, static_cast<int>(count));
 }
 
 void ProjectMVisualizer::render() {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_pm)
     m_pm->renderFrame();
 }
 
 void ProjectMVisualizer::nextPreset() {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_pm)
     m_pm->selectNext(true);
 }
 
 void ProjectMVisualizer::previousPreset() {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_pm)
     m_pm->selectPrevious(true);
 }
 
 void ProjectMVisualizer::loadPreset(const std::string &file) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (!m_pm)
     return;
   projectM::RatingList ratings;
@@ -65,31 +78,35 @@ void ProjectMVisualizer::loadPreset(const std::string &file) {
 }
 
 void ProjectMVisualizer::setMeshSize(int x, int y) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_config.meshX == x && m_config.meshY == y)
     return;
   m_config.meshX = x;
   m_config.meshY = y;
-  init();
+  initLocked();
 }
 
 void ProjectMVisualizer::setFPS(int fps) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_config.fps == fps)
     return;
   m_config.fps = fps;
-  init();
+  initLocked();
 }
 
 void ProjectMVisualizer::setPresetPath(const std::string &path) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_config.presetPath == path)
     return;
   m_config.presetPath = path;
-  init();
+  initLocked();
 }
 
 void ProjectMVisualizer::setFonts(const std::string &title, const std::string &menu) {
+  std::lock_guard<std::mutex> lock(m_mutex);
   if (m_config.titleFont == title && m_config.menuFont == menu)
     return;
   m_config.titleFont = title;
   m_config.menuFont = menu;
-  init();
+  initLocked();
 }


### PR DESCRIPTION
## Summary
- avoid overflow when feeding PCM data to projectM
- add mutex to `ProjectMVisualizer` for thread-safe usage
- document the thread safety guarantee in README

## Testing
- `cmake ..` *(fails: libavformat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d63b58a48331b8f57700ef00d1f1