### PR TITLE
Add previous track playback support

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -46,6 +46,7 @@ public:
   void addToPlaylist(const std::string &path);
   void clearPlaylist();
   bool nextTrack();
+  bool previousTrack();
   void enableShuffle(bool enabled);
   bool shuffleEnabled() const;
   std::vector<std::string> queue() const;

--- a/src/core/include/mediaplayer/PlaylistManager.h
+++ b/src/core/include/mediaplayer/PlaylistManager.h
@@ -14,6 +14,7 @@ public:
   bool remove(const std::string &path);
   void clear();
   std::string next();
+  std::string previous();
   bool empty() const;
   void reset();
   void enableShuffle(bool enabled);
@@ -28,6 +29,8 @@ private:
   bool m_shuffle{false};
   std::vector<size_t> m_unusedIndices;
   std::mt19937 m_rng{std::random_device{}()};
+  std::vector<size_t> m_history;
+  size_t m_historyPos{0};
   void resetShuffle();
 };
 

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -493,6 +493,21 @@ bool MediaPlayer::nextTrack() {
   return true;
 }
 
+bool MediaPlayer::previousTrack() {
+  std::string path;
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    path = m_playlist.previous();
+    if (path.empty())
+      return false;
+  }
+  stop();
+  if (!open(path))
+    return false;
+  play();
+  return true;
+}
+
 void MediaPlayer::demuxLoop() {
   AVPacket pkt;
   while (true) {

--- a/src/desktop/app/MediaPlayerController.cpp
+++ b/src/desktop/app/MediaPlayerController.cpp
@@ -77,7 +77,12 @@ void MediaPlayerController::nextTrack() {
   }
 }
 
-void MediaPlayerController::previousTrack() { seek(position() - 10); }
+void MediaPlayerController::previousTrack() {
+  if (m_player.previousTrack()) {
+    m_nowPlaying->refresh();
+    emit queueUpdated();
+  }
+}
 
 void MediaPlayerController::removeFromQueue(int row) {
   if (m_player.removeFromQueue(static_cast<size_t>(row))) {


### PR DESCRIPTION
## Summary
- extend PlaylistManager with history tracking and a new `previous()` function
- expose `MediaPlayer::previousTrack()` and hook it up in the controller
- update queue modifications to account for playlist history
- wire up existing hotkey and MPRIS integrations via controller

## Testing
- `g++ -std=c++17 -I src/core/include -c src/core/src/PlaylistManager.cpp -o /tmp/pm.o`
- `g++ -std=c++17 -I src/core/include -c src/core/src/MediaPlayer.cpp -o /tmp/mp.o` *(fails: libavcodec/avcodec.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868629c9e548331a9972cc0b03a1f04