### PR TITLE
Add NowPlayingView to main UI

### DIFF
--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Dialogs 1.3
+import "NowPlayingView.qml" as NowPlayingView
 
 ApplicationWindow {
     id: win
@@ -99,6 +100,10 @@ ApplicationWindow {
         }
         LibraryView { Layout.fillWidth: true; Layout.fillHeight: true }
         PlaylistView { Layout.fillWidth: true; height: 100 }
+        NowPlayingView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 120
+        }
         VisualizationView { Layout.fillWidth: true; height: 150 }
         RowLayout {
             Layout.fillWidth: true


### PR DESCRIPTION
## Summary
- import `NowPlayingView.qml` in `Main.qml`
- insert `NowPlayingView` after `PlaylistView` to show current queue

No new translation strings were introduced. `lupdate` confirmed this during the update process.

## Testing
- `lupdate qml main.cpp -ts translations/player_en.ts translations/player_es.ts`
- `lrelease translations/player_en.ts -qm translations/player_en.qm`
- `lrelease translations/player_es.ts -qm translations/player_es.qm`


------
https://chatgpt.com/codex/tasks/task_e_68686e82fbf48331a8236722e0c04732