### PR TITLE
Link core in desktop app and demo usage

### DIFF
--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -12,12 +12,18 @@ target_link_libraries(mediaplayer_desktop_app PRIVATE
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickControls2
+    mediaplayer_core
     mediaplayer_desktop
 )
 
 set_target_properties(mediaplayer_desktop_app PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
+)
+
+target_include_directories(mediaplayer_desktop_app PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core/include
+    ${CMAKE_SOURCE_DIR}/src/desktop
 )
 
 file(COPY qml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -1,9 +1,12 @@
+#include "mediaplayer/MediaPlayer.h"
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
 int main(int argc, char *argv[]) {
   QGuiApplication app(argc, argv);
   QQmlApplicationEngine engine;
+  mediaplayer::MediaPlayer player;
+  player.setVolume(1.0);
   const QUrl url = QUrl::fromLocalFile("qml/Main.qml");
   engine.load(url);
   if (engine.rootObjects().isEmpty())


### PR DESCRIPTION
## Summary
- update desktop app build to include core library and include dirs
- show trivial `MediaPlayer` usage in `main.cpp`

## Testing
- `cmake -S . -B build` *(fails: Qt6 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e13615408331b6a298b51f6acae0