### PR TITLE
Add Qt Dockerfile

### DIFF
--- a/Dockerfile.qt
+++ b/Dockerfile.qt
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential cmake git \
+        qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-multimedia-dev \
+        libqt6svg6-dev \
+        libavcodec-dev libavformat-dev libswresample-dev libswscale-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+RUN cmake -S . -B /build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build /build --parallel
+
+CMD ["/bin/bash"]

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,1 +1,30 @@
 # DevOps & Infrastructure
+
+This directory contains container definitions and helper scripts for building MediaPlayer.
+
+## Qt build container
+
+`Dockerfile.qt` provides an Ubuntu image with the Qt 6 SDK installed. Use it when you want to compile the desktop application without installing Qt locally.
+
+### Build the image
+
+```bash
+docker build -f Dockerfile.qt -t mediaplayer-qt .
+```
+
+### Build the desktop app inside the container
+
+Running the image drops you in a shell where the project has already been configured and built with CMake. The resulting binary lives in `/build/mediaplayer_desktop_app`.
+
+```bash
+docker run --rm -it mediaplayer-qt
+```
+
+To launch the GUI on a Linux host using X11 forwarding:
+
+```bash
+docker run --rm -it \
+    -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    mediaplayer-qt /build/mediaplayer_desktop_app
+```


### PR DESCRIPTION
## Summary
- add Dockerfile.qt for Qt 6 development
- document how to use the container for building the desktop app

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868629a56bc8331a44a1a51f8f61f33