### PR TITLE
Implement desktop UI improvements

### DIFF
--- a/src/desktop/app/AudioDevicesModel.cpp
+++ b/src/desktop/app/AudioDevicesModel.cpp
@@ -1,0 +1,43 @@
+#include "AudioDevicesModel.h"
+#include <QMediaDevices>
+
+using namespace mediaplayer;
+
+AudioDevicesModel::AudioDevicesModel(QObject *parent) : QAbstractListModel(parent) { refresh(); }
+
+int AudioDevicesModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid())
+    return 0;
+  return static_cast<int>(m_devices.size());
+}
+
+QVariant AudioDevicesModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid() || index.row() >= static_cast<int>(m_devices.size()))
+    return {};
+  const auto &dev = m_devices[index.row()];
+  if (role == NameRole)
+    return dev.description();
+  return {};
+}
+
+QHash<int, QByteArray> AudioDevicesModel::roleNames() const {
+  QHash<int, QByteArray> roles;
+  roles[NameRole] = "name";
+  return roles;
+}
+
+void AudioDevicesModel::refresh() {
+  m_devices = QMediaDevices::audioOutputs().toVector().toStdVector();
+  beginResetModel();
+  endResetModel();
+}
+
+QAudioDevice AudioDevicesModel::defaultDevice() const {
+  return QMediaDevices::defaultAudioOutput();
+}
+
+QAudioDevice AudioDevicesModel::deviceAt(int row) const {
+  if (row < 0 || row >= static_cast<int>(m_devices.size()))
+    return QAudioDevice();
+  return m_devices[row];
+}

