### PR TITLE
Fix property access for player position in QML

### DIFF
--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -109,7 +109,7 @@ ApplicationWindow {
             Layout.fillWidth: true
             ToolButton {
                 icon.source: "qrc:/icons/prev.svg"
-                onClicked: player.seek(player.position() - 10)
+                onClicked: player.seek(player.position - 10)
             }
             ToolButton {
                 id: playPause
@@ -118,7 +118,7 @@ ApplicationWindow {
             }
             ToolButton {
                 icon.source: "qrc:/icons/next.svg"
-                onClicked: player.seek(player.position() + 10)
+                onClicked: player.seek(player.position + 10)
             }
             Label { text: Math.floor(player.position) }
             Slider {

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -76,7 +76,7 @@ Dialog {
                 Text { text: name }
                 Button {
                     text: qsTr("Send")
-                    onClicked: sync.sendSync(address, port, win.currentFile, player.position())
+                    onClicked: sync.sendSync(address, port, win.currentFile, player.position)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix incorrect calls to `player.position()` in QML
- update seek buttons and sync send usage to use `player.position`

## Testing
- `qmlcachegen src/desktop/app/qml/Main.qml`
- `qmlcachegen src/desktop/app/qml/SettingsDialog.qml`
- `qmllint src/desktop/app/qml/Main.qml`

------
https://chatgpt.com/codex/tasks/task_e_6868874b80248331a69254b712a9c62e