### PR TITLE
Implement playlist item dialog and smart playlist creation

### DIFF
--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -61,6 +61,11 @@ target_include_directories(mediaplayer_desktop_app PRIVATE
 )
 
 file(COPY qml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY
+    qml/PlaylistItemsDialog.qml
+    qml/PlaylistItemsView.qml
+    qml/SmartPlaylistEditor.qml
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/qml)
 set(TS_FILES translations/player_en.ts translations/player_es.ts)
 qt6_add_translations(QM_FILES ${TS_FILES})
 add_custom_target(trans_qm ALL DEPENDS ${QM_FILES})

--- a/src/desktop/app/app.qrc
+++ b/src/desktop/app/app.qrc
@@ -4,5 +4,11 @@
         <file>resources/icons/pause.svg</file>
         <file>resources/icons/next.svg</file>
         <file>resources/icons/prev.svg</file>
+</qresource>
+    <qresource prefix="/qml">
+        <file>qml/PlaylistItemsDialog.qml</file>
+        <file>qml/PlaylistItemsView.qml</file>
+        <file>qml/SmartPlaylistEditor.qml</file>
+        <file>qml/PlaylistView.qml</file>
     </qresource>
 </RCC>

--- a/src/desktop/app/qml/PlaylistItemsDialog.qml
+++ b/src/desktop/app/qml/PlaylistItemsDialog.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Dialog {
+    id: dlg
+    property string playlistName: ""
+    title: playlistName
+    width: 400
+    height: 300
+    standardButtons: Dialog.Close
+
+    PlaylistItemsView {
+        anchors.fill: parent
+        playlistName: dlg.playlistName
+    }
+}

--- a/src/desktop/app/qml/PlaylistView.qml
+++ b/src/desktop/app/qml/PlaylistView.qml
@@ -3,19 +3,33 @@ import QtQuick.Controls 2.15
 
 Column {
     spacing: 4
-    TextField {
-        id: nameField
-        placeholderText: qsTr("New playlist")
-        onAccepted: { playlistModel.createPlaylist(text); text = "" }
+
+    SmartPlaylistEditor { id: smartEditor }
+    PlaylistItemsDialog { id: itemsDialog }
+
+    Row {
+        spacing: 4
+        TextField {
+            id: nameField
+            placeholderText: qsTr("New playlist")
+            onAccepted: { playlistModel.createPlaylist(text); text = "" }
+        }
+        Button {
+            text: qsTr("New smart playlist")
+            onClicked: smartEditor.open()
+        }
     }
+
     ListView {
         id: list
         anchors.fill: parent
         model: playlistModel
         delegate: Row {
             spacing: 4
-            Text { text: model.name }
-            Button { text: qsTr("Delete"); onClicked: playlistModel.removePlaylist(model.name) }
+            property string plName: model.name
+            Text { text: plName }
+            Button { text: qsTr("Open"); onClicked: { itemsDialog.playlistName = plName; itemsDialog.open() } }
+            Button { text: qsTr("Delete"); onClicked: playlistModel.removePlaylist(plName) }
         }
     }
 }

--- a/src/desktop/app/translations/player_en.ts
+++ b/src/desktop/app/translations/player_en.ts
@@ -52,6 +52,14 @@
         <translation>New playlist</translation>
     </message>
     <message>
+        <source>New smart playlist</source>
+        <translation>New smart playlist</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Open</translation>
+    </message>
+    <message>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>

--- a/src/desktop/app/translations/player_es.ts
+++ b/src/desktop/app/translations/player_es.ts
@@ -52,6 +52,14 @@
         <translation>Nueva lista de reproducción</translation>
     </message>
     <message>
+        <source>New smart playlist</source>
+        <translation>Nueva lista inteligente</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Abrir</translation>
+    </message>
+    <message>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>


### PR DESCRIPTION
## Summary
- allow creating smart playlists from PlaylistView
- open selected playlists in a new PlaylistItemsDialog
- add PlaylistItemsDialog QML component
- include QML files in resources and copy via CMake
- update English and Spanish translations

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_686887458c008331b47eef8290b98a03