### PR TITLE
Add roles to LibraryModel and update view

### DIFF
--- a/src/desktop/app/LibraryModel.cpp
+++ b/src/desktop/app/LibraryModel.cpp
@@ -28,6 +28,16 @@ QVariant LibraryModel::data(const QModelIndex &index, int role) const {
     return QString::fromStdString(m.path);
   case TitleRole:
     return QString::fromStdString(m.title);
+  case ArtistRole:
+    return QString::fromStdString(m.artist);
+  case AlbumRole:
+    return QString::fromStdString(m.album);
+  case GenreRole:
+    return QString::fromStdString(m.genre);
+  case DurationRole:
+    return m.duration;
+  case RatingRole:
+    return m.rating;
   }
   return {};
 }
@@ -36,6 +46,11 @@ QHash<int, QByteArray> LibraryModel::roleNames() const {
   QHash<int, QByteArray> roles;
   roles[PathRole] = "path";
   roles[TitleRole] = "title";
+  roles[ArtistRole] = "artist";
+  roles[AlbumRole] = "album";
+  roles[GenreRole] = "genre";
+  roles[DurationRole] = "duration";
+  roles[RatingRole] = "rating";
   return roles;
 }
 

--- a/src/desktop/app/LibraryModel.h
+++ b/src/desktop/app/LibraryModel.h
@@ -9,7 +9,15 @@ namespace mediaplayer {
 class LibraryModel : public QAbstractListModel {
   Q_OBJECT
 public:
-  enum Roles { PathRole = Qt::UserRole + 1, TitleRole };
+  enum Roles {
+    PathRole = Qt::UserRole + 1,
+    TitleRole,
+    ArtistRole,
+    AlbumRole,
+    GenreRole,
+    DurationRole,
+    RatingRole
+  };
 
   explicit LibraryModel(QObject *parent = nullptr);
   void setLibrary(LibraryDB *db);

--- a/src/desktop/app/qml/LibraryView.qml
+++ b/src/desktop/app/qml/LibraryView.qml
@@ -7,9 +7,17 @@ ListView {
     model: libraryModel
     delegate: Item {
         width: parent.width
-        height: 24
+        height: 40
         property string path: model.path
-        Text { text: model.title; anchors.verticalCenter: parent.verticalCenter }
+        Column {
+            anchors.verticalCenter: parent.verticalCenter
+            Text { text: model.title }
+            Text {
+                text: model.artist
+                font.pixelSize: 10
+                color: "#666"
+            }
+        }
         MouseArea {
             id: dragArea
             anchors.fill: parent


### PR DESCRIPTION
## Summary
- extend `LibraryModel` roles to expose artist, album and more metadata
- implement new role handling in `LibraryModel` implementation
- enhance QML library view to show title and artist

## Testing
- `clang-format -i src/desktop/app/LibraryModel.h src/desktop/app/LibraryModel.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686967b451ec833197419fa6f2cdc0ad