### PR TITLE
Link core library in desktop app

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -37,6 +37,8 @@ public:
   MediaPlayer();
   ~MediaPlayer();
 
+  static std::string version();
+
   bool open(const std::string &path);
   void play();
   void pause();

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -711,4 +711,6 @@ void MediaPlayer::subtitleLoop() {
   }
 }
 
+std::string MediaPlayer::version() { return "0.1.0"; }
+
 } // namespace mediaplayer

--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(mediaplayer_desktop_app PRIVATE ${mediaplayer_desktop_app_resourc
 
 target_include_directories(mediaplayer_desktop_app PRIVATE
     ${CMAKE_SOURCE_DIR}/src/core/include
+    ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/src/desktop
 )
 

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -15,6 +15,8 @@
 #include "SyncController.h"
 #include "TranslationManager.h"
 #include "VideoItem.h"
+#include "mediaplayer/MediaPlayer.h"
+#include <QDebug>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
@@ -32,6 +34,9 @@ void setupWindowsIntegration();
 
 int main(int argc, char *argv[]) {
   QGuiApplication app(argc, argv);
+
+  qInfo() << "MediaPlayer core version:"
+          << QString::fromStdString(mediaplayer::MediaPlayer::version());
 
   mediaplayer::SettingsManager settings;
 


### PR DESCRIPTION
## Summary
- expose `MediaPlayer::version()` in the core library
- include core headers in the desktop app build
- print the core version at startup

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp src/desktop/app/main.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68695dfb4100833188f70b35cfd2d467