--- a/src/desktop/app/AudioDevicesModel.h
+++ b/src/desktop/app/AudioDevicesModel.h
@@ -1,0 +1,30 @@
+#ifndef MEDIAPLAYER_AUDIODEVICESMODEL_H
+#define MEDIAPLAYER_AUDIODEVICESMODEL_H
+
+#include <QAbstractListModel>
+#include <QAudioDevice>
+#include <vector>
+
+namespace mediaplayer {
+
+class AudioDevicesModel : public QAbstractListModel {
+  Q_OBJECT
+public:
+  enum Roles { NameRole = Qt::UserRole + 1 };
+  explicit AudioDevicesModel(QObject *parent = nullptr);
+
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+  Q_INVOKABLE void refresh();
+  QAudioDevice defaultDevice() const;
+  QAudioDevice deviceAt(int row) const;
+
+private:
+  std::vector<QAudioDevice> m_devices;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIODEVICESMODEL_H

--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -5,13 +5,16 @@ add_executable(mediaplayer_desktop_app
     MediaPlayerController.cpp
     LibraryModel.cpp
     PlaylistModel.cpp
+    SyncController.cpp
+    AudioDevicesModel.cpp
+    TranslationManager.cpp
     VideoItem.cpp
     windows/WinIntegration.cpp
     macos/MacIntegration.mm
     linux/Mpris.cpp
 )
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Multimedia)
 if(UNIX AND NOT APPLE)
     find_package(Qt6 REQUIRED COMPONENTS DBus)
 endif()
@@ -25,10 +28,12 @@ target_link_libraries(mediaplayer_desktop_app PRIVATE
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickControls2
+    Qt6::Multimedia
     Qt6::Gui
     Qt6::Widgets
     mediaplayer_core
     mediaplayer_desktop
+    mediaplayer_sync
 )
 if(TARGET Qt6::DBus)
     target_link_libraries(mediaplayer_desktop_app PRIVATE Qt6::DBus)

--- a/src/desktop/app/SyncController.cpp
+++ b/src/desktop/app/SyncController.cpp
@@ -1,0 +1,38 @@
+#include "SyncController.h"
+
+using namespace mediaplayer;
+
+SyncController::SyncController(QObject *parent) : QObject(parent), m_service("Desktop") {
+  m_service.setSyncCallback([this](const std::string &path, double pos) {
+    emit syncReceived(QString::fromStdString(path), pos);
+  });
+  m_service.start();
+}
+
+SyncController::~SyncController() { m_service.stop(); }
+
+QVariantList SyncController::discoverDevices() {
+  QVariantList list;
+  for (const auto &dev : m_client.discover()) {
+    QVariantMap m;
+    m["name"] = QString::fromStdString(dev.name);
+    m["address"] = QString::fromStdString(dev.address);
+    m["port"] = dev.port;
+    m["path"] = QString::fromStdString(dev.path);
+    m["position"] = dev.position;
+    list.push_back(m);
+  }
+  return list;
+}
+
+void SyncController::sendSync(const QString &address, quint16 port, const QString &path,
+                              double position) {
+  DeviceInfo info;
+  info.address = address.toStdString();
+  info.port = port;
+  m_client.sendSync(info, path.toStdString(), position);
+}
+
+void SyncController::updateStatus(const QString &path, double position) {
+  m_service.setStatus(path.toStdString(), position);
+}

--- a/src/desktop/app/SyncController.h
+++ b/src/desktop/app/SyncController.h
@@ -1,0 +1,31 @@
+#ifndef MEDIAPLAYER_SYNCCONTROLLER_H
+#define MEDIAPLAYER_SYNCCONTROLLER_H
+
+#include "mediaplayer/SyncService.h"
+#include <QObject>
+#include <QVariant>
+
+namespace mediaplayer {
+
+class SyncController : public QObject {
+  Q_OBJECT
+public:
+  explicit SyncController(QObject *parent = nullptr);
+  ~SyncController() override;
+
+  Q_INVOKABLE QVariantList discoverDevices();
+  Q_INVOKABLE void sendSync(const QString &address, quint16 port, const QString &path,
+                            double position);
+  Q_INVOKABLE void updateStatus(const QString &path, double position);
+
+signals:
+  void syncReceived(const QString &path, double position);
+
+private:
+  SyncService m_service;
+  SyncClient m_client;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_SYNCCONTROLLER_H

--- a/src/desktop/app/TranslationManager.cpp
+++ b/src/desktop/app/TranslationManager.cpp
@@ -1,0 +1,14 @@
+#include "TranslationManager.h"
+#include <QGuiApplication>
+
+using namespace mediaplayer;
+
+TranslationManager::TranslationManager(QObject *parent) : QObject(parent) {}
+
+void TranslationManager::switchLanguage(const QString &locale) {
+  QGuiApplication::instance()->removeTranslator(&m_translator);
+  if (!locale.isEmpty()) {
+    m_translator.load("player_" + locale, "translations");
+    QGuiApplication::instance()->installTranslator(&m_translator);
+  }
+}

--- a/src/desktop/app/TranslationManager.h
+++ b/src/desktop/app/TranslationManager.h
@@ -1,0 +1,22 @@
+#ifndef MEDIAPLAYER_TRANSLATIONMANAGER_H
+#define MEDIAPLAYER_TRANSLATIONMANAGER_H
+
+#include <QObject>
+#include <QTranslator>
+
+namespace mediaplayer {
+
+class TranslationManager : public QObject {
+  Q_OBJECT
+public:
+  explicit TranslationManager(QObject *parent = nullptr);
+
+  Q_INVOKABLE void switchLanguage(const QString &locale);
+
+private:
+  QTranslator m_translator;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_TRANSLATIONMANAGER_H

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -4,12 +4,20 @@
 #ifdef Q_OS_LINUX
 #include "linux/Mpris.h"
 #endif
+#include "../VideoOutputQt.h"
+#include "../VisualizerItem.h"
+#include "../VisualizerQt.h"
+#include "AudioDevicesModel.h"
+#include "SyncController.h"
+#include "TranslationManager.h"
+#include "VideoItem.h"
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
-#include <QTranslator>
+#include <QtQml/qqml.h>
 #ifdef Q_OS_MAC
 void setupMacIntegration();
+#endif
 #ifdef _WIN32
 void setupWindowsIntegration();
 #include <QVariant>
@@ -18,18 +26,22 @@ void setupWindowsIntegration();
 
 int main(int argc, char *argv[]) {
   QGuiApplication app(argc, argv);
-  QTranslator translator;
-  translator.load("player_en", "translations");
-  app.installTranslator(&translator);
 
 #ifdef Q_OS_MAC
   setupMacIntegration();
 #endif
 
   QQmlApplicationEngine engine;
+  mediaplayer::registerVideoOutputQtQmlType();
+  mediaplayer::registerVisualizerQtQmlType();
+  mediaplayer::registerVisualizerItemQmlType();
+  qmlRegisterType<mediaplayer::VideoItem>("MediaPlayer", 1, 0, "VideoItem");
   mediaplayer::MediaPlayerController controller;
   mediaplayer::LibraryModel libraryModel;
   mediaplayer::PlaylistModel playlistModel;
+  mediaplayer::AudioDevicesModel audioDevicesModel;
+  mediaplayer::SyncController syncController;
+  mediaplayer::TranslationManager translation;
 #ifdef Q_OS_LINUX
   setupMprisIntegration(&controller);
 #endif
@@ -37,6 +49,9 @@ int main(int argc, char *argv[]) {
   engine.rootContext()->setContextProperty("player", &controller);
   engine.rootContext()->setContextProperty("libraryModel", &libraryModel);
   engine.rootContext()->setContextProperty("playlistModel", &playlistModel);
+  engine.rootContext()->setContextProperty("audioDevicesModel", &audioDevicesModel);
+  engine.rootContext()->setContextProperty("sync", &syncController);
+  engine.rootContext()->setContextProperty("translation", &translation);
 
   const QUrl url = QUrl::fromLocalFile("qml/Main.qml");
   engine.load(url);

--- a/src/desktop/app/qml/LibraryView.qml
+++ b/src/desktop/app/qml/LibraryView.qml
@@ -5,7 +5,13 @@ ListView {
     id: view
     anchors.fill: parent
     model: libraryModel
-    delegate: Text {
-        text: model.title
+    delegate: Item {
+        width: parent.width
+        height: 24
+        Text { text: model.title; anchors.verticalCenter: parent.verticalCenter }
+        MouseArea {
+            anchors.fill: parent
+            onDoubleClicked: player.openFile(model.path)
+        }
     }
 }

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Dialogs 1.3
 
 ApplicationWindow {
     id: win
@@ -8,6 +9,7 @@ ApplicationWindow {
     height: 600
     title: qsTr("MediaPlayer")
     property string errorMessage: ""
+    property string currentFile: ""
 
     MediaPlayerController {
         id: player
@@ -15,6 +17,7 @@ ApplicationWindow {
             win.errorMessage = message
             errorDialog.open()
         }
+        onPositionChanged: sync.updateStatus(win.currentFile, position)
     }
     LibraryModel { id: libraryModel }
     PlaylistModel { id: playlistModel }
@@ -27,7 +30,20 @@ ApplicationWindow {
                 placeholderText: qsTr("Search")
                 onTextChanged: libraryModel.search(text)
             }
+            Button {
+                text: qsTr("Open")
+                onClicked: fileDialog.open()
+            }
             Button { text: qsTr("Settings"); onClicked: settings.open() }
+        }
+    }
+
+    FileDialog {
+        id: fileDialog
+        onAccepted: {
+            player.openFile(fileDialog.file)
+            win.currentFile = fileDialog.file
+            sync.updateStatus(win.currentFile, 0)
         }
     }
 

--- a/src/desktop/app/qml/PlaylistView.qml
+++ b/src/desktop/app/qml/PlaylistView.qml
@@ -1,9 +1,21 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-ListView {
-    id: list
-    anchors.fill: parent
-    model: playlistModel
-    delegate: Text { text: model.name }
+Column {
+    spacing: 4
+    TextField {
+        id: nameField
+        placeholderText: qsTr("New playlist")
+        onAccepted: { playlistModel.createPlaylist(text); text = "" }
+    }
+    ListView {
+        id: list
+        anchors.fill: parent
+        model: playlistModel
+        delegate: Row {
+            spacing: 4
+            Text { text: model.name }
+            Button { text: qsTr("Delete"); onClicked: playlistModel.removePlaylist(model.name) }
+        }
+    }
 }

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -8,5 +8,41 @@ Dialog {
     Column {
         spacing: 8
         CheckBox { text: qsTr("Dark theme"); onToggled: Qt.application.theme = checked ? "dark" : "light" }
+        Row {
+            spacing: 4
+            Label { text: qsTr("Audio device") }
+            ComboBox { id: deviceBox; model: audioDevicesModel; textRole: "name" }
+            Button { text: qsTr("Refresh"); onClicked: audioDevicesModel.refresh() }
+        }
+        Row {
+            spacing: 4
+            Label { text: qsTr("Language") }
+            ComboBox {
+                id: lang
+                model: [ { text: "English", value: "en" }, { text: "Español", value: "es" } ]
+                textRole: "text"
+                onActivated: translation.switchLanguage(model[currentIndex].value)
+            }
+        }
+        Button {
+            text: qsTr("Discover Devices")
+            onClicked: discoveredDevices = sync.discoverDevices()
+        }
+        ListView {
+            id: deviceList
+            height: 100
+            width: parent.width
+            model: discoveredDevices
+            delegate: Row {
+                spacing: 4
+                Text { text: name }
+                Button {
+                    text: qsTr("Send")
+                    onClicked: sync.sendSync(address, port, win.currentFile, player.position())
+                }
+            }
+        }
     }
+
+    property var discoveredDevices: []
 }

--- a/src/desktop/app/qml/SmartPlaylistEditor.qml
+++ b/src/desktop/app/qml/SmartPlaylistEditor.qml
@@ -5,8 +5,42 @@ Dialog {
     id: dlg
     title: qsTr("Smart Playlist Editor")
     standardButtons: Dialog.Ok | Dialog.Cancel
+    property var rules: []
     Column {
         spacing: 8
-        TextField { id: field; placeholderText: qsTr("Filter query") }
+        Repeater {
+            model: dlg.rules
+            delegate: Row {
+                spacing: 4
+                ComboBox {
+                    id: fieldBox
+                    model: ["title", "artist", "genre"]
+                    currentText: modelData.field
+                    onCurrentTextChanged: dlg.rules[index].field = currentText
+                }
+                ComboBox {
+                    id: opBox
+                    model: ["contains", "equals"]
+                    currentText: modelData.op
+                    onCurrentTextChanged: dlg.rules[index].op = currentText
+                }
+                TextField {
+                    id: valueField
+                    text: modelData.value
+                    onTextChanged: dlg.rules[index].value = text
+                }
+                Button { text: qsTr("Remove"); onClicked: dlg.rules.splice(index,1) }
+            }
+        }
+        Button { text: qsTr("Add Rule"); onClicked: dlg.rules.push({field:"title", op:"contains", value:""}) }
+    }
+    onAccepted: {
+        var query = "";
+        for (var i=0; i<rules.length; ++i) {
+            var r = rules[i];
+            if (i > 0) query += " AND ";
+            query += r.field + " " + r.op + " " + r.value;
+        }
+        console.log("smart playlist", query)
     }
 }

--- a/src/desktop/app/qml/VideoPlayer.qml
+++ b/src/desktop/app/qml/VideoPlayer.qml
@@ -4,7 +4,24 @@ import MediaPlayer 1.0
 Item {
     width: 640; height: 360
     VideoItem {
+        id: item
         anchors.fill: parent
         videoOutput: player.videoOutput
+        MouseArea {
+            anchors.fill: parent
+            onDoubleClicked: fsWindow.visible = true
+        }
+    }
+    Window {
+        id: fsWindow
+        visible: false
+        flags: Qt.Window | Qt.FramelessWindowHint
+        visibility: Window.FullScreen
+        color: "black"
+        VideoItem {
+            anchors.fill: parent
+            videoOutput: player.videoOutput
+            MouseArea { anchors.fill: parent; onDoubleClicked: fsWindow.visible = false }
+        }
     }
 }

--- a/src/desktop/app/translations/player_es.ts
+++ b/src/desktop/app/translations/player_es.ts
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TS version="2.1" language="es_ES">
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>MediaPlayer</source>
+        <translation>Reproductor</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary
- register custom QML types in `main.cpp`
- introduce `AudioDevicesModel`, `SyncController`, and `TranslationManager`
- expose these objects to QML
- add open file button and sync status updates
- expand playlist view and smart playlist editor
- add settings for audio device, language switching and sync
- provide fullscreen video support
- include Spanish translation file

## Testing
- `clang-format -i src/desktop/app/main.cpp src/desktop/app/AudioDevicesModel.cpp src/desktop/app/AudioDevicesModel.h src/desktop/app/SyncController.cpp src/desktop/app/SyncController.h src/desktop/app/TranslationManager.cpp src/desktop/app/TranslationManager.h`

------
https://chatgpt.com/codex/tasks/task_e_686809d1fd6c83319d41f1a355e15790