### PR TITLE
Add Windows taskbar helper functions

### DIFF
--- a/src/desktop/app/windows/WinIntegration.cpp
+++ b/src/desktop/app/windows/WinIntegration.cpp
@@ -15,6 +15,24 @@ static QWinTaskbarProgress *g_progress = nullptr;
 static QWinThumbnailToolButton *g_playBtn = nullptr;
 static QWinThumbnailToolButton *g_pauseBtn = nullptr;
 
+void updateTaskbarProgress(double value) {
+  if (!g_progress)
+    return;
+  int v = static_cast<int>(value);
+  if (v < 0)
+    v = 0;
+  if (v > 100)
+    v = 100;
+  g_progress->setValue(v);
+}
+
+void updateThumbnailButtons(bool playing) {
+  if (g_playBtn)
+    g_playBtn->setVisible(!playing);
+  if (g_pauseBtn)
+    g_pauseBtn->setVisible(playing);
+}
+
 void setupWindowsIntegration() {
   if (!QtWin::isCompositionEnabled())
     return;


### PR DESCRIPTION
## Summary
- extend WinIntegration with helpers for Windows taskbar integration

## Testing
- `cmake -B build -S .` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_686967bca1d883319632bc18def609fd