### PR TITLE
Improve desktop features

### DIFF
--- a/src/desktop/app/MediaPlayerController.cpp
+++ b/src/desktop/app/MediaPlayerController.cpp
@@ -1,5 +1,7 @@
 #include "MediaPlayerController.h"
 #include "../VideoOutputQt.h"
+#include "../VisualizerQt.h"
+#include "mediaplayer/ProjectMVisualizer.h"
 
 using namespace mediaplayer;
 
@@ -7,6 +9,10 @@ MediaPlayerController::MediaPlayerController(QObject *parent) : QObject(parent) 
   auto output = std::make_unique<VideoOutputQt>();
   m_videoOutput = output.get();
   m_player.setVideoOutput(std::move(output));
+  auto vis = std::make_shared<ProjectMVisualizer>();
+  m_player.setVisualizer(vis);
+  m_visualizer = new VisualizerQt(this);
+  m_visualizer->setVisualizer(vis);
 }
 
 void MediaPlayerController::openFile(const QString &path) {

--- a/src/desktop/app/MediaPlayerController.h
+++ b/src/desktop/app/MediaPlayerController.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_MEDIAPLAYERCONTROLLER_H
 
 #include "../VideoOutputQt.h"
+#include "../VisualizerQt.h"
 #include "mediaplayer/MediaPlayer.h"
 #include <QObject>
 
@@ -13,6 +14,7 @@ class MediaPlayerController : public QObject {
   Q_PROPERTY(double position READ position NOTIFY positionChanged)
   Q_PROPERTY(double volume READ volume WRITE setVolume NOTIFY volumeChanged)
   Q_PROPERTY(VideoOutputQt *videoOutput READ videoOutput CONSTANT)
+  Q_PROPERTY(VisualizerQt *visualizer READ visualizer CONSTANT)
 public:
   explicit MediaPlayerController(QObject *parent = nullptr);
 
@@ -28,6 +30,7 @@ public:
   double volume() const;
 
   VideoOutputQt *videoOutput() const { return m_videoOutput; }
+  VisualizerQt *visualizer() const { return m_visualizer; }
 
 signals:
   void playbackStateChanged();
@@ -38,6 +41,7 @@ signals:
 private:
   MediaPlayer m_player;
   VideoOutputQt *m_videoOutput{nullptr};
+  VisualizerQt *m_visualizer{nullptr};
 };
 
 } // namespace mediaplayer

--- a/src/desktop/app/PlaylistModel.cpp
+++ b/src/desktop/app/PlaylistModel.cpp
@@ -44,6 +44,16 @@ void PlaylistModel::createPlaylist(const QString &name) {
   endInsertRows();
 }
 
+void PlaylistModel::createSmartPlaylist(const QString &name, const QString &filter) {
+  if (!m_db)
+    return;
+  if (!m_db->createSmartPlaylist(name.toStdString(), filter.toStdString()))
+    return;
+  m_playlists.append(name);
+  beginInsertRows(QModelIndex(), m_playlists.size() - 1, m_playlists.size() - 1);
+  endInsertRows();
+}
+
 void PlaylistModel::removePlaylist(const QString &name) {
   if (!m_db)
     return;

--- a/src/desktop/app/PlaylistModel.h
+++ b/src/desktop/app/PlaylistModel.h
@@ -18,6 +18,7 @@ public:
   QHash<int, QByteArray> roleNames() const override;
   Q_INVOKABLE void createPlaylist(const QString &name);
   Q_INVOKABLE void removePlaylist(const QString &name);
+  Q_INVOKABLE void createSmartPlaylist(const QString &name, const QString &filter);
 
 private:
   LibraryDB *m_db{nullptr};

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -4,6 +4,7 @@
 #ifdef Q_OS_LINUX
 #include "linux/Mpris.h"
 #endif
+#include "../FormatConverterQt.h"
 #include "../VideoOutputQt.h"
 #include "../VisualizerItem.h"
 #include "../VisualizerQt.h"
@@ -42,6 +43,7 @@ int main(int argc, char *argv[]) {
   mediaplayer::AudioDevicesModel audioDevicesModel;
   mediaplayer::SyncController syncController;
   mediaplayer::TranslationManager translation;
+  mediaplayer::FormatConverterQt converter;
 #ifdef Q_OS_LINUX
   setupMprisIntegration(&controller);
 #endif
@@ -52,6 +54,7 @@ int main(int argc, char *argv[]) {
   engine.rootContext()->setContextProperty("audioDevicesModel", &audioDevicesModel);
   engine.rootContext()->setContextProperty("sync", &syncController);
   engine.rootContext()->setContextProperty("translation", &translation);
+  engine.rootContext()->setContextProperty("formatConverter", &converter);
 
   const QUrl url = QUrl::fromLocalFile("qml/Main.qml");
   engine.load(url);

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -42,7 +42,59 @@ Dialog {
                 }
             }
         }
+        CheckBox {
+            id: visToggle
+            text: qsTr("Enable Visualization")
+            checked: true
+            onToggled: player.visualizer.setEnabled(checked)
+        }
+        Row {
+            spacing: 4
+            Button { text: qsTr("Prev Preset"); onClicked: player.visualizer.previousPreset() }
+            Button { text: qsTr("Next Preset"); onClicked: player.visualizer.nextPreset() }
+        }
+        GroupBox {
+            title: qsTr("Format Converter")
+            Column {
+                spacing: 4
+                Row {
+                    spacing: 4
+                    Button { text: qsTr("Input"); onClicked: inDialog.open() }
+                    Label { text: convInput }
+                }
+                Row {
+                    spacing: 4
+                    Button { text: qsTr("Output"); onClicked: outDialog.open() }
+                    Label { text: convOutput }
+                }
+                ComboBox { id: convType; model: [qsTr("Audio"), qsTr("Video")] }
+                Button {
+                    text: qsTr("Start")
+                    enabled: convInput !== "" && convOutput !== ""
+                    onClicked: {
+                        converting = true
+                        if (convType.currentIndex === 0)
+                            formatConverter.convertAudio(convInput, convOutput)
+                        else
+                            formatConverter.convertVideo(convInput, convOutput)
+                    }
+                }
+                ProgressBar { id: convProgress; value: 0; visible: converting }
+            }
+        }
     }
 
     property var discoveredDevices: []
