### PR TITLE
Handle playback errors in UI

### DIFF
--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -7,8 +7,15 @@ ApplicationWindow {
     width: 800
     height: 600
     title: qsTr("MediaPlayer")
+    property string errorMessage: ""
 
-    MediaPlayerController { id: player }
+    MediaPlayerController {
+        id: player
+        onErrorOccurred: {
+            win.errorMessage = message
+            errorDialog.open()
+        }
+    }
     LibraryModel { id: libraryModel }
     PlaylistModel { id: playlistModel }
 
@@ -25,6 +32,16 @@ ApplicationWindow {
     }
 
     SettingsDialog { id: settings }
+
+    Dialog {
+        id: errorDialog
+        title: qsTr("Playback Error")
+        standardButtons: Dialog.Ok
+        Column {
+            spacing: 8
+            Label { text: win.errorMessage }
+        }
+    }
 
     focus: true
     Keys.onPressed: {


### PR DESCRIPTION
## Summary
- display a dialog box when `MediaPlayerController` emits `errorOccurred`

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_6867f913135c833195cd88c72dae791d