### PR TITLE
Expand installer scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ cmake-build-*/
 *.nib
 *.plist
 
+# Packaging output
+dist/
+
 # macOS
 .DS_Store
 

--- a/src/desktop/app/installers/linux/build_appimage.sh
+++ b/src/desktop/app/installers/linux/build_appimage.sh
@@ -1,3 +1,30 @@
 #!/bin/bash
-# Placeholder script for AppImage packaging
-linuxdeployqt ./mediaplayer_desktop_app -appimage
+# Build an AppImage or .deb package using linuxdeployqt.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/../../../../.."
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build}"
+DIST_DIR="${PROJECT_ROOT}/dist"
+APP_NAME="mediaplayer_desktop_app"
+
+APPIMAGE_DIR="${DIST_DIR}/${APP_NAME}.AppDir"
+mkdir -p "$APPIMAGE_DIR"
+mkdir -p "$DIST_DIR"
+
+# Copy built binaries and resources
+cp "${BUILD_DIR}/${APP_NAME}" "$APPIMAGE_DIR/"
+cp -r "${PROJECT_ROOT}/src/desktop/app/qml" "$APPIMAGE_DIR/" 2>/dev/null || true
+cp -r "${PROJECT_ROOT}/src/desktop/app/translations" "$APPIMAGE_DIR/" 2>/dev/null || true
+
+PACKAGE_TYPE="${1:-appimage}" # 'appimage' or 'deb'
+
+if [ "$PACKAGE_TYPE" = "deb" ]; then
+    linuxdeployqt "$APPIMAGE_DIR/${APP_NAME}" -deb -unsupported-allow-new-glibc
+    mv ./*.deb "$DIST_DIR/" 2>/dev/null || true
+else
+    linuxdeployqt "$APPIMAGE_DIR/${APP_NAME}" -appimage -unsupported-allow-new-glibc
+    mv ./*.AppImage "$DIST_DIR/MediaPlayer.AppImage" 2>/dev/null || true
+fi
+
+echo "Packages placed in $DIST_DIR"

--- a/src/desktop/app/installers/macos/package.sh
+++ b/src/desktop/app/installers/macos/package.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
-# Placeholder script for macOS bundle
-APP_NAME="MediaPlayer.app"
-macdeployqt "$APP_NAME" -qmldir=../qml
+# Package the macOS application bundle and create a DMG.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/../../../../.."
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build}"
+DIST_DIR="${PROJECT_ROOT}/dist"
+
+APP_BUNDLE_SRC="${BUILD_DIR}/mediaplayer_desktop_app.app"
+APP_BUNDLE="${DIST_DIR}/MediaPlayer.app"
+DMG_NAME="MediaPlayer.dmg"
+
+mkdir -p "$DIST_DIR"
+
+# Copy built .app bundle to distribution directory
+cp -R "$APP_BUNDLE_SRC" "$APP_BUNDLE"
+
+# Deploy Qt frameworks and QML files
+macdeployqt "$APP_BUNDLE" -qmldir="${PROJECT_ROOT}/src/desktop/app/qml" -verbose=1
+
+# Create compressed DMG
+hdiutil create "$DIST_DIR/$DMG_NAME" -volname "MediaPlayer" -srcfolder "$APP_BUNDLE" -ov -format UDZO
+
+echo "DMG created at $DIST_DIR/$DMG_NAME"

--- a/src/desktop/app/installers/windows/mediaplayer.nsi
+++ b/src/desktop/app/installers/windows/mediaplayer.nsi
@@ -1,7 +1,14 @@
-; NSIS installer script placeholder for MediaPlayer
+; NSIS installer script for MediaPlayer
+!include "MUI2.nsh"
+
+!ifndef APP_DIR
+!error "APP_DIR not defined. Pass /DAPP_DIR=path to makensis."
+!endif
+
 OutFile "MediaPlayerSetup.exe"
 InstallDir "$PROGRAMFILES\MediaPlayer"
+
 Section "MainSection" SEC01
     SetOutPath "$INSTDIR"
-    ; Files will be added here by packaging workflow
+    File /r "${APP_DIR}\*"
 SectionEnd

--- a/src/desktop/app/installers/windows/package.ps1
+++ b/src/desktop/app/installers/windows/package.ps1
@@ -1,0 +1,22 @@
+# PowerShell script to deploy Qt dependencies and build the NSIS installer
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$projectRoot = Resolve-Path "$scriptDir\..\..\..\..\.."
+$buildDir = $env:BUILD_DIR
+if (-not $buildDir) { $buildDir = Join-Path $projectRoot 'build\Release' }
+$distDir = Join-Path $projectRoot 'dist'
+$appName = 'mediaplayer_desktop_app.exe'
+$deployDir = Join-Path $distDir 'MediaPlayer'
+
+New-Item -ItemType Directory -Path $deployDir -Force | Out-Null
+
+Copy-Item "$buildDir\$appName" $deployDir -Force
+Copy-Item "$buildDir\qml" $deployDir -Recurse -Force -ErrorAction SilentlyContinue
+Copy-Item "$buildDir\translations" $deployDir -Recurse -Force -ErrorAction SilentlyContinue
+
+& windeployqt "$deployDir\$appName" --qmldir "$projectRoot\src\desktop\app\qml"
+
+& makensis /DAPP_DIR="$deployDir" "$scriptDir\mediaplayer.nsi"
+Move-Item "$scriptDir\MediaPlayerSetup.exe" $distDir -Force
+Write-Host "Installer created at $distDir\MediaPlayerSetup.exe"


### PR DESCRIPTION
## Summary
- improve `.gitignore` for packaging output
- automate macOS packaging with `macdeployqt` and DMG creation
- build AppImage or deb packages using `linuxdeployqt`
- expand the Windows NSIS script and add PowerShell automation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867f919c6b483319c800f0490636d9d