### PR TITLE
Enhance Linux packaging script

### DIFF
--- a/src/desktop/app/README.md
+++ b/src/desktop/app/README.md
@@ -24,7 +24,7 @@ The `installers` directory contains helper scripts to produce distributable pack
 
 - `installers/windows/package.ps1` – Runs `windeployqt` and builds the NSIS installer. Set `BUILD_DIR` to your build output directory before running.
 - `installers/macos/package.sh` – Uses `macdeployqt` to bundle Qt frameworks then creates a DMG. Requires `BUILD_DIR` pointing at the build folder.
-- `installers/linux/build_appimage.sh` – Invokes `linuxdeployqt` to create an AppImage or `.deb`. Set `BUILD_DIR` accordingly and pass `appimage` or `deb` as the first argument.
+- `installers/linux/build_appimage.sh` – Invokes `linuxdeployqt` (with `-qmldir` to include QML files) to create an AppImage or `.deb`. Set `BUILD_DIR` accordingly and pass `appimage` or `deb` as the first argument.
 
 Ensure `windeployqt`, `macdeployqt` or `linuxdeployqt` are available in your `PATH` depending on platform.
 

--- a/src/desktop/app/installers/linux/build_appimage.sh
+++ b/src/desktop/app/installers/linux/build_appimage.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Build an AppImage or .deb package using linuxdeployqt.
+#
+# Usage: BUILD_DIR=path/to/build ./build_appimage.sh [appimage|deb]
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="${SCRIPT_DIR}/../../../../.."
+QML_DIR="${PROJECT_ROOT}/src/desktop/app/qml"
 BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build}"
 DIST_DIR="${PROJECT_ROOT}/dist"
 APP_NAME="mediaplayer_desktop_app"
@@ -11,6 +14,12 @@ APP_NAME="mediaplayer_desktop_app"
 APPIMAGE_DIR="${DIST_DIR}/${APP_NAME}.AppDir"
 mkdir -p "$APPIMAGE_DIR"
 mkdir -p "$DIST_DIR"
+
+# Ensure linuxdeployqt is available
+command -v linuxdeployqt >/dev/null || {
+    echo "linuxdeployqt not found in PATH" >&2
+    exit 1
+}
 
 # Copy built binaries and resources
 cp "${BUILD_DIR}/${APP_NAME}" "$APPIMAGE_DIR/"
@@ -20,10 +29,10 @@ cp -r "${BUILD_DIR}/translations" "$APPIMAGE_DIR/" 2>/dev/null || true
 PACKAGE_TYPE="${1:-appimage}" # 'appimage' or 'deb'
 
 if [ "$PACKAGE_TYPE" = "deb" ]; then
-    linuxdeployqt "$APPIMAGE_DIR/${APP_NAME}" -deb -unsupported-allow-new-glibc
+    linuxdeployqt "$APPIMAGE_DIR/${APP_NAME}" -qmldir="$QML_DIR" -deb -verbose=2 -unsupported-allow-new-glibc
     mv ./*.deb "$DIST_DIR/" 2>/dev/null || true
 else
-    linuxdeployqt "$APPIMAGE_DIR/${APP_NAME}" -appimage -unsupported-allow-new-glibc
+    linuxdeployqt "$APPIMAGE_DIR/${APP_NAME}" -qmldir="$QML_DIR" -appimage -verbose=2 -unsupported-allow-new-glibc
     mv ./*.AppImage "$DIST_DIR/MediaPlayer.AppImage" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary
- improve `build_appimage.sh` to check for linuxdeployqt and pass `-qmldir`
- document linuxdeployqt usage in the desktop app README

## Testing
- `bash -n src/desktop/app/installers/linux/build_appimage.sh`

------
https://chatgpt.com/codex/tasks/task_e_686967ca4420833191b246d73f2bc075