### PR TITLE
Add stop and shuffle icons for desktop app

### DIFF
--- a/src/desktop/app/app.qrc
+++ b/src/desktop/app/app.qrc
@@ -4,6 +4,8 @@
         <file>resources/icons/pause.svg</file>
         <file>resources/icons/next.svg</file>
         <file>resources/icons/prev.svg</file>
+        <file>resources/icons/stop.svg</file>
+        <file>resources/icons/shuffle.svg</file>
 </qresource>
     <qresource prefix="/qml">
         <file>qml/PlaylistItemsDialog.qml</file>

--- a/src/desktop/app/resources/icons/README.md
+++ b/src/desktop/app/resources/icons/README.md
@@ -1,2 +1,3 @@
 Open-source SVG icons for playback controls are provided here as simple placeholders.
+They include play, pause, next, previous as well as newly added stop and shuffle icons.
 Replace them with your own artwork if desired.

--- a/src/desktop/app/resources/icons/shuffle.svg
+++ b/src/desktop/app/resources/icons/shuffle.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 20 H30 L70 80 H90" fill="none" stroke="black" stroke-width="10"/>
+  <polygon points="80,75 90,80 80,85" fill="black"/>
+  <path d="M10 80 H30 L70 20 H90" fill="none" stroke="black" stroke-width="10"/>
+  <polygon points="80,15 90,20 80,25" fill="black"/>
+</svg>

--- a/src/desktop/app/resources/icons/stop.svg
+++ b/src/desktop/app/resources/icons/stop.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="20" width="60" height="60" fill="black"/>
+</svg>


### PR DESCRIPTION
## Summary
- provide additional SVG icons (`stop.svg` and `shuffle.svg`)
- reference new icons in `app.qrc`
- document icons in `resources/icons/README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686967c5cb9883318da040ff20dcbdb6