+    property string convInput: ""
+    property string convOutput: ""
+    property bool converting: false
+
+    FileDialog { id: inDialog; onAccepted: convInput = file }
+    FileDialog { id: outDialog; onAccepted: convOutput = file }
+
+    Connections {
+        target: formatConverter
+        onProgressChanged: convProgress.value = progress
+        onConversionFinished: converting = false
+    }
 }

--- a/src/desktop/app/qml/SmartPlaylistEditor.qml
+++ b/src/desktop/app/qml/SmartPlaylistEditor.qml
@@ -6,8 +6,10 @@ Dialog {
     title: qsTr("Smart Playlist Editor")
     standardButtons: Dialog.Ok | Dialog.Cancel
     property var rules: []
+    property string playlistName: ""
     Column {
         spacing: 8
+        TextField { id: nameField; placeholderText: qsTr("Name"); text: dlg.playlistName }
         Repeater {
             model: dlg.rules
             delegate: Row {
@@ -41,6 +43,6 @@ Dialog {
             if (i > 0) query += " AND ";
             query += r.field + " " + r.op + " " + r.value;
         }
-        console.log("smart playlist", query)
+        playlistModel.createSmartPlaylist(nameField.text, query)
     }
 }

--- a/src/desktop/app/qml/VisualizationView.qml
+++ b/src/desktop/app/qml/VisualizationView.qml
@@ -1,5 +1,35 @@
 import QtQuick 2.15
+import QtQuick.Controls 2.15
+import MediaPlayer 1.0
 
-VisualizerItem {
-    anchors.fill: parent
+Item {
+    id: root
+    VisualizerItem {
+        id: canvas
+        anchors.fill: parent
+        visualizer: player.visualizer
+    }
+
+    Timer {
+        interval: 16
+        running: true
+        repeat: true
+        onTriggered: canvas.update()
+    }
+
+    Row {
+        spacing: 10
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        Button {
+            text: qsTr("Prev")
+            onClicked: player.visualizer.previousPreset()
+        }
+        Button {
+            text: qsTr("Next")
+            onClicked: player.visualizer.nextPreset()
+        }
+    }
+
+    Component.onCompleted: player.visualizer.setEnabled(true)
 }


### PR DESCRIPTION
## Summary
- allow creating smart playlists from QML
- expose a VisualizerQt instance through `MediaPlayerController`
- show visualization controls and format converter options in settings
- update visualization view to use the controller visualizer
- make `SmartPlaylistEditor` create playlists

## Testing
- `clang-format -i src/desktop/app/PlaylistModel.h src/desktop/app/PlaylistModel.cpp src/desktop/app/MediaPlayerController.h src/desktop/app/MediaPlayerController.cpp src/desktop/app/main.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68681dd8ab888331a105d607972616e4