### PR TITLE
Improve QML responsiveness

### DIFF
--- a/src/desktop/VisualizerView.qml
+++ b/src/desktop/VisualizerView.qml
@@ -4,8 +4,7 @@ import MediaPlayer 1.0
 
 Item {
     id: root
-    width: 640
-    height: 480
+    anchors.fill: parent
 
     VisualizerQt { id: vis }
     VisualizerItem {

--- a/src/desktop/app/qml/LibraryView.qml
+++ b/src/desktop/app/qml/LibraryView.qml
@@ -4,10 +4,12 @@ import QtQuick.Controls 2.15
 ListView {
     id: view
     anchors.fill: parent
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     model: libraryModel
     delegate: Item {
         width: parent.width
-        height: 24
+        implicitHeight: 24
         property string path: model.path
         Text { text: model.title; anchors.verticalCenter: parent.verticalCenter }
         MouseArea {

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -91,20 +91,32 @@ ApplicationWindow {
 
     ColumnLayout {
         anchors.fill: parent
-        VideoPlayer { Layout.fillWidth: true; height: 300 }
+        VideoPlayer {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 300
+        }
         RowLayout {
             spacing: 8
             Label { text: player.title }
             Label { text: player.artist }
             Label { text: player.album }
         }
-        LibraryView { Layout.fillWidth: true; Layout.fillHeight: true }
-        PlaylistView { Layout.fillWidth: true; height: 100 }
+        LibraryView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+        PlaylistView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 100
+        }
         NowPlayingView {
             Layout.fillWidth: true
             Layout.preferredHeight: 120
         }
-        VisualizationView { Layout.fillWidth: true; height: 150 }
+        VisualizationView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 150
+        }
         RowLayout {
             Layout.fillWidth: true
             ToolButton {

--- a/src/desktop/app/qml/NowPlayingView.qml
+++ b/src/desktop/app/qml/NowPlayingView.qml
@@ -4,6 +4,8 @@ import QtQuick.Controls 2.15
 ListView {
     id: nowPlaying
     anchors.fill: parent
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     model: nowPlayingModel
     delegate: Row {
         id: row

--- a/src/desktop/app/qml/PlaylistItemsDialog.qml
+++ b/src/desktop/app/qml/PlaylistItemsDialog.qml
@@ -5,10 +5,9 @@ Dialog {
     id: dlg
     property string playlistName: ""
     title: playlistName
-    width: 400
-    height: 300
+    implicitWidth: 400
+    implicitHeight: 300
     standardButtons: Dialog.Close
-
     PlaylistItemsView {
         anchors.fill: parent
         playlistName: dlg.playlistName

--- a/src/desktop/app/qml/PlaylistItemsView.qml
+++ b/src/desktop/app/qml/PlaylistItemsView.qml
@@ -4,6 +4,8 @@ import QtQuick.Controls 2.15
 ListView {
     id: playlistItems
     anchors.fill: parent
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     property string playlistName: ""
     model: playlistModel.playlistItems(playlistName)
     delegate: Row {

--- a/src/desktop/app/qml/PlaylistView.qml
+++ b/src/desktop/app/qml/PlaylistView.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-Column {
+ColumnLayout {
     spacing: 4
+    anchors.fill: parent
 
     SmartPlaylistEditor { id: smartEditor }
     PlaylistItemsDialog { id: itemsDialog }
 
-    Row {
+    RowLayout {
         spacing: 4
         TextField {
             id: nameField
@@ -22,7 +23,8 @@ Column {
 
     ListView {
         id: list
-        anchors.fill: parent
+        Layout.fillWidth: true
+        Layout.fillHeight: true
         model: playlistModel
         delegate: Row {
             spacing: 4

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -16,7 +16,8 @@ Dialog {
         }
     }
 
-    Column {
+    ColumnLayout {
+        anchors.fill: parent
         spacing: 8
 
         CheckBox {
@@ -28,7 +29,7 @@ Dialog {
             }
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Label { text: qsTr("Audio device") }
             ComboBox {
@@ -47,7 +48,7 @@ Dialog {
             }
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Label { text: qsTr("Language") }
             ComboBox {
@@ -68,8 +69,8 @@ Dialog {
 
         ListView {
             id: deviceList
-            height: 100
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: 100
             model: discoveredDevices
             delegate: Row {
                 spacing: 4
@@ -81,7 +82,7 @@ Dialog {
             }
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Button {
                 text: qsTr("Scan Library")
@@ -101,7 +102,7 @@ Dialog {
             onToggled: player.visualizer.setEnabled(checked)
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Button {
                 text: qsTr("Prev Preset")
@@ -115,11 +116,10 @@ Dialog {
 
         GroupBox {
             title: qsTr("Format Converter")
-
-            Column {
+            ColumnLayout {
                 spacing: 4
 
-                Row {
+                RowLayout {
                     spacing: 4
                     Button {
                         text: qsTr("Input")
@@ -128,7 +128,7 @@ Dialog {
                     Label { text: convInput }
                 }
 
-                Row {
+                RowLayout {
                     spacing: 4
                     Button {
                         text: qsTr("Output")

--- a/src/desktop/app/qml/SmartPlaylistEditor.qml
+++ b/src/desktop/app/qml/SmartPlaylistEditor.qml
@@ -7,12 +7,13 @@ Dialog {
     standardButtons: Dialog.Ok | Dialog.Cancel
     property var rules: []
     property string playlistName: ""
-    Column {
+    ColumnLayout {
+        anchors.fill: parent
         spacing: 8
         TextField { id: nameField; placeholderText: qsTr("Name"); text: dlg.playlistName }
         Repeater {
             model: dlg.rules
-            delegate: Row {
+            delegate: RowLayout {
                 spacing: 4
                 ComboBox {
                     id: fieldBox

--- a/src/desktop/app/qml/VideoPlayer.qml
+++ b/src/desktop/app/qml/VideoPlayer.qml
@@ -2,7 +2,8 @@ import QtQuick 2.15
 import MediaPlayer 1.0
 
 Item {
-    width: 640; height: 360
+    Layout.fillWidth: true
+    Layout.preferredHeight: 360
     VideoItem {
         id: item
         anchors.fill: parent

--- a/src/desktop/app/qml/VisualizationView.qml
+++ b/src/desktop/app/qml/VisualizationView.qml
@@ -4,6 +4,8 @@ import MediaPlayer 1.0
 
 Item {
     id: root
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     VisualizerItem {
         id: canvas
         anchors.fill: parent


### PR DESCRIPTION
## Summary
- use Layouts and anchors in QML components
- make dialogs and lists scale with window size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686967bb7ea48331aaf4d4f02f301fc0