### PR TITLE
Add SmartPlaylistManager for smart playlist rules

### DIFF
--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(mediaplayer_desktop_app
     AudioDevicesModel.cpp
     TranslationManager.cpp
     SettingsManager.cpp
+    SmartPlaylistManager.cpp
     VideoItem.cpp
     windows/WinIntegration.cpp
     windows/Hotkeys.cpp

--- a/src/desktop/app/SmartPlaylistManager.cpp
+++ b/src/desktop/app/SmartPlaylistManager.cpp
@@ -1,0 +1,22 @@
+#include "SmartPlaylistManager.h"
+#include "PlaylistModel.h"
+
+using namespace mediaplayer;
+
+SmartPlaylistManager::SmartPlaylistManager(QObject *parent) : QObject(parent) {}
+
+void SmartPlaylistManager::setPlaylistModel(PlaylistModel *model) { m_playlistModel = model; }
+
+void SmartPlaylistManager::createSmartPlaylist(const QString &name, const QVariantList &rules) {
+  if (!m_playlistModel)
+    return;
+  QString query;
+  for (int i = 0; i < rules.size(); ++i) {
+    QVariantMap map = rules[i].toMap();
+    if (i > 0)
+      query += " AND ";
+    query += map.value("field").toString() + " " + map.value("op").toString() + " " +
+             map.value("value").toString();
+  }
+  m_playlistModel->createSmartPlaylist(name, query);
+}

--- a/src/desktop/app/SmartPlaylistManager.h
+++ b/src/desktop/app/SmartPlaylistManager.h
@@ -1,0 +1,26 @@
+#ifndef MEDIAPLAYER_SMARTPLAYLISTMANAGER_H
+#define MEDIAPLAYER_SMARTPLAYLISTMANAGER_H
+
+#include <QObject>
+#include <QVariantList>
+
+namespace mediaplayer {
+
+class PlaylistModel;
+
+class SmartPlaylistManager : public QObject {
+  Q_OBJECT
+public:
+  explicit SmartPlaylistManager(QObject *parent = nullptr);
+
+  void setPlaylistModel(PlaylistModel *model);
+
+  Q_INVOKABLE void createSmartPlaylist(const QString &name, const QVariantList &rules);
+
+private:
+  PlaylistModel *m_playlistModel{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_SMARTPLAYLISTMANAGER_H

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -12,6 +12,7 @@
 #include "../VisualizerQt.h"
 #include "AudioDevicesModel.h"
 #include "SettingsManager.h"
+#include "SmartPlaylistManager.h"
 #include "SyncController.h"
 #include "TranslationManager.h"
 #include "VideoItem.h"
@@ -49,12 +50,14 @@ int main(int argc, char *argv[]) {
   mediaplayer::LibraryModel libraryModel;
   mediaplayer::PlaylistModel playlistModel;
   mediaplayer::LibraryQt libraryQt;
+  mediaplayer::SmartPlaylistManager spManager;
   mediaplayer::LibraryDB libraryDb(
       QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).toStdString() +
       "/library.db");
   libraryDb.open();
   libraryModel.setLibrary(&libraryDb);
   playlistModel.setLibrary(&libraryDb);
+  spManager.setPlaylistModel(&playlistModel);
   libraryQt.setLibrary(&libraryDb);
   controller.setLibrary(&libraryDb);
   mediaplayer::AudioDevicesModel audioDevicesModel;
@@ -88,6 +91,7 @@ int main(int argc, char *argv[]) {
   engine.rootContext()->setContextProperty("player", &controller);
   engine.rootContext()->setContextProperty("libraryModel", &libraryModel);
   engine.rootContext()->setContextProperty("playlistModel", &playlistModel);
+  engine.rootContext()->setContextProperty("smartPlaylistManager", &spManager);
   engine.rootContext()->setContextProperty("libraryQt", &libraryQt);
   engine.rootContext()->setContextProperty("audioDevicesModel", &audioDevicesModel);
   engine.rootContext()->setContextProperty("sync", &syncController);

--- a/src/desktop/app/qml/SmartPlaylistEditor.qml
+++ b/src/desktop/app/qml/SmartPlaylistEditor.qml
@@ -37,12 +37,6 @@ Dialog {
         Button { text: qsTr("Add Rule"); onClicked: dlg.rules.push({field:"title", op:"contains", value:""}) }
     }
     onAccepted: {
-        var query = "";
-        for (var i=0; i<rules.length; ++i) {
-            var r = rules[i];
-            if (i > 0) query += " AND ";
-            query += r.field + " " + r.op + " " + r.value;
-        }
-        playlistModel.createSmartPlaylist(nameField.text, query)
+        smartPlaylistManager.createSmartPlaylist(nameField.text, dlg.rules)
     }
 }


### PR DESCRIPTION
## Summary
- add `SmartPlaylistManager` QObject to receive smart playlist rules
- wire the manager into `main.cpp` and expose to QML
- update `SmartPlaylistEditor.qml` to send rules to C++

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_686967b7e72883319953dd65395fed4d