### PR TITLE
Integrate library database and metadata updates

### DIFF
--- a/docs/folder_structure.md
+++ b/docs/folder_structure.md
@@ -3,18 +3,22 @@
 This document describes the intended layout of the repository. Each directory is accompanied by a short explanation or placeholder.
 
 ```
-/core/           - C++ engine
-/ui/desktop/     - Qt/QML interface
-/ui/android/     - Kotlin + JNI
-/ui/ios/         - Swift components
-/tests/          - unit/integration tests
-/docs/           - planning and contribution docs
+/core/        - cross-platform playback engine
+/desktop/     - desktop Qt UI and helpers
+/android/     - Android frontend (Kotlin)
+/ios/         - iOS frontend (Swift)
+/library/     - SQLite based media library
+/network/     - networking utilities
+/sync/        - device sync service
 ```
 
-- **/core/** – Contains the cross-platform C++17 engine responsible for media decoding and playback. Implementations are yet to be added.
-- **/ui/desktop/** – Desktop user interface built with Qt and QML. This folder will hold all desktop-specific source files and resources.
-- **/ui/android/** – Android application code written in Kotlin with JNI bindings to the core engine.
-- **/ui/ios/** – iOS interface components written in Swift, linked to the core through native bindings.
-- **/tests/** – Placeholder for unit and integration tests across modules. Includes test media files and scripts.
-- **/docs/** – Documentation for planning, contribution guidelines, and design notes. This file lives here along with other docs.
+- **/core/** – Cross-platform C++17 engine with audio/video decoders, outputs and player logic already implemented.
+- **/desktop/** – Qt/QML desktop interface and platform integrations.
+- **/android/** – Android application using JNI to the core engine.
+- **/ios/** – iOS interface components in Swift tied to the core.
+- **/library/** – Database layer providing media and playlist management.
+- **/network/** – Network helpers and streaming utilities.
+- **/sync/** – Local network sync service.
+- **/tests/** – Placeholder for unit and integration tests.
+- **/docs/** – Project documentation and guides.
 

--- a/src/desktop/AudioOutputQt.cpp
+++ b/src/desktop/AudioOutputQt.cpp
@@ -1,0 +1,57 @@
+#include "AudioOutputQt.h"
+#include <QMediaDevices>
+
+using namespace mediaplayer;
+
+AudioOutputQt::AudioOutputQt() : m_device(QMediaDevices::defaultAudioOutput()) {}
+
+AudioOutputQt::AudioOutputQt(const QAudioDevice &device) : m_device(device) {}
+
+AudioOutputQt::~AudioOutputQt() { shutdown(); }
+
+bool AudioOutputQt::init(int sampleRate, int channels) {
+  shutdown();
+  QAudioFormat fmt;
+  fmt.setSampleRate(sampleRate);
+  fmt.setChannelCount(channels);
+  fmt.setSampleFormat(QAudioFormat::Int16);
+  if (m_device.isNull())
+    m_device = QMediaDevices::defaultAudioOutput();
+  m_sink = new QAudioSink(m_device, fmt);
+  m_io = m_sink->start();
+  return m_io != nullptr;
+}
+
+void AudioOutputQt::shutdown() {
+  if (m_sink) {
+    m_sink->stop();
+    delete m_sink;
+    m_sink = nullptr;
+    m_io = nullptr;
+  }
+}
+
+int AudioOutputQt::write(const uint8_t *data, int len) {
+  if (!m_io)
+    return 0;
+  return static_cast<int>(m_io->write(reinterpret_cast<const char *>(data), len));
+}
+
+void AudioOutputQt::pause() {
+  if (m_sink)
+    m_sink->suspend();
+}
+
+void AudioOutputQt::resume() {
+  if (m_sink)
+    m_sink->resume();
+}
+
+void AudioOutputQt::setVolume(double volume) {
+  if (m_sink)
+    m_sink->setVolume(volume);
+}
+
+double AudioOutputQt::volume() const { return m_sink ? m_sink->volume() : 1.0; }
+
+void AudioOutputQt::setDevice(const QAudioDevice &device) { m_device = device; }

--- a/src/desktop/AudioOutputQt.h
+++ b/src/desktop/AudioOutputQt.h
@@ -1,0 +1,34 @@
+#ifndef MEDIAPLAYER_AUDIOOUTPUTQT_H
+#define MEDIAPLAYER_AUDIOOUTPUTQT_H
+
+#include "mediaplayer/AudioOutput.h"
+#include <QAudioDevice>
+#include <QAudioSink>
+
+namespace mediaplayer {
+
+class AudioOutputQt : public AudioOutput {
+public:
+  AudioOutputQt();
+  explicit AudioOutputQt(const QAudioDevice &device);
+  ~AudioOutputQt() override;
+
+  bool init(int sampleRate, int channels) override;
+  void shutdown() override;
+  int write(const uint8_t *data, int len) override;
+  void pause() override;
+  void resume() override;
+  void setVolume(double volume) override;
+  double volume() const override;
+
+  void setDevice(const QAudioDevice &device);
+
+private:
+  QAudioDevice m_device;
+  QAudioSink *m_sink{nullptr};
+  QIODevice *m_io{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_AUDIOOUTPUTQT_H

--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_AUTOMOC ON)
 add_library(mediaplayer_desktop
     FormatConverterQt.cpp
     LibraryQt.cpp
+    AudioOutputQt.cpp
     VisualizerQt.cpp
     VisualizerItem.cpp
     VideoOutputQt.cpp

--- a/src/desktop/app/MediaPlayerController.h
+++ b/src/desktop/app/MediaPlayerController.h
@@ -3,8 +3,12 @@
 
 #include "../VideoOutputQt.h"
 #include "../VisualizerQt.h"
+#include "mediaplayer/LibraryDB.h"
+#include "mediaplayer/MediaMetadata.h"
 #include "mediaplayer/MediaPlayer.h"
+#include <QAudioDevice>
 #include <QObject>
+#include <memory>
 
 namespace mediaplayer {
 
@@ -15,6 +19,10 @@ class MediaPlayerController : public QObject {
   Q_PROPERTY(double volume READ volume WRITE setVolume NOTIFY volumeChanged)
   Q_PROPERTY(VideoOutputQt *videoOutput READ videoOutput CONSTANT)
   Q_PROPERTY(VisualizerQt *visualizer READ visualizer CONSTANT)
+  Q_PROPERTY(QString title READ title NOTIFY currentMetadataChanged)
+  Q_PROPERTY(QString artist READ artist NOTIFY currentMetadataChanged)
+  Q_PROPERTY(QString album READ album NOTIFY currentMetadataChanged)
+  Q_PROPERTY(double duration READ duration NOTIFY currentMetadataChanged)
 public:
   explicit MediaPlayerController(QObject *parent = nullptr);
 
@@ -24,10 +32,16 @@ public:
   Q_INVOKABLE void stop();
   Q_INVOKABLE void seek(double position);
   Q_INVOKABLE void setVolume(double vol);
+  Q_INVOKABLE void setAudioDevice(const QAudioDevice &device);
+  void setLibrary(LibraryDB *db);
 
   bool playing() const;
   double position() const;
   double volume() const;
+  QString title() const;
+  QString artist() const;
+  QString album() const;
+  double duration() const;
 
   VideoOutputQt *videoOutput() const { return m_videoOutput; }
   VisualizerQt *visualizer() const { return m_visualizer; }
@@ -36,12 +50,14 @@ signals:
   void playbackStateChanged();
   void positionChanged();
   void volumeChanged();
+  void currentMetadataChanged(const MediaMetadata &meta);
   void errorOccurred(const QString &message);
 
 private:
   MediaPlayer m_player;
   VideoOutputQt *m_videoOutput{nullptr};
   VisualizerQt *m_visualizer{nullptr};
+  MediaMetadata m_meta;
 };
 
 } // namespace mediaplayer

--- a/src/desktop/app/macos/MacIntegration.mm
+++ b/src/desktop/app/macos/MacIntegration.mm
@@ -78,4 +78,11 @@ void updateNowPlayingInfo(const MediaMetadata &meta) {
   [[MPNowPlayingInfoCenter defaultCenter] setNowPlayingInfo:info];
 }
 
+#include "../MediaPlayerController.h"
+
+void connectNowPlayingInfo(mediaplayer::MediaPlayerController *controller) {
+  QObject::connect(controller, &mediaplayer::MediaPlayerController::currentMetadataChanged,
+                   [](const mediaplayer::MediaMetadata &meta) { updateNowPlayingInfo(meta); });
+}
+
 void setupMacIntegration() { setupMediaKeyTap(); }

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -11,6 +11,15 @@ ApplicationWindow {
     property string errorMessage: ""
     property string currentFile: ""
 
+    Connections {
+        target: sync
+        function onSyncReceived(path, position) {
+            player.openFile(path)
+            player.seek(position)
+            win.currentFile = path
+        }
+    }
+
     MediaPlayerController {
         id: player
         onErrorOccurred: {
@@ -70,6 +79,12 @@ ApplicationWindow {
     ColumnLayout {
         anchors.fill: parent
         VideoPlayer { Layout.fillWidth: true; height: 300 }
+        RowLayout {
+            spacing: 8
+            Label { text: player.title }
+            Label { text: player.artist }
+            Label { text: player.album }
+        }
         LibraryView { Layout.fillWidth: true; Layout.fillHeight: true }
         PlaylistView { Layout.fillWidth: true; height: 100 }
         VisualizationView { Layout.fillWidth: true; height: 150 }
@@ -88,7 +103,16 @@ ApplicationWindow {
                 icon.source: "qrc:/icons/next.svg"
                 onClicked: player.seek(player.position() + 10)
             }
-            Slider { Layout.fillWidth: true; from: 0; to: 100; onMoved: player.seek(value) }
+            Label { text: Math.floor(player.position) }
+            Slider {
+                id: seekSlider
+                Layout.fillWidth: true
+                from: 0
+                to: player.duration
+                value: player.position
+                onMoved: player.seek(value)
+            }
+            Label { text: Math.floor(player.duration) }
             Slider { from: 0; to: 1; value: 1; onValueChanged: player.setVolume(value) }
         }
     }

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -11,7 +11,12 @@ Dialog {
         Row {
             spacing: 4
             Label { text: qsTr("Audio device") }
-            ComboBox { id: deviceBox; model: audioDevicesModel; textRole: "name" }
+            ComboBox {
+                id: deviceBox
+                model: audioDevicesModel
+                textRole: "name"
+                onActivated: player.setAudioDevice(audioDevicesModel.deviceAt(currentIndex))
+            }
             Button { text: qsTr("Refresh"); onClicked: audioDevicesModel.refresh() }
         }
         Row {
@@ -40,6 +45,18 @@ Dialog {
                     text: qsTr("Send")
                     onClicked: sync.sendSync(address, port, win.currentFile, player.position())
                 }
+            }
+        }
+        Row {
+            spacing: 4
+            Button {
+                text: qsTr("Scan Library")
+                onClicked: scanDialog.open()
+            }
+            ProgressBar {
+                id: scanProgress
+                value: 0
+                visible: libraryQt.scanRunning()
             }
         }
         CheckBox {
@@ -89,8 +106,20 @@ Dialog {
     property string convOutput: ""
     property bool converting: false
 
+    FileDialog {
+        id: scanDialog
+        selectFolder: true
+        onAccepted: libraryQt.startScan(folder)
+    }
+
     FileDialog { id: inDialog; onAccepted: convInput = file }
     FileDialog { id: outDialog; onAccepted: convOutput = file }
+
+    Connections {
+        target: libraryQt
+        onScanProgress: scanProgress.value = total > 0 ? current / total : 0
+        onScanFinished: scanProgress.value = 1
+    }
 
     Connections {
         target: formatConverter


### PR DESCRIPTION
## Summary
- hook up `LibraryDB` in the desktop app and expose it through `LibraryQt`
- emit metadata change and playback signals from `MediaPlayerController`
- update macOS and Windows integrations for metadata and state handling
- add Qt audio output implementation and audio device selection
- improve QML UI with sync handling, metadata display, and library scanning
- refresh folder structure documentation

## Testing
- `clang-format -i src/desktop/AudioOutputQt.h src/desktop/AudioOutputQt.cpp src/desktop/app/MediaPlayerController.h src/desktop/app/MediaPlayerController.cpp src/desktop/app/main.cpp src/desktop/app/macos/MacIntegration.mm src/desktop/app/windows/WinIntegration.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68682500dd58833189168fd6e21c1da4