### PR TITLE
Integrate Qt Quick video rendering

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(mediaplayer_desktop
     LibraryQt.cpp
     VisualizerQt.cpp
     VisualizerItem.cpp
+    VideoOutputQt.cpp
 )
 
 find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick)

--- a/src/desktop/VideoOutputQt.cpp
+++ b/src/desktop/VideoOutputQt.cpp
@@ -1,0 +1,61 @@
+#include "VideoOutputQt.h"
+#include <QtQml/qqml.h>
+
+extern "C" {
+#include <libswscale/swscale.h>
+}
+
+using namespace mediaplayer;
+
+VideoOutputQt::VideoOutputQt(QObject *parent) : QObject(parent) {}
+
+VideoOutputQt::~VideoOutputQt() { shutdown(); }
+
+bool VideoOutputQt::init(int width, int height) {
+  m_width = width;
+  m_height = height;
+  m_image = QImage(width, height, QImage::Format_RGBA8888);
+  return true;
+}
+
+void VideoOutputQt::shutdown() {
+  if (m_swsCtx) {
+    sws_freeContext(m_swsCtx);
+    m_swsCtx = nullptr;
+  }
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_image = QImage();
+}
+
+void VideoOutputQt::displayFrame(const uint8_t *rgba, int linesize) {
+  if (!m_width || !m_height)
+    return;
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_image.size() != QSize(m_width, m_height))
+    m_image = QImage(m_width, m_height, QImage::Format_RGBA8888);
+  for (int y = 0; y < m_height; ++y)
+    memcpy(m_image.scanLine(y), rgba + y * linesize, m_width * 4);
+  emit frameReady();
+}
+
+void VideoOutputQt::displayFrame(const VideoFrame &frame) {
+  if (!m_swsCtx) {
+    m_swsCtx =
+        sws_getContext(frame.width, frame.height, AV_PIX_FMT_YUV420P, frame.width, frame.height,
+                       AV_PIX_FMT_RGBA, SWS_BILINEAR, nullptr, nullptr, nullptr);
+  }
+  std::vector<uint8_t> rgba(frame.width * frame.height * 4);
+  uint8_t *dstData[4] = {rgba.data(), nullptr, nullptr, nullptr};
+  int dstLines[4] = {frame.width * 4, 0, 0, 0};
+  sws_scale(m_swsCtx, frame.data, frame.linesize, 0, frame.height, dstData, dstLines);
+  displayFrame(rgba.data(), dstLines[0]);
+}
+
+QImage VideoOutputQt::currentFrame() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_image;
+}
+
+void mediaplayer::registerVideoOutputQtQmlType() {
+  qmlRegisterType<VideoOutputQt>("MediaPlayer", 1, 0, "VideoOutputQt");
+}

