### PR TITLE
Add translations and remove compiled files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository hosts the early scaffolding for a cross-platform media player wr
 - Commit logically separated changes with clear messages. Pull requests are squash-merged into `main`.
 - There is currently no automated test suite or build script. Agents do not need to run tests, but should ensure modified code compiles where applicable.
 - Binary assets such as images (`*.png`, `*.jpg`) are not stored in the repository. If a task requires them, describe the intended asset instead of adding the file so maintainers can create it manually.
+- Compiled Qt translation files (`*.qm`) are treated as binary assets and should not be committed. Generate them locally when needed and exclude them from pull requests.
 
 ## Repo Structure
 

--- a/src/desktop/app/translations/player_en.ts
+++ b/src/desktop/app/translations/player_en.ts
@@ -5,182 +5,182 @@
     <name>Main</name>
     <message>
         <source>MediaPlayer</source>
-        <translation type="unfinished">MediaPlayer</translation>
+        <translation>MediaPlayer</translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Search</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Open</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>Playback Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Playback Error</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <source>MediaPlayer</source>
-        <translation type="vanished">MediaPlayer</translation>
+        <translation>MediaPlayer</translation>
     </message>
 </context>
 <context>
     <name>NowPlayingView</name>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove</translation>
     </message>
 </context>
 <context>
     <name>PlaylistItemsView</name>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove</translation>
     </message>
 </context>
 <context>
     <name>PlaylistView</name>
     <message>
         <source>New playlist</source>
-        <translation type="unfinished"></translation>
+        <translation>New playlist</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Previous</translation>
     </message>
     <message>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Play</translation>
     </message>
     <message>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>Dark theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Dark theme</translation>
     </message>
     <message>
         <source>Audio device</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio device</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>Refresh</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>Language</translation>
     </message>
     <message>
         <source>Discover Devices</source>
-        <translation type="unfinished"></translation>
+        <translation>Discover Devices</translation>
     </message>
     <message>
         <source>Send</source>
-        <translation type="unfinished"></translation>
+        <translation>Send</translation>
     </message>
     <message>
         <source>Scan Library</source>
-        <translation type="unfinished"></translation>
+        <translation>Scan Library</translation>
     </message>
     <message>
         <source>Enable Visualization</source>
-        <translation type="unfinished"></translation>
+        <translation>Enable Visualization</translation>
     </message>
     <message>
         <source>Prev Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Prev Preset</translation>
     </message>
     <message>
         <source>Next Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Next Preset</translation>
     </message>
     <message>
         <source>Format Converter</source>
-        <translation type="unfinished"></translation>
+        <translation>Format Converter</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Input</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Output</translation>
     </message>
     <message>
         <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio</translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"></translation>
+        <translation>Video</translation>
     </message>
     <message>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation>Start</translation>
     </message>
 </context>
 <context>
     <name>SmartPlaylistEditor</name>
     <message>
         <source>Smart Playlist Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Smart Playlist Editor</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Name</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Remove</translation>
     </message>
     <message>
         <source>Add Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Add Rule</translation>
     </message>
 </context>
 <context>
     <name>VisualizationView</name>
     <message>
         <source>Prev</source>
-        <translation type="unfinished"></translation>
+        <translation>Prev</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Next</translation>
     </message>
 </context>
 <context>
     <name>mediaplayer::MediaPlayerController</name>
     <message>
         <source>Failed to open file</source>
-        <translation type="unfinished"></translation>
+        <translation>Failed to open file</translation>
     </message>
 </context>
 </TS>

--- a/src/desktop/app/translations/player_es.ts
+++ b/src/desktop/app/translations/player_es.ts
@@ -5,182 +5,182 @@
     <name>Main</name>
     <message>
         <source>MediaPlayer</source>
-        <translation type="unfinished">Reproductor</translation>
+        <translation>Reproductor</translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Buscar</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuración</translation>
     </message>
     <message>
         <source>Playback Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error de reproducción</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <source>MediaPlayer</source>
-        <translation type="vanished">Reproductor</translation>
+        <translation>Reproductor</translation>
     </message>
 </context>
 <context>
     <name>NowPlayingView</name>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>PlaylistItemsView</name>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>PlaylistView</name>
     <message>
         <source>New playlist</source>
-        <translation type="unfinished"></translation>
+        <translation>Nueva lista de reproducción</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducir</translation>
     </message>
     <message>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pausar</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente</translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuración</translation>
     </message>
     <message>
         <source>Dark theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Tema oscuro</translation>
     </message>
     <message>
         <source>Audio device</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo de audio</translation>
     </message>
     <message>
         <source>Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>Actualizar</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>Idioma</translation>
     </message>
     <message>
         <source>Discover Devices</source>
-        <translation type="unfinished"></translation>
+        <translation>Buscar dispositivos</translation>
     </message>
     <message>
         <source>Send</source>
-        <translation type="unfinished"></translation>
+        <translation>Enviar</translation>
     </message>
     <message>
         <source>Scan Library</source>
-        <translation type="unfinished"></translation>
+        <translation>Escanear biblioteca</translation>
     </message>
     <message>
         <source>Enable Visualization</source>
-        <translation type="unfinished"></translation>
+        <translation>Activar visualización</translation>
     </message>
     <message>
         <source>Prev Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Preajuste anterior</translation>
     </message>
     <message>
         <source>Next Preset</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente preajuste</translation>
     </message>
     <message>
         <source>Format Converter</source>
-        <translation type="unfinished"></translation>
+        <translation>Convertidor de formato</translation>
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrada</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Salida</translation>
     </message>
     <message>
         <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio</translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"></translation>
+        <translation>Vídeo</translation>
     </message>
     <message>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation>Comenzar</translation>
     </message>
 </context>
 <context>
     <name>SmartPlaylistEditor</name>
     <message>
         <source>Smart Playlist Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Editor de listas inteligentes</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar</translation>
     </message>
     <message>
         <source>Add Rule</source>
-        <translation type="unfinished"></translation>
+        <translation>Agregar regla</translation>
     </message>
 </context>
 <context>
     <name>VisualizationView</name>
     <message>
         <source>Prev</source>
-        <translation type="unfinished"></translation>
+        <translation>Anterior</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Siguiente</translation>
     </message>
 </context>
 <context>
     <name>mediaplayer::MediaPlayerController</name>
     <message>
         <source>Failed to open file</source>
-        <translation type="unfinished"></translation>
+        <translation>No se pudo abrir el archivo</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary
- provide English and Spanish translations for all UI strings
- document in `AGENTS.md` that `.qm` files are binary and should not be committed
- remove compiled `.qm` files from the repository

## Testing
- `lrelease src/desktop/app/translations/player_en.ts -qm /tmp/player_en.qm`
- `lrelease src/desktop/app/translations/player_es.ts -qm /tmp/player_es.qm`


------
https://chatgpt.com/codex/tasks/task_e_68686298a0b88331a2ed6e78e7e2aa1b