### PR TITLE
Add initial desktop Qt app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ endif()
 
 add_compile_options(${SIMD_FLAGS})
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2)
+
 add_subdirectory(src/core)
 
 add_subdirectory(src/network)
@@ -27,6 +29,7 @@ add_subdirectory(src/subtitles)
 add_subdirectory(src/format_conversion)
 
 add_subdirectory(src/desktop)
+add_subdirectory(src/desktop/app)
 
 # Sync module for cross-device playback position sharing
 add_subdirectory(src/sync)

--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(CMAKE_AUTOMOC ON)
+
+add_executable(mediaplayer_desktop_app
+    main.cpp
+)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2)
+
+target_link_libraries(mediaplayer_desktop_app PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::QuickControls2
+    mediaplayer_desktop
+)
+
+set_target_properties(mediaplayer_desktop_app PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+file(COPY qml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -1,0 +1,12 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+int main(int argc, char *argv[]) {
+  QGuiApplication app(argc, argv);
+  QQmlApplicationEngine engine;
+  const QUrl url = QUrl::fromLocalFile("qml/Main.qml");
+  engine.load(url);
+  if (engine.rootObjects().isEmpty())
+    return -1;
+  return app.exec();
+}

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -1,0 +1,14 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+ApplicationWindow {
+    visible: true
+    width: 800
+    height: 600
+    title: "MediaPlayer"
+
+    Text {
+        anchors.centerIn: parent
+        text: "Hello, MediaPlayer!"
+    }
+}


### PR DESCRIPTION
## Summary
- configure Qt6 in root `CMakeLists.txt`
- build desktop app executable in `src/desktop/app`
- add a basic QML entry point and startup code

## Testing
- `cmake -S . -B build` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e04c55b48331910e249e2c7ae75b