--- a/src/desktop/VideoOutputQt.h
+++ b/src/desktop/VideoOutputQt.h
@@ -1,0 +1,41 @@
+#ifndef MEDIAPLAYER_VIDEOOUTPUTQT_H
+#define MEDIAPLAYER_VIDEOOUTPUTQT_H
+
+#include "mediaplayer/VideoOutput.h"
+#include <QImage>
+#include <QObject>
+#include <mutex>
+
+struct SwsContext;
+
+namespace mediaplayer {
+
+class VideoOutputQt : public QObject, public VideoOutput {
+  Q_OBJECT
+public:
+  explicit VideoOutputQt(QObject *parent = nullptr);
+  ~VideoOutputQt() override;
+
+  bool init(int width, int height) override;
+  void shutdown() override;
+  void displayFrame(const uint8_t *rgba, int linesize) override;
+  void displayFrame(const VideoFrame &frame) override;
+
+  QImage currentFrame() const;
+
+signals:
+  void frameReady();
+
+private:
+  mutable std::mutex m_mutex;
+  QImage m_image;
+  SwsContext *m_swsCtx{nullptr};
+  int m_width{0};
+  int m_height{0};
+};
+
+void registerVideoOutputQtQmlType();
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VIDEOOUTPUTQT_H

--- a/src/desktop/app/MediaPlayerController.cpp
+++ b/src/desktop/app/MediaPlayerController.cpp
@@ -1,8 +1,13 @@
 #include "MediaPlayerController.h"
+#include "../VideoOutputQt.h"
 
 using namespace mediaplayer;
 
-MediaPlayerController::MediaPlayerController(QObject *parent) : QObject(parent) {}
+MediaPlayerController::MediaPlayerController(QObject *parent) : QObject(parent) {
+  auto output = std::make_unique<VideoOutputQt>();
+  m_videoOutput = output.get();
+  m_player.setVideoOutput(std::move(output));
+}
 
 void MediaPlayerController::openFile(const QString &path) {
   if (!m_player.open(path.toStdString()))

--- a/src/desktop/app/MediaPlayerController.h
+++ b/src/desktop/app/MediaPlayerController.h
@@ -1,6 +1,7 @@
 #ifndef MEDIAPLAYER_MEDIAPLAYERCONTROLLER_H
 #define MEDIAPLAYER_MEDIAPLAYERCONTROLLER_H
 
+#include "../VideoOutputQt.h"
 #include "mediaplayer/MediaPlayer.h"
 #include <QObject>
 
@@ -11,6 +12,7 @@ class MediaPlayerController : public QObject {
   Q_PROPERTY(bool playing READ playing NOTIFY playbackStateChanged)
   Q_PROPERTY(double position READ position NOTIFY positionChanged)
   Q_PROPERTY(double volume READ volume WRITE setVolume NOTIFY volumeChanged)
+  Q_PROPERTY(VideoOutputQt *videoOutput READ videoOutput CONSTANT)
 public:
   explicit MediaPlayerController(QObject *parent = nullptr);
 
@@ -25,6 +27,8 @@ public:
   double position() const;
   double volume() const;
 
+  VideoOutputQt *videoOutput() const { return m_videoOutput; }
+
 signals:
   void playbackStateChanged();
   void positionChanged();
@@ -33,6 +37,7 @@ signals:
 
 private:
   MediaPlayer m_player;
+  VideoOutputQt *m_videoOutput{nullptr};
 };
 
 } // namespace mediaplayer

--- a/src/desktop/app/VideoItem.cpp
+++ b/src/desktop/app/VideoItem.cpp
@@ -1,18 +1,53 @@
 #include "VideoItem.h"
+#include "../VideoOutputQt.h"
+#include <QOpenGLFramebufferObject>
+#include <QPainter>
 
 using namespace mediaplayer;
 
 class VideoItemRenderer : public QQuickFramebufferObject::Renderer {
 public:
-  void render() override {}
+  explicit VideoItemRenderer(VideoItem *item) : m_item(item) {}
+
+  void synchronize(QQuickFramebufferObject *item) override {
+    m_item = static_cast<VideoItem *>(item);
+    m_output = m_item->videoOutput();
+  }
+
+  QOpenGLFramebufferObject *createFramebufferObject(const QSize &size) override {
+    return new QOpenGLFramebufferObject(size, QOpenGLFramebufferObject::CombinedDepthStencil);
+  }
+
+  void render() override {
+    if (!m_output)
+      return;
+    QImage img = m_output->currentFrame();
+    if (img.isNull())
+      return;
+    QOpenGLFramebufferObject *fbo = framebufferObject();
+    QPainter p(fbo);
+    p.drawImage(QRect(QPoint(0, 0), fbo->size()), img);
+    p.end();
+  }
+
+private:
+  VideoItem *m_item{nullptr};
+  VideoOutputQt *m_output{nullptr};
 };
 
-VideoItem::VideoItem() {}
+VideoItem::VideoItem(QQuickItem *parent) : QQuickFramebufferObject(parent) {}
 
 QQuickFramebufferObject::Renderer *VideoItem::createRenderer() const {
-  return new VideoItemRenderer();
+  return new VideoItemRenderer(const_cast<VideoItem *>(this));
 }
 
-void VideoItem::setVideoOutput(std::unique_ptr<VideoOutput> output) {
-  m_output = std::move(output);
+void VideoItem::setVideoOutput(VideoOutputQt *output) {
+  if (m_output == output)
+    return;
+  if (m_output)
+    disconnect(m_output, &VideoOutputQt::frameReady, this, &VideoItem::update);
+  m_output = output;
+  if (m_output)
+    connect(m_output, &VideoOutputQt::frameReady, this, &VideoItem::update, Qt::DirectConnection);
+  emit videoOutputChanged();
 }

--- a/src/desktop/app/VideoItem.h
+++ b/src/desktop/app/VideoItem.h
@@ -1,22 +1,30 @@
 #ifndef MEDIAPLAYER_VIDEOITEM_H
 #define MEDIAPLAYER_VIDEOITEM_H
 
-#include "mediaplayer/VideoOutput.h"
 #include <QQuickFramebufferObject>
 
 namespace mediaplayer {
 
+class VideoOutputQt;
 class VideoItemRenderer;
 
 class VideoItem : public QQuickFramebufferObject {
   Q_OBJECT
+  Q_PROPERTY(
+      VideoOutputQt *videoOutput READ videoOutput WRITE setVideoOutput NOTIFY videoOutputChanged)
+
 public:
-  VideoItem();
+  explicit VideoItem(QQuickItem *parent = nullptr);
   Renderer *createRenderer() const override;
-  void setVideoOutput(std::unique_ptr<VideoOutput> output);
+
+  VideoOutputQt *videoOutput() const { return m_output; }
+  void setVideoOutput(VideoOutputQt *output);
+
+signals:
+  void videoOutputChanged();
 
 private:
-  std::unique_ptr<VideoOutput> m_output;
+  VideoOutputQt *m_output{nullptr};
 };
 
 } // namespace mediaplayer

--- a/src/desktop/app/qml/VideoPlayer.qml
+++ b/src/desktop/app/qml/VideoPlayer.qml
@@ -1,6 +1,10 @@
 import QtQuick 2.15
+import MediaPlayer 1.0
 
 Item {
     width: 640; height: 360
-    VideoItem { anchors.fill: parent }
+    VideoItem {
+        anchors.fill: parent
+        videoOutput: player.videoOutput
+    }
 }


### PR DESCRIPTION
## Summary
- add `VideoOutputQt` providing decoded frames to Qt Quick
- implement `VideoItem` renderer that draws frames from `VideoOutputQt`
- expose the video output from `MediaPlayerController`
- wire the new item up in `VideoPlayer.qml`
- update desktop build to compile the new files

## Testing
- `clang-format -i src/desktop/VideoOutputQt.h src/desktop/VideoOutputQt.cpp src/desktop/app/VideoItem.h src/desktop/app/VideoItem.cpp src/desktop/app/MediaPlayerController.h src/desktop/app/MediaPlayerController.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6867f8f707008331b4b805597d6085d6