### PR TITLE
Update macOS packaging script

### DIFF
--- a/src/desktop/app/README.md
+++ b/src/desktop/app/README.md
@@ -23,7 +23,7 @@ Packaging scripts are available under `installers/` for Windows (PowerShell + NS
 The `installers` directory contains helper scripts to produce distributable packages.
 
 - `installers/windows/package.ps1` – Runs `windeployqt` and builds the NSIS installer. Set `BUILD_DIR` to your build output directory before running.
-- `installers/macos/package.sh` – Uses `macdeployqt` to bundle Qt frameworks then creates a DMG. Requires `BUILD_DIR` pointing at the build folder.
+- `installers/macos/package.sh` – Runs `macdeployqt` and optionally signs the bundle when `CODE_SIGN_IDENTITY` is set, then creates a DMG. Set `BUILD_DIR` and signing variables before running.
 - `installers/linux/build_appimage.sh` – Invokes `linuxdeployqt` to create an AppImage or `.deb`. Set `BUILD_DIR` accordingly and pass `appimage` or `deb` as the first argument.
 
 Ensure `windeployqt`, `macdeployqt` or `linuxdeployqt` are available in your `PATH` depending on platform.
@@ -38,6 +38,7 @@ $env:BUILD_DIR="build\Release"
 
 ```bash
 # macOS
+CODE_SIGN_IDENTITY="Developer ID Application: Example" \
 BUILD_DIR=build ./src/desktop/app/installers/macos/package.sh
 
 # Linux (AppImage)

--- a/src/desktop/app/installers/macos/package.sh
+++ b/src/desktop/app/installers/macos/package.sh
@@ -10,6 +10,8 @@ DIST_DIR="${PROJECT_ROOT}/dist"
 APP_BUNDLE_SRC="${BUILD_DIR}/mediaplayer_desktop_app.app"
 APP_BUNDLE="${DIST_DIR}/MediaPlayer.app"
 DMG_NAME="MediaPlayer.dmg"
+CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:-}" 
+ENTITLEMENTS_FILE="${ENTITLEMENTS_FILE:-}" 
 
 mkdir -p "$DIST_DIR"
 
@@ -20,7 +22,24 @@ cp -R "$APP_BUNDLE_SRC" "$APP_BUNDLE"
 macdeployqt "$APP_BUNDLE" -qmldir="${PROJECT_ROOT}/src/desktop/app/qml" -verbose=1
 cp -R "${BUILD_DIR}/translations" "$APP_BUNDLE/Contents/MacOS/" 2>/dev/null || true
 
+# Code sign the .app bundle if an identity is provided
+if [ -n "$CODE_SIGN_IDENTITY" ]; then
+    echo "Signing app bundle with '$CODE_SIGN_IDENTITY'"
+    if [ -n "$ENTITLEMENTS_FILE" ]; then
+        codesign --force --options runtime --deep --sign "$CODE_SIGN_IDENTITY" \
+            --entitlements "$ENTITLEMENTS_FILE" "$APP_BUNDLE"
+    else
+        codesign --force --options runtime --deep --sign "$CODE_SIGN_IDENTITY" \
+            "$APP_BUNDLE"
+    fi
+fi
+
 # Create compressed DMG
 hdiutil create "$DIST_DIR/$DMG_NAME" -volname "MediaPlayer" -srcfolder "$APP_BUNDLE" -ov -format UDZO
 
 echo "DMG created at $DIST_DIR/$DMG_NAME"
+
+if [ -n "$CODE_SIGN_IDENTITY" ]; then
+    codesign --force --sign "$CODE_SIGN_IDENTITY" "$DIST_DIR/$DMG_NAME"
+    echo "Signed DMG with '$CODE_SIGN_IDENTITY'"
+fi


### PR DESCRIPTION
## Summary
- add CODE_SIGN_IDENTITY options to macOS package script
- update README with signing instructions

## Testing
- `shellcheck src/desktop/app/installers/macos/package.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686967c8f6ac83318f424bf931532e77