### PR TITLE
Implement VisualizerItem QML renderer

### DIFF
--- a/src/desktop/VisualizerItem.cpp
+++ b/src/desktop/VisualizerItem.cpp
@@ -38,12 +38,26 @@ QSGNode *VisualizerItem::updatePaintNode(QSGNode *node, UpdatePaintNodeData *) {
           window()->createTextureFromId(texId, QSize(size, size), QQuickWindow::TextureIsExternal);
       n->setTexture(texture);
       n->setRect(boundingRect());
+      if (m_texture && m_texture != texture)
+        delete m_texture;
+      m_texture = texture;
+    }
+  } else {
+    if (m_texture) {
+      delete m_texture;
+      m_texture = nullptr;
+      n->setTexture(nullptr);
     }
   }
   return n;
 }
 
-void VisualizerItem::releaseResources() {}
+void VisualizerItem::releaseResources() {
+  if (m_texture) {
+    delete m_texture;
+    m_texture = nullptr;
+  }
+}
 
 void mediaplayer::registerVisualizerItemQmlType() {
   qmlRegisterType<VisualizerItem>("MediaPlayer", 1, 0, "VisualizerItem");

--- a/src/desktop/VisualizerItem.h
+++ b/src/desktop/VisualizerItem.h
@@ -31,6 +31,7 @@ protected:
 private:
   VisualizerQt *m_visualizer{nullptr};
   bool m_running{true};
+  QSGTexture *m_texture{nullptr};
 };
 
 void registerVisualizerItemQmlType();


### PR DESCRIPTION
## Summary
- manage QSGTexture lifetime in `VisualizerItem`
- expose `m_texture` member for cleanup

## Testing
- `cmake ..` *(fails: Could not find required packages)*
- `g++ -std=c++17 -I../src/desktop -I../src/visualization/include -I../src/core/include -I/usr/include/libprojectM -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtQuick -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtCore -fPIC -c ../src/desktop/VisualizerItem.cpp` *(fails: QQuickWindow missing createTextureFromId)*

------
https://chatgpt.com/codex/tasks/task_e_686967bb05488331b9458e8f75e71293