### PR TITLE
Add playback icons and hook them into QML

### DIFF
--- a/src/desktop/app/app.qrc
+++ b/src/desktop/app/app.qrc
@@ -1,13 +1,8 @@
 <RCC>
-    <!-- Icon resources (play.png, pause.png, next.png, prev.png) should be
-         added here by developers. These placeholder entries are commented out
-         because binary assets are not stored in the repository. -->
-    <!--
     <qresource prefix="/icons">
-        <file>resources/icons/play.png</file>
-        <file>resources/icons/pause.png</file>
-        <file>resources/icons/next.png</file>
-        <file>resources/icons/prev.png</file>
+        <file>resources/icons/play.svg</file>
+        <file>resources/icons/pause.svg</file>
+        <file>resources/icons/next.svg</file>
+        <file>resources/icons/prev.svg</file>
     </qresource>
-    -->
 </RCC>

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -42,11 +42,19 @@ ApplicationWindow {
         VisualizationView { Layout.fillWidth: true; height: 150 }
         RowLayout {
             Layout.fillWidth: true
-            // Icon resources are omitted in the repository. Text labels are used
-            // as placeholders. Replace with icons when available.
-            Button { text: qsTr("Prev"); onClicked: player.seek(player.position() - 10) }
-            Button { text: player.playing ? qsTr("Pause") : qsTr("Play"); onClicked: player.playing ? player.pause() : player.play() }
-            Button { text: qsTr("Next"); onClicked: player.seek(player.position() + 10) }
+            ToolButton {
+                icon.source: "qrc:/icons/prev.svg"
+                onClicked: player.seek(player.position() - 10)
+            }
+            ToolButton {
+                id: playPause
+                icon.source: player.playing ? "qrc:/icons/pause.svg" : "qrc:/icons/play.svg"
+                onClicked: player.playing ? player.pause() : player.play()
+            }
+            ToolButton {
+                icon.source: "qrc:/icons/next.svg"
+                onClicked: player.seek(player.position() + 10)
+            }
             Slider { Layout.fillWidth: true; from: 0; to: 100; onMoved: player.seek(value) }
             Slider { from: 0; to: 1; value: 1; onValueChanged: player.setVolume(value) }
         }

--- a/src/desktop/app/resources/icons/README.md
+++ b/src/desktop/app/resources/icons/README.md
@@ -1,1 +1,2 @@
-This directory should contain PNG icons for playback controls: play, pause, next, and previous. Because binary files are not stored in the repository, add these images manually when building the application.
+Open-source SVG icons for playback controls are provided here as simple placeholders.
+Replace them with your own artwork if desired.

--- a/src/desktop/app/resources/icons/next.svg
+++ b/src/desktop/app/resources/icons/next.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="20,20 20,80 55,50" fill="black"/>
+  <polygon points="45,20 45,80 80,50" fill="black"/>
+  <rect x="80" y="20" width="10" height="60" fill="black"/>
+</svg>

--- a/src/desktop/app/resources/icons/pause.svg
+++ b/src/desktop/app/resources/icons/pause.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="25" y="20" width="20" height="60" fill="black"/>
+  <rect x="55" y="20" width="20" height="60" fill="black"/>
+</svg>

--- a/src/desktop/app/resources/icons/play.svg
+++ b/src/desktop/app/resources/icons/play.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="30,20 30,80 80,50" fill="black"/>
+</svg>

--- a/src/desktop/app/resources/icons/prev.svg
+++ b/src/desktop/app/resources/icons/prev.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="20" width="10" height="60" fill="black"/>
+  <polygon points="10,20 45,50 10,80" fill="black"/>
+  <polygon points="35,20 70,50 35,80" fill="black"/>
+</svg>


### PR DESCRIPTION
## Summary
- add simple SVG icons for play, pause, next and previous
- bundle icons in the desktop app resource file
- switch playback controls to use icon buttons
- document icons directory

## Testing
- `cmake -B build -S .` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6867f918a7e483318f54c88bfcb10589