### PR TITLE
Add keyboard shortcuts in QML

### DIFF
--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -72,20 +72,26 @@ ApplicationWindow {
     focus: true
     Keys.onPressed: {
         if (event.key === Qt.Key_Space) {
-            player.playing ? player.pause() : player.play();
-            event.accepted = true;
+            player.playing ? player.pause() : player.play()
+            event.accepted = true
         } else if (event.key === Qt.Key_Left) {
             player.seek(player.position - 5)
-            event.accepted = true;
+            event.accepted = true
         } else if (event.key === Qt.Key_Right) {
             player.seek(player.position + 5)
-            event.accepted = true;
+            event.accepted = true
+        } else if (event.key === Qt.Key_Up) {
+            player.setVolume(Math.min(1, player.volume + 0.05))
+            event.accepted = true
+        } else if (event.key === Qt.Key_Down) {
+            player.setVolume(Math.max(0, player.volume - 0.05))
+            event.accepted = true
         } else if (event.key === Qt.Key_MediaNext) {
-            player.seek(player.position + 10)
-            event.accepted = true;
+            player.nextTrack()
+            event.accepted = true
         } else if (event.key === Qt.Key_MediaPrevious) {
-            player.seek(player.position - 10)
-            event.accepted = true;
+            player.previousTrack()
+            event.accepted = true
         }
     }
 


### PR DESCRIPTION
## Summary
- handle key presses through `Keys.onPressed`
- call controller slots for seek, volume, track navigation, and play/pause

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_686967c1c42883319fdab1ad7fb05789