### PR TITLE
Integrate features from 7 conflicting PRs

### DIFF
--- a/src/core/include/mediaplayer/PlaybackCallbacks.h
+++ b/src/core/include/mediaplayer/PlaybackCallbacks.h
@@ -2,6 +2,7 @@
 #define MEDIAPLAYER_PLAYBACKCALLBACKS_H
 
 #include <functional>
+#include <string>
 
 #include "MediaMetadata.h"
 #include "SrtParser.h"
@@ -16,6 +17,7 @@ struct PlaybackCallbacks {
   std::function<void(const MediaMetadata &)> onTrackLoaded;
   std::function<void(double)> onPosition;
   std::function<void(const SubtitleCue &)> onSubtitle;
+  std::function<void(const std::string &)> onError;
 };
 
 } // namespace mediaplayer

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -76,18 +76,24 @@ static bool isUrl(const std::string &path) {
 bool MediaPlayer::open(const std::string &path) {
   m_demuxer.setBufferSize(m_networkBufferSize);
   if (!m_demuxer.open(path)) {
+    if (m_callbacks.onError)
+      m_callbacks.onError("Failed to open media");
     return false;
   }
   AVFormatContext *fmtCtx = m_demuxer.context();
   if (m_demuxer.audioStream() >= 0) {
     if (!m_audioDecoder.open(fmtCtx, m_demuxer.audioStream())) {
       std::cerr << "Failed to open audio decoder\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to open audio decoder");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       return false;
     }
     if (m_output && !m_output->init(m_audioDecoder.sampleRate(), m_audioDecoder.channels())) {
       std::cerr << "Failed to init audio output\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to init audio output");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       return false;
@@ -100,6 +106,8 @@ bool MediaPlayer::open(const std::string &path) {
     if (!m_videoDecoder.open(fmtCtx, m_demuxer.videoStream())) {
 #endif
       std::cerr << "Failed to open video decoder\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to open video decoder");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       m_videoDecoder = VideoDecoder();
@@ -107,6 +115,8 @@ bool MediaPlayer::open(const std::string &path) {
     }
     if (m_videoOutput && !m_videoOutput->init(m_videoDecoder.width(), m_videoDecoder.height())) {
       std::cerr << "Failed to init video output\n";
+      if (m_callbacks.onError)
+        m_callbacks.onError("Failed to init video output");
       m_demuxer.close();
       m_audioDecoder = AudioDecoder();
       m_videoDecoder = VideoDecoder();

--- a/src/desktop/VisualizerView.qml
+++ b/src/desktop/VisualizerView.qml
@@ -4,8 +4,7 @@ import MediaPlayer 1.0
 
 Item {
     id: root
-    width: 640
-    height: 480
+    anchors.fill: parent
 
     VisualizerQt { id: vis }
     VisualizerItem {

--- a/src/desktop/app/MediaPlayerController.cpp
+++ b/src/desktop/app/MediaPlayerController.cpp
@@ -4,7 +4,9 @@
 #include "../VisualizerQt.h"
 #include "NowPlayingModel.h"
 #include <QAudioDevice>
+#include <QVariantMap>
 #include <QtQml/qqml.h>
+#include <string>
 #ifdef Q_OS_MAC
 void updateNowPlayingInfo(const mediaplayer::MediaMetadata &meta);
 #endif
@@ -23,28 +25,34 @@ MediaPlayerController::MediaPlayerController(QObject *parent) : QObject(parent) 
   m_nowPlaying = new NowPlayingModel(&m_player, this);
   PlaybackCallbacks cb;
   cb.onPlay = [this]() {
-    m_state = Playing;
+    m_playing = true;
     emit playbackStateChanged();
   };
   cb.onPause = [this]() {
-    m_state = Paused;
+    m_playing = false;
     emit playbackStateChanged();
   };
   cb.onStop = [this]() {
-    m_state = Stopped;
+    m_playing = false;
+    m_position = 0.0;
     emit playbackStateChanged();
+    emit positionChanged();
   };
   cb.onTrackLoaded = [this](const MediaMetadata &meta) {
     m_meta = meta;
+    m_position = 0.0;
     emit currentMetadataChanged(meta);
 #ifdef Q_OS_MAC
     updateNowPlayingInfo(meta);
 #endif
   };
-  cb.onPosition = [this](double) { emit positionChanged(); };
+  cb.onPosition = [this](double pos) {
+    m_position = pos;
+    emit positionChanged();
+  };
+  cb.onError = [this](const std::string &msg) { emit errorOccurred(QString::fromStdString(msg)); };
   m_player.setCallbacks(cb);
 }
-
 void MediaPlayerController::openFile(const QString &path) {
   if (!m_player.open(path.toStdString()))
     emit errorOccurred(tr("Failed to open file"));
@@ -52,20 +60,26 @@ void MediaPlayerController::openFile(const QString &path) {
 
 void MediaPlayerController::play() {
   m_player.play();
-  m_state = Playing;
+  m_playing = true;
   emit playbackStateChanged();
 }
 void MediaPlayerController::pause() {
   m_player.pause();
-  m_state = Paused;
+  m_playing = false;
   emit playbackStateChanged();
 }
 void MediaPlayerController::stop() {
   m_player.stop();
-  m_state = Stopped;
+  m_playing = false;
+  m_position = 0.0;
   emit playbackStateChanged();
+  emit positionChanged();
 }
-void MediaPlayerController::seek(double position) { m_player.seek(position); }
+void MediaPlayerController::seek(double position) {
+  m_player.seek(position);
+  m_position = position;
+  emit positionChanged();
+}
 
 void MediaPlayerController::setVolume(double vol) {
   m_player.setVolume(vol);
@@ -113,13 +127,27 @@ void MediaPlayerController::moveQueueItem(int from, int to) {
 
 void MediaPlayerController::setLibrary(LibraryDB *db) { m_player.setLibrary(db); }
 
-bool MediaPlayerController::playing() const { return m_player.isPlaying(); }
-double MediaPlayerController::position() const { return m_player.position(); }
+bool MediaPlayerController::playing() const { return m_playing; }
+double MediaPlayerController::position() const { return m_position; }
 double MediaPlayerController::volume() const { return m_player.volume(); }
 QString MediaPlayerController::title() const { return QString::fromStdString(m_meta.title); }
 QString MediaPlayerController::artist() const { return QString::fromStdString(m_meta.artist); }
 QString MediaPlayerController::album() const { return QString::fromStdString(m_meta.album); }
 double MediaPlayerController::duration() const { return m_meta.duration; }
+
+QVariantMap MediaPlayerController::currentTrack() const {
+  QVariantMap m;
+  m[QStringLiteral("path")] = QString::fromStdString(m_meta.path);
+  m[QStringLiteral("title")] = QString::fromStdString(m_meta.title);
+  m[QStringLiteral("artist")] = QString::fromStdString(m_meta.artist);
+  m[QStringLiteral("album")] = QString::fromStdString(m_meta.album);
+  m[QStringLiteral("genre")] = QString::fromStdString(m_meta.genre);
+  m[QStringLiteral("duration")] = m_meta.duration;
+  m[QStringLiteral("width")] = m_meta.width;
+  m[QStringLiteral("height")] = m_meta.height;
+  m[QStringLiteral("rating")] = m_meta.rating;
+  return m;
+}
 
 void mediaplayer::registerMediaPlayerControllerQmlType() {
   qmlRegisterType<MediaPlayerController>("MediaPlayer", 1, 0, "MediaPlayerController");

--- a/src/desktop/app/MediaPlayerController.h
+++ b/src/desktop/app/MediaPlayerController.h
@@ -9,6 +9,7 @@
 #include "mediaplayer/MediaPlayer.h"
 #include <QAudioDevice>
 #include <QObject>
+#include <QVariantMap>
 #include <memory>
 
 namespace mediaplayer {
@@ -16,8 +17,8 @@ namespace mediaplayer {
 class MediaPlayerController : public QObject {
   Q_OBJECT
   Q_PROPERTY(bool playing READ playing NOTIFY playbackStateChanged)
-  Q_PROPERTY(PlaybackState playbackState READ playbackState NOTIFY playbackStateChanged)
   Q_PROPERTY(double position READ position NOTIFY positionChanged)
+  Q_PROPERTY(QVariantMap currentTrack READ currentTrack NOTIFY currentMetadataChanged)
   Q_PROPERTY(double volume READ volume WRITE setVolume NOTIFY volumeChanged)
   Q_PROPERTY(VideoOutputQt *videoOutput READ videoOutput CONSTANT)
   Q_PROPERTY(VisualizerQt *visualizer READ visualizer CONSTANT)
@@ -28,9 +29,6 @@ class MediaPlayerController : public QObject {
   Q_PROPERTY(NowPlayingModel *nowPlaying READ nowPlaying CONSTANT)
 public:
   explicit MediaPlayerController(QObject *parent = nullptr);
-
-  enum PlaybackState { Stopped, Playing, Paused };
-  Q_ENUM(PlaybackState)
 
   Q_INVOKABLE void openFile(const QString &path);
   Q_INVOKABLE void play();
@@ -55,7 +53,7 @@ public:
   double duration() const;
   NowPlayingModel *nowPlaying() const { return m_nowPlaying; }
 
-  PlaybackState playbackState() const { return m_state; }
+  QVariantMap currentTrack() const;
 
   VideoOutputQt *videoOutput() const { return m_videoOutput; }
   VisualizerQt *visualizer() const { return m_visualizer; }
@@ -70,15 +68,15 @@ signals:
 
 private:
   MediaPlayer m_player;
+  bool m_playing{false};
+  double m_position{0.0};
   VideoOutputQt *m_videoOutput{nullptr};
   VisualizerQt *m_visualizer{nullptr};
   MediaMetadata m_meta;
   NowPlayingModel *m_nowPlaying{nullptr};
-  PlaybackState m_state{Stopped};
 };
 
 void registerMediaPlayerControllerQmlType();
-
 } // namespace mediaplayer
 
 #endif // MEDIAPLAYER_MEDIAPLAYERCONTROLLER_H

--- a/src/desktop/app/README.md
+++ b/src/desktop/app/README.md
@@ -23,9 +23,8 @@ Packaging scripts are available under `installers/` for Windows (PowerShell + NS
 The `installers` directory contains helper scripts to produce distributable packages.
 
 - `installers/windows/package.ps1` – Runs `windeployqt` and builds the NSIS installer. Set `BUILD_DIR` to your build output directory before running.
-- `installers/macos/package.sh` – Uses `macdeployqt` to bundle Qt frameworks then creates a DMG. Requires `BUILD_DIR` pointing at the build folder.
-- `installers/linux/build_appimage.sh` – Invokes `linuxdeployqt` (with `-qmldir` to include QML files) to create an AppImage or `.deb`. Set `BUILD_DIR` accordingly and pass `appimage` or `deb` as the first argument.
-
+- `installers/macos/package.sh` – Runs `macdeployqt` and optionally signs the bundle when `CODE_SIGN_IDENTITY` is set, then creates a DMG. Set `BUILD_DIR` and signing variables before running.
+- `installers/linux/build_appimage.sh` – Invokes `linuxdeployqt` to create an AppImage or `.deb`. Set `BUILD_DIR` accordingly and pass `appimage` or `deb` as the first argument.
 Ensure `windeployqt`, `macdeployqt` or `linuxdeployqt` are available in your `PATH` depending on platform.
 
 Example commands run from the repository root:
@@ -38,6 +37,7 @@ $env:BUILD_DIR="build\Release"
 
 ```bash
 # macOS
+CODE_SIGN_IDENTITY="Developer ID Application: Example" \
 BUILD_DIR=build ./src/desktop/app/installers/macos/package.sh
 
 # Linux (AppImage)

--- a/src/desktop/app/installers/macos/package.sh
+++ b/src/desktop/app/installers/macos/package.sh
@@ -10,6 +10,8 @@ DIST_DIR="${PROJECT_ROOT}/dist"
 APP_BUNDLE_SRC="${BUILD_DIR}/mediaplayer_desktop_app.app"
 APP_BUNDLE="${DIST_DIR}/MediaPlayer.app"
 DMG_NAME="MediaPlayer.dmg"
+CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:-}" 
+ENTITLEMENTS_FILE="${ENTITLEMENTS_FILE:-}" 
 
 mkdir -p "$DIST_DIR"
 
@@ -20,7 +22,24 @@ cp -R "$APP_BUNDLE_SRC" "$APP_BUNDLE"
 macdeployqt "$APP_BUNDLE" -qmldir="${PROJECT_ROOT}/src/desktop/app/qml" -verbose=1
 cp -R "${BUILD_DIR}/translations" "$APP_BUNDLE/Contents/MacOS/" 2>/dev/null || true
 
+# Code sign the .app bundle if an identity is provided
+if [ -n "$CODE_SIGN_IDENTITY" ]; then
+    echo "Signing app bundle with '$CODE_SIGN_IDENTITY'"
+    if [ -n "$ENTITLEMENTS_FILE" ]; then
+        codesign --force --options runtime --deep --sign "$CODE_SIGN_IDENTITY" \
+            --entitlements "$ENTITLEMENTS_FILE" "$APP_BUNDLE"
+    else
+        codesign --force --options runtime --deep --sign "$CODE_SIGN_IDENTITY" \
+            "$APP_BUNDLE"
+    fi
+fi
+
 # Create compressed DMG
 hdiutil create "$DIST_DIR/$DMG_NAME" -volname "MediaPlayer" -srcfolder "$APP_BUNDLE" -ov -format UDZO
 
 echo "DMG created at $DIST_DIR/$DMG_NAME"
+
+if [ -n "$CODE_SIGN_IDENTITY" ]; then
+    codesign --force --sign "$CODE_SIGN_IDENTITY" "$DIST_DIR/$DMG_NAME"
+    echo "Signed DMG with '$CODE_SIGN_IDENTITY'"
+fi

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -21,6 +21,7 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQuickStyle>
 #include <QStandardPaths>
 #include <QtQml/qqml.h>
 #ifdef Q_OS_MAC
@@ -34,6 +35,7 @@ void setupWindowsIntegration();
 #endif
 
 int main(int argc, char *argv[]) {
+  QQuickStyle::setStyle("Material");
   QGuiApplication app(argc, argv);
 
   qInfo() << "MediaPlayer core version:"

--- a/src/desktop/app/qml/LibraryView.qml
+++ b/src/desktop/app/qml/LibraryView.qml
@@ -1,30 +1,42 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-ListView {
-    id: view
-    anchors.fill: parent
-    model: libraryModel
-    delegate: Item {
-        width: parent.width
-        height: 40
-        property string path: model.path
-        Column {
-            anchors.verticalCenter: parent.verticalCenter
-            Text { text: model.title }
-            Text {
-                text: model.artist
-                font.pixelSize: 10
-                color: "#666"
+Column {
+    spacing: 4
+
+    TextField {
+        id: searchField
+        placeholderText: qsTr("Search")
+        onTextChanged: libraryModel.search(text)
+    }
+
+    ListView {
+        id: view
+        anchors.fill: parent
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        model: libraryModel
+        delegate: Item {
+            width: parent.width
+            implicitHeight: 24
+            property string path: model.path
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                Text { text: model.title }
+                Text {
+                    text: model.artist
+                    font.pixelSize: 10
+                    color: "#666"
+                }
             }
+            MouseArea {
+                id: dragArea
+                anchors.fill: parent
+                drag.target: dragArea
+                onDoubleClicked: player.openFile(model.path)
+            }
+            Drag.active: dragArea.drag.active
+            Drag.mimeData: { "path": path }
         }
-        MouseArea {
-            id: dragArea
-            anchors.fill: parent
-            drag.target: dragArea
-            onDoubleClicked: player.openFile(model.path)
-        }
-        Drag.active: dragArea.drag.active
-        Drag.mimeData: { "path": path }
     }
 }

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -1,55 +1,154 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Controls.Material 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Dialogs 1.3
+import "NowPlayingView.qml" as NowPlayingView
 
 ApplicationWindow {
     id: window
     visible: true
     width: 800
     height: 600
-    title: qsTr("Media Player")
+    title: qsTr("MediaPlayer")
+    property string errorMessage: ""
+    Material.theme: settings.theme === "dark" ? Material.Dark : Material.Light
+    property string currentFile: ""
+
+    Connections {
+        target: sync
+        function onSyncReceived(path, position) {
+            player.openFile(path)
+            player.seek(position)
+            window.currentFile = path
+        }
+    }
 
     MediaPlayerController {
         id: player
+        onErrorOccurred: {
+            window.errorMessage = message
+            errorDialog.open()
+        }
+        onPositionChanged: sync.updateStatus(window.currentFile, position)
+    }
+    LibraryModel { id: libraryModel }
+    PlaylistModel { id: playlistModel }
+
+    header: ToolBar {
+        RowLayout {
+            anchors.fill: parent
+            TextField {
+                id: search
+                placeholderText: qsTr("Search")
+                onTextChanged: libraryModel.search(text)
+            }
+            Button {
+                text: qsTr("Open")
+                onClicked: fileDialog.open()
+            }
+            Button { text: qsTr("Settings"); onClicked: settings.open() }
+        }
+    }
+
+    FileDialog {
+        id: fileDialog
+        onAccepted: {
+            player.openFile(fileDialog.file)
+            window.currentFile = fileDialog.file
+            sync.updateStatus(window.currentFile, 0)
+        }
+    }
+
+    SettingsDialog { id: settings }
+
+    MessageDialog {
+        id: errorDialog
+        title: qsTr("Playback Error")
+        text: window.errorMessage
+        standardButtons: Dialog.Ok
+    }
+
+    focus: true
+    Keys.onPressed: {
+        if (event.key === Qt.Key_Space) {
+            player.playing ? player.pause() : player.play()
+            event.accepted = true
+        } else if (event.key === Qt.Key_Left) {
+            player.seek(player.position - 5)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Right) {
+            player.seek(player.position + 5)
+            event.accepted = true
+        } else if (event.key === Qt.Key_Up) {
+            player.setVolume(Math.min(1, player.volume + 0.05))
+            event.accepted = true
+        } else if (event.key === Qt.Key_Down) {
+            player.setVolume(Math.max(0, player.volume - 0.05))
+            event.accepted = true
+        } else if (event.key === Qt.Key_MediaNext) {
+            player.nextTrack()
+            event.accepted = true
+        } else if (event.key === Qt.Key_MediaPrevious) {
+            player.previousTrack()
+            event.accepted = true
+        }
     }
 
     ColumnLayout {
         anchors.fill: parent
-        spacing: 8
-
         VideoPlayer {
-            id: video
+            Layout.fillWidth: true
+            Layout.preferredHeight: 300
+        }
+        RowLayout {
+            spacing: 8
+            Label { text: player.title }
+            Label { text: player.artist }
+            Label { text: player.album }
+        }
+        LibraryView {
             Layout.fillWidth: true
             Layout.fillHeight: true
         }
-
+        PlaylistView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 100
+        }
+        NowPlayingView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 120
+        }
+        VisualizationView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 150
+        }
         RowLayout {
             Layout.fillWidth: true
-            spacing: 8
-
+            ToolButton {
+                icon.source: "qrc:/icons/prev.svg"
+                onClicked: player.seek(player.position - 10)
+            }
             ToolButton {
                 id: playPause
                 icon.source: player.playing ? "qrc:/icons/pause.svg" : "qrc:/icons/play.svg"
                 onClicked: player.playing ? player.pause() : player.play()
             }
-
+            ToolButton {
+                icon.source: "qrc:/icons/next.svg"
+                onClicked: player.seek(player.position + 10)
+            }
+            Label { text: Math.floor(player.position) }
             Slider {
-                id: seek
+                id: seekSlider
                 Layout.fillWidth: true
                 from: 0
                 to: player.duration
                 value: player.position
                 onMoved: player.seek(value)
             }
-
-            Slider {
-                id: volume
-                width: 100
-                from: 0
-                to: 1
-                value: player.volume
-                onValueChanged: player.setVolume(value)
-            }
+            Label { text: Math.floor(player.duration) }
+            Slider { from: 0; to: 1; value: 1; onValueChanged: player.setVolume(value) }
         }
     }
 }

--- a/src/desktop/app/qml/NowPlayingView.qml
+++ b/src/desktop/app/qml/NowPlayingView.qml
@@ -4,6 +4,8 @@ import QtQuick.Controls 2.15
 ListView {
     id: nowPlaying
     anchors.fill: parent
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     model: nowPlayingModel
     delegate: Row {
         id: row

--- a/src/desktop/app/qml/PlaylistItemsDialog.qml
+++ b/src/desktop/app/qml/PlaylistItemsDialog.qml
@@ -5,10 +5,9 @@ Dialog {
     id: dlg
     property string playlistName: ""
     title: playlistName
-    width: 400
-    height: 300
+    implicitWidth: 400
+    implicitHeight: 300
     standardButtons: Dialog.Close
-
     PlaylistItemsView {
         anchors.fill: parent
         playlistName: dlg.playlistName

--- a/src/desktop/app/qml/PlaylistItemsView.qml
+++ b/src/desktop/app/qml/PlaylistItemsView.qml
@@ -4,6 +4,8 @@ import QtQuick.Controls 2.15
 ListView {
     id: playlistItems
     anchors.fill: parent
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     property string playlistName: ""
     model: playlistModel.playlistItems(playlistName)
     delegate: Row {

--- a/src/desktop/app/qml/PlaylistView.qml
+++ b/src/desktop/app/qml/PlaylistView.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-Column {
+ColumnLayout {
     spacing: 4
+    anchors.fill: parent
 
     SmartPlaylistEditor { id: smartEditor }
     PlaylistItemsDialog { id: itemsDialog }
 
-    Row {
+    RowLayout {
         spacing: 4
         TextField {
             id: nameField
@@ -44,8 +45,10 @@ Column {
 
     ListView {
         id: list
-        anchors.fill: parent
-        anchors.topMargin: removeArea.height + 4
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.fillWidth: true
+        Layout.fillHeight: true
         model: playlistModel
         delegate: Rectangle {
             width: parent.width

--- a/src/desktop/app/qml/SettingsDialog.qml
+++ b/src/desktop/app/qml/SettingsDialog.qml
@@ -16,19 +16,17 @@ Dialog {
         }
     }
 
-    Column {
+    ColumnLayout {
+        anchors.fill: parent
         spacing: 8
 
         CheckBox {
             id: themeBox
             text: qsTr("Dark theme")
-            onToggled: {
-                Qt.application.theme = checked ? "dark" : "light"
-                settings.theme = checked ? "dark" : "light"
-            }
+            onToggled: settings.theme = checked ? "dark" : "light"
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Label { text: qsTr("Audio device") }
             ComboBox {
@@ -47,7 +45,7 @@ Dialog {
             }
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Label { text: qsTr("Language") }
             ComboBox {
@@ -68,8 +66,8 @@ Dialog {
 
         ListView {
             id: deviceList
-            height: 100
-            width: parent.width
+            Layout.fillWidth: true
+            Layout.preferredHeight: 100
             model: discoveredDevices
             delegate: Row {
                 spacing: 4
@@ -81,7 +79,7 @@ Dialog {
             }
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Button {
                 text: qsTr("Scan Library")
@@ -101,7 +99,7 @@ Dialog {
             onToggled: player.visualizer.setEnabled(checked)
         }
 
-        Row {
+        RowLayout {
             spacing: 4
             Button {
                 text: qsTr("Prev Preset")
@@ -115,11 +113,10 @@ Dialog {
 
         GroupBox {
             title: qsTr("Format Converter")
-
-            Column {
+            ColumnLayout {
                 spacing: 4
 
-                Row {
+                RowLayout {
                     spacing: 4
                     Button {
                         text: qsTr("Input")
@@ -128,7 +125,7 @@ Dialog {
                     Label { text: convInput }
                 }
 
-                Row {
+                RowLayout {
                     spacing: 4
                     Button {
                         text: qsTr("Output")

--- a/src/desktop/app/qml/SmartPlaylistEditor.qml
+++ b/src/desktop/app/qml/SmartPlaylistEditor.qml
@@ -7,12 +7,13 @@ Dialog {
     standardButtons: Dialog.Ok | Dialog.Cancel
     property var rules: []
     property string playlistName: ""
-    Column {
+    ColumnLayout {
+        anchors.fill: parent
         spacing: 8
         TextField { id: nameField; placeholderText: qsTr("Name"); text: dlg.playlistName }
         Repeater {
             model: dlg.rules
-            delegate: Row {
+            delegate: RowLayout {
                 spacing: 4
                 ComboBox {
                     id: fieldBox

--- a/src/desktop/app/qml/VideoPlayer.qml
+++ b/src/desktop/app/qml/VideoPlayer.qml
@@ -2,7 +2,8 @@ import QtQuick 2.15
 import MediaPlayer 1.0
 
 Item {
-    width: 640; height: 360
+    Layout.fillWidth: true
+    Layout.preferredHeight: 360
     VideoItem {
         id: item
         anchors.fill: parent

--- a/src/desktop/app/qml/VisualizationView.qml
+++ b/src/desktop/app/qml/VisualizationView.qml
@@ -4,6 +4,8 @@ import MediaPlayer 1.0
 
 Item {
     id: root
+    Layout.fillWidth: true
+    Layout.fillHeight: true
     VisualizerItem {
         id: canvas
         anchors.fill: parent


### PR DESCRIPTION
## Summary
- add optional code signing to macOS packaging script
- enable Material style with theme switching and error dialog
- expose player state and track info to QML
- add keyboard shortcuts and responsive layouts
- add search bar to library view

## Testing
- `clang-format -i src/desktop/app/MediaPlayerController.cpp src/desktop/app/MediaPlayerController.h src/core/include/mediaplayer/PlaybackCallbacks.h src/core/src/MediaPlayer.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6869daa098688331b08a5a0a1509d9be