### PR TITLE
Handle playback errors via signal

### DIFF
--- a/src/core/include/mediaplayer/PlaybackCallbacks.h
+++ b/src/core/include/mediaplayer/PlaybackCallbacks.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_PLAYBACKCALLBACKS_H
 
 #include <functional>
+#include <string>
 
 #include "MediaMetadata.h"
 #include "SrtParser.h"
@@ -16,6 +17,7 @@ struct PlaybackCallbacks {
   std::function<void(const MediaMetadata &)> onTrackLoaded;
   std::function<void(double)> onPosition;
   std::function<void(const SubtitleCue &)> onSubtitle;
+  std::function<void(const std::string &)> onError;
 };
 
 } // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -76,18 +76,24 @@ static bool isUrl(const std::string &path) {
 bool MediaPlayer::open(const std::string &path) {
   m_demuxer.setBufferSize(m_networkBufferSize);
   if (!m_demuxer.open(path)) {
+    if (m_callbacks.onError)
+      m_callbacks.onError("Failed to open media");
     return false;
   }
   AVFormatContext *fmtCtx = m_demuxer.context();
   if (m_demuxer.audioStream() >= 0) {
     if (!m_audioDecoder.open(fmtCtx, m_demuxer.audioStream())) {
       std::cerr << "Failed to open audio decoder\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to open audio decoder");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       return false;
     }
     if (m_output && !m_output->init(m_audioDecoder.sampleRate(), m_audioDecoder.channels())) {
       std::cerr << "Failed to init audio output\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to init audio output");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       return false;
@@ -100,6 +106,8 @@ bool MediaPlayer::open(const std::string &path) {
     if (!m_videoDecoder.open(fmtCtx, m_demuxer.videoStream())) {
 #endif
       std::cerr << "Failed to open video decoder\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to open video decoder");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       m_videoDecoder = VideoDecoder();
@@ -107,6 +115,8 @@ bool MediaPlayer::open(const std::string &path) {
     }
     if (m_videoOutput && !m_videoOutput->init(m_videoDecoder.width(), m_videoDecoder.height())) {
       std::cerr << "Failed to init video output\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to init video output");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       m_videoDecoder = VideoDecoder();

--- a/src/desktop/app/MediaPlayerController.cpp
+++ b/src/desktop/app/MediaPlayerController.cpp
@@ -4,6 +4,7 @@
 #include "../VisualizerQt.h"
 #include "NowPlayingModel.h"
 #include <QAudioDevice>
+#include <string>
 #ifdef Q_OS_MAC
 void updateNowPlayingInfo(const mediaplayer::MediaMetadata &meta);
 #endif
@@ -32,13 +33,11 @@ MediaPlayerController::MediaPlayerController(QObject *parent) : QObject(parent) 
 #endif
   };
   cb.onPosition = [this](double) { emit positionChanged(); };
+  cb.onError = [this](const std::string &msg) { emit errorOccurred(QString::fromStdString(msg)); };
   m_player.setCallbacks(cb);
 }
 
-void MediaPlayerController::openFile(const QString &path) {
-  if (!m_player.open(path.toStdString()))
-    emit errorOccurred(tr("Failed to open file"));
-}
+void MediaPlayerController::openFile(const QString &path) { m_player.open(path.toStdString()); }
 
 void MediaPlayerController::play() {
   m_player.play();

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -59,14 +59,11 @@ ApplicationWindow {
 
     SettingsDialog { id: settings }
 
-    Dialog {
+    MessageDialog {
         id: errorDialog
         title: qsTr("Playback Error")
+        text: win.errorMessage
         standardButtons: Dialog.Ok
-        Column {
-            spacing: 8
-            Label { text: win.errorMessage }
-        }
     }
 
     focus: true


### PR DESCRIPTION
## Summary
- add `onError` to `PlaybackCallbacks`
- emit error callbacks from `MediaPlayer` when initialization fails
- forward errors through `MediaPlayerController`
- display a `MessageDialog` in QML when an error occurs

## Testing
- `clang-format -i src/desktop/app/MediaPlayerController.cpp src/core/src/MediaPlayer.cpp src/core/include/mediaplayer/PlaybackCallbacks.h`

------
https://chatgpt.com/codex/tasks/task_e_686967c33a8483318e05b30b5c4f3abb