### PR TITLE
Enable Material theme with runtime switch

### DIFF
--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -20,6 +20,7 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQuickStyle>
 #include <QStandardPaths>
 #include <QtQml/qqml.h>
 #ifdef Q_OS_MAC
@@ -33,6 +34,7 @@ void setupWindowsIntegration();
 #endif
 
 int main(int argc, char *argv[]) {
+  QQuickStyle::setStyle("Material");
   QGuiApplication app(argc, argv);
 
   qInfo() << "MediaPlayer core version:"

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Controls.Material 2.15
 import QtQuick.Dialogs 1.3
 import "NowPlayingView.qml" as NowPlayingView
 
@@ -9,6 +10,7 @@ ApplicationWindow {
     width: 800
     height: 600
     title: qsTr("MediaPlayer")
+    Material.theme: settings.theme === "dark" ? Material.Dark : Material.Light
     property string errorMessage: ""
     property string currentFile: ""
 

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -22,10 +22,7 @@ Dialog {
         CheckBox {
             id: themeBox
             text: qsTr("Dark theme")
-            onToggled: {
-                Qt.application.theme = checked ? "dark" : "light"
-                settings.theme = checked ? "dark" : "light"
-            }
+            onToggled: settings.theme = checked ? "dark" : "light"
         }
 
         Row {


### PR DESCRIPTION
## Summary
- use QtQuick.Controls.Material across the UI
- bind ApplicationWindow's theme to saved settings
- simplify theme checkbox logic
- initialize Material style from C++

## Testing
- `clang-format -i src/desktop/app/main.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686967c3fd7483318040771a0176783b