### PR TITLE
Implement macOS menu and Touch Bar

### DIFF
--- a/src/desktop/app/macos/TouchBar.h
+++ b/src/desktop/app/macos/TouchBar.h
@@ -9,3 +9,4 @@ class MediaPlayerController;
 @end
 
 void setupTouchBar(mediaplayer::MediaPlayerController *controller);
+void cleanupTouchBar();


### PR DESCRIPTION
## Summary
- implement application menu and open-file handler on macOS
- improve Touch Bar controller with play/pause updates and volume sync
- clean up Touch Bar and menu when quitting

## Testing
- `clang-format -i src/desktop/app/macos/MacIntegration.mm src/desktop/app/macos/TouchBar.mm src/desktop/app/macos/TouchBar.h`

------
https://chatgpt.com/codex/tasks/task_e_686967bdc5dc8331a63ae7c4dbb2868c