### PR TITLE
Reformat SettingsDialog QML

### DIFF
--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -1,164 +1,198 @@
-import QtQuick 2.15 import QtQuick.Controls 2.15
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Dialogs 1.3
 
-    Dialog{id:settingsDialog title:qsTr("Settings") standardButtons:Dialog.Close onOpened: {themeBox.checked = settings.theme == = "dark" for (let i = 0;
-i < audioDevicesModel.rowCount(); ++i) {
-  if (audioDevicesModel.get(i).name == = settings.audioDevice) {
-    deviceBox.currentIndex = i break
-  }
-}
-}
-Column {
-spacing:
-  8 CheckBox {
-  id:
-    themeBox text : qsTr("Dark theme") onToggled
-        : {Qt.application.theme =
-               checked ? "dark" : "light" settings.theme = checked ? "dark" : "light"}
-  }
-  Row {
-  spacing:
-    4 Label{text : qsTr("Audio device")} ComboBox {
-    id:
-      deviceBox model : audioDevicesModel textRole : "name" onActivated : {
-        let dev = audioDevicesModel.deviceAt(currentIndex) player.setAudioDevice(dev)
-                      settings.audioDevice = audioDevicesModel.get(currentIndex).name
-      }
-    }
-    Button {
-    text:
-      qsTr("Refresh");
-    onClicked:
-      audioDevicesModel.refresh()
-    }
-  }
-  Row {
-  spacing:
-    4 Label{text : qsTr("Language")} ComboBox {
-    id:
-      lang model : [ {text : "English", value : "en"}, {text : "Español", value : "es"} ] textRole
-          : "text" onActivated : translation.switchLanguage(model[currentIndex].value)
-    }
-  }
-  Button{
-    text : qsTr("Discover Devices") onClicked : discoveredDevices = sync.discoverDevices()
-  } ListView {
-  id:
-    deviceList height : 100 width : parent.width model : discoveredDevices delegate : Row {
-    spacing:
-      4 Text{text : name} Button {
-      text:
-        qsTr("Send") onClicked : sync.sendSync(address, port, win.currentFile, player.position())
-      }
-    }
-  }
-  Row {
-  spacing:
-    4 Button{text : qsTr("Scan Library") onClicked : scanDialog.open()} ProgressBar {
-    id:
-      scanProgress value : 0 visible : libraryQt.scanRunning()
-    }
-  }
-  CheckBox{
-    id : visToggle text : qsTr("Enable Visualization") checked : true
-    onToggled : player.visualizer.setEnabled(checked)
-  } Row {
-  spacing:
-    4 Button {
-    text:
-      qsTr("Prev Preset");
-    onClicked:
-      player.visualizer.previousPreset()
-    }
-    Button {
-    text:
-      qsTr("Next Preset");
-    onClicked:
-      player.visualizer.nextPreset()
-    }
-  }
-  GroupBox {
-  title:
-    qsTr("Format Converter") Column {
-    spacing:
-      4 Row {
-      spacing:
-        4 Button {
-        text:
-          qsTr("Input");
-        onClicked:
-          inDialog.open()
+Dialog {
+    id: settingsDialog
+    title: qsTr("Settings")
+    standardButtons: Dialog.Close
+    onOpened: {
+        themeBox.checked = settings.theme == "dark"
+        for (let i = 0; i < audioDevicesModel.rowCount(); ++i) {
+            if (audioDevicesModel.get(i).name == settings.audioDevice) {
+                deviceBox.currentIndex = i
+                break
+            }
         }
-        Label {
-        text:
-          convInput
-        }
-      }
-      Row {
-      spacing:
-        4 Button {
-        text:
-          qsTr("Output");
-        onClicked:
-          outDialog.open()
-        }
-        Label {
-        text:
-          convOutput
-        }
-      }
-      ComboBox {
-      id:
-        convType;
-      model:
-        [ qsTr("Audio"), qsTr("Video") ]
-      }
-      Button {
-      text:
-        qsTr("Start") enabled : convInput != = "" &&convOutput != = "" onClicked : {
-          converting = true if (convType.currentIndex == = 0)
-                           formatConverter.convertAudio(convInput, convOutput) else formatConverter
-                               .convertVideo(convInput, convOutput)
-        }
-      }
-      ProgressBar {
-      id:
-        convProgress;
-      value:
-        0;
-      visible:
-        converting
-      }
     }
-  }
-}
 
-property var discoveredDevices : [] property string convInput : "" property string convOutput
-    : "" property bool converting
-    : false
+    Column {
+        spacing: 8
 
-      FileDialog{id : scanDialog selectFolder : true onAccepted : libraryQt.startScan(folder)}
+        CheckBox {
+            id: themeBox
+            text: qsTr("Dark theme")
+            onToggled: {
+                Qt.application.theme = checked ? "dark" : "light"
+                settings.theme = checked ? "dark" : "light"
+            }
+        }
 
-      FileDialog {
-id:
-  inDialog;
-onAccepted:
-  convInput = file
-}
-FileDialog {
-id:
-  outDialog;
-onAccepted:
-  convOutput = file
-}
+        Row {
+            spacing: 4
+            Label { text: qsTr("Audio device") }
+            ComboBox {
+                id: deviceBox
+                model: audioDevicesModel
+                textRole: "name"
+                onActivated: {
+                    let dev = audioDevicesModel.deviceAt(currentIndex)
+                    player.setAudioDevice(dev)
+                    settings.audioDevice = audioDevicesModel.get(currentIndex).name
+                }
+            }
+            Button {
+                text: qsTr("Refresh")
+                onClicked: audioDevicesModel.refresh()
+            }
+        }
 
-Connections{
-  target : libraryQt onScanProgress : scanProgress.value =
-      total > 0 ? current / total : 0 onScanFinished : scanProgress.value = 1
-}
+        Row {
+            spacing: 4
+            Label { text: qsTr("Language") }
+            ComboBox {
+                id: lang
+                model: [
+                    { text: "English", value: "en" },
+                    { text: "Español", value: "es" }
+                ]
+                textRole: "text"
+                onActivated: translation.switchLanguage(model[currentIndex].value)
+            }
+        }
 
-Connections {
-target:
-  formatConverter onProgressChanged : convProgress.value =
-      progress onConversionFinished : converting = false
-}
+        Button {
+            text: qsTr("Discover Devices")
+            onClicked: discoveredDevices = sync.discoverDevices()
+        }
+
+        ListView {
+            id: deviceList
+            height: 100
+            width: parent.width
+            model: discoveredDevices
+            delegate: Row {
+                spacing: 4
+                Text { text: name }
+                Button {
+                    text: qsTr("Send")
+                    onClicked: sync.sendSync(address, port, win.currentFile, player.position())
+                }
+            }
+        }
+
+        Row {
+            spacing: 4
+            Button {
+                text: qsTr("Scan Library")
+                onClicked: scanDialog.open()
+            }
+            ProgressBar {
+                id: scanProgress
+                value: 0
+                visible: libraryQt.scanRunning()
+            }
+        }
+
+        CheckBox {
+            id: visToggle
+            text: qsTr("Enable Visualization")
+            checked: true
+            onToggled: player.visualizer.setEnabled(checked)
+        }
+
+        Row {
+            spacing: 4
+            Button {
+                text: qsTr("Prev Preset")
+                onClicked: player.visualizer.previousPreset()
+            }
+            Button {
+                text: qsTr("Next Preset")
+                onClicked: player.visualizer.nextPreset()
+            }
+        }
+
+        GroupBox {
+            title: qsTr("Format Converter")
+
+            Column {
+                spacing: 4
+
+                Row {
+                    spacing: 4
+                    Button {
+                        text: qsTr("Input")
+                        onClicked: inDialog.open()
+                    }
+                    Label { text: convInput }
+                }
+
+                Row {
+                    spacing: 4
+                    Button {
+                        text: qsTr("Output")
+                        onClicked: outDialog.open()
+                    }
+                    Label { text: convOutput }
+                }
+
+                ComboBox {
+                    id: convType
+                    model: [ qsTr("Audio"), qsTr("Video") ]
+                }
+
+                Button {
+                    text: qsTr("Start")
+                    enabled: convInput != "" && convOutput != ""
+                    onClicked: {
+                        converting = true
+                        if (convType.currentIndex == 0)
+                            formatConverter.convertAudio(convInput, convOutput)
+                        else
+                            formatConverter.convertVideo(convInput, convOutput)
+                    }
+                }
+
+                ProgressBar {
+                    id: convProgress
+                    value: 0
+                    visible: converting
+                }
+            }
+        }
+    }
+
+    property var discoveredDevices: []
+    property string convInput: ""
+    property string convOutput: ""
+    property bool converting: false
+
+    FileDialog {
+        id: scanDialog
+        selectFolder: true
+        onAccepted: libraryQt.startScan(folder)
+    }
+
+    FileDialog {
+        id: inDialog
+        onAccepted: convInput = file
+    }
+
+    FileDialog {
+        id: outDialog
+        onAccepted: convOutput = file
+    }
+
+    Connections {
+        target: libraryQt
+        onScanProgress: scanProgress.value = total > 0 ? current / total : 0
+        onScanFinished: scanProgress.value = 1
+    }
+
+    Connections {
+        target: formatConverter
+        onProgressChanged: convProgress.value = progress
+        onConversionFinished: converting = false
+    }
 }


### PR DESCRIPTION
## Summary
- reformat `SettingsDialog.qml` to follow standard QML style
- fix comparison operators
- keep all UI controls (theme toggle, audio device list, library scan, visualization, format converter)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68686295d29483319f8f0ae009fcd783