### PR TITLE
Add task table generator script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Tasks are organized in `parallel_tasks.md`. To claim a task:
 2. Assign the issue to yourself (or request assignment from a maintainer).
 3. Create a feature branch named after the task, e.g. `feature/123-audio-decoder`.
 4. When the task is complete, open a pull request referencing the issue.
+5. If you edit `Tasks.MD`, regenerate `parallel_tasks.md` using
+   `python tools/generate_parallel_tasks.py > parallel_tasks.md` so the task table stays in sync.
 
 Only work on one unclaimed task per branch. This keeps merges straightforward and mirrors the parallel development model described in the task list.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 MediaPlayer is an open-source, cross-platform AI-enabled media player focused on speed and a polished user experience.
 High level design is described in [Masterplan.MD](Masterplan.MD) and a breakdown of work items is in [Tasks.MD](Tasks.MD).
 For a quick index of task IDs see [parallel_tasks.md](parallel_tasks.md).
+If you modify `Tasks.MD`, regenerate that table with `python tools/generate_parallel_tasks.py > parallel_tasks.md`.
 
 See `docs/` for additional documentation and `src/` for module code. The
 new [library integration guide](docs/library_integration.md) describes how the

--- a/tools/generate_parallel_tasks.py
+++ b/tools/generate_parallel_tasks.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+
+def anchor(text: str) -> str:
+    """Convert heading text to a GitHub anchor."""
+    a = text.lower()
+    a = re.sub(r"[^a-z0-9 ,&-]", "", a)
+    a = a.replace("&", "")
+    a = a.replace(" ", "-")
+    a = re.sub(r"-+", "-", a)
+    return a.strip("-")
+
+
+def parse_tasks(md_path: Path):
+    sections = []
+    current = None
+    with md_path.open(encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("## "):
+                heading = line[3:].strip()
+                if heading.lower().startswith("module overview"):
+                    current = None
+                    continue
+                current = [heading, []]
+                sections.append(current)
+            else:
+                m = re.search(r"\*\s*\*Task:\*\s*\*\*(.+?)\*\*", line)
+                if m and current:
+                    current[1].append(m.group(1).strip())
+    return sections
+
+
+def generate(sections):
+    out_lines = ["#Parallel Development Tasks", ""]
+    idx = 1
+    for heading, tasks in sections:
+        out_lines.append(f"## {heading} ([Tasks.MD](Tasks.MD#{anchor(heading)}))")
+        out_lines.append("")
+        out_lines.append("| # | Task | Status | Notes |")
+        out_lines.append("|-:|------|--------|-------|")
+        for task in tasks:
+            out_lines.append(f"| {idx} | {task} | open | |")
+            idx += 1
+        out_lines.append("")
+    return "\n".join(out_lines)
+
+
+def main():
+    md_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("Tasks.MD")
+    sections = parse_tasks(md_path)
+    print(generate(sections))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/generate_parallel_tasks.py` for regenerating `parallel_tasks.md`
- document how to run the generator in README and CONTRIBUTING

## Testing
- `python3 tools/generate_parallel_tasks.py >/tmp/test_out.md`

------
https://chatgpt.com/codex/tasks/task_e_686a99c3add8833184aa1addb4e86a06