### PR TITLE
Implement VideoItem for FBO playback

### DIFF
--- a/src/desktop/app/qml/VideoPlayer.qml
+++ b/src/desktop/app/qml/VideoPlayer.qml
@@ -18,6 +18,11 @@ Item {
         flags: Qt.Window | Qt.FramelessWindowHint
         visibility: Window.FullScreen
         color: "black"
+        focus: true
+        Keys.onPressed: if (event.key === Qt.Key_Escape) {
+            fsWindow.visible = false
+            event.accepted = true
+        }
         VideoItem {
             anchors.fill: parent
             videoOutput: player.videoOutput


### PR DESCRIPTION
## Summary
- handle Esc key in `VideoPlayer.qml` fullscreen window
- VideoItem uses `QQuickFramebufferObject` to render video frames from `VideoOutputQt`

## Testing
- `cmake ..` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_686967b9b53c8331a22821eaa7244040