### PR TITLE
Add Android app skeleton with JNI bindings

### DIFF
--- a/src/android/README.md
+++ b/src/android/README.md
@@ -1,1 +1,14 @@
 # Android App
+
+This directory contains the Android front end for the MediaPlayer project.
+It is a standard Gradle project located in `app/`.
+
+The app integrates the C++ core through JNI. Native sources are in `jni/` and
+are built via the `CMakeLists.txt` included with the module. Kotlin code resides
+under `app/src/main/java` and uses Jetpack components for navigation and
+preferences.
+
+Minimum SDK version is 24 and the project targets the latest API level.
+Supported ABIs are `arm64-v8a`, `armeabi-v7a` and `x86_64`.
+
+Run instrumented tests with `./gradlew connectedAndroidTest`.

--- a/src/android/app/CMakeLists.txt
+++ b/src/android/app/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.18.1)
+project(mediaplayer_android)
+
+add_library(mediaplayer SHARED
+    ../../core/src/AudioDecoder.cpp
+    ../../core/src/VideoDecoder.cpp
+)
+
+# Simplified: link to core library if built separately
+find_library(log-lib log)
+
+target_link_libraries(mediaplayer
+    PUBLIC mediaplayer_core
+    ${log-lib}
+)

--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    namespace 'com.example.mediaplayer'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.mediaplayer"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "0.1"
+
+        externalNativeBuild {
+            cmake {
+                cppFlags "-std=c++17"
+            }
+        }
+
+        ndk {
+            abiFilters "arm64-v8a", "armeabi-v7a", "x86_64"
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        debug {}
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
+        }
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.7.4'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.7.4'
+}

--- a/src/android/app/src/androidTest/java/com/example/mediaplayer/PlaybackTest.kt
+++ b/src/android/app/src/androidTest/java/com/example/mediaplayer/PlaybackTest.kt
@@ -1,0 +1,20 @@
+package com.example.mediaplayer
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlaybackTest {
+    @get:Rule
+    val rule = ActivityTestRule(MainActivity::class.java)
+
+    @Test
+    fun startPlayback() {
+        // Simple smoke test ensuring activity launches
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+}

--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest package="com.example.mediaplayer"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <application
+        android:label="MediaPlayer"
+        android:allowBackup="true"
+        android:theme="@style/Theme.App">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/android/app/src/main/java/com/example/mediaplayer/LibraryFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/LibraryFragment.kt
@@ -1,0 +1,59 @@
+package com.example.mediaplayer
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class LibraryFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_library, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val list = view.findViewById<RecyclerView>(R.id.list)
+        list.layoutManager = LinearLayoutManager(requireContext())
+        lifecycleScope.launch(Dispatchers.IO) {
+            val items = MediaPlayerNative.nativeListMedia().toList()
+            launch(Dispatchers.Main) {
+                list.adapter = MediaAdapter(items)
+            }
+        }
+    }
+}
+
+private class MediaAdapter(private val items: List<String>) :
+    RecyclerView.Adapter<MediaViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MediaViewHolder {
+        val v = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return MediaViewHolder(v)
+    }
+
+    override fun onBindViewHolder(holder: MediaViewHolder, position: Int) {
+        (holder.itemView as android.widget.TextView).text = items[position]
+        holder.itemView.setOnClickListener {
+            holder.itemView.context.let { ctx ->
+                (ctx as? androidx.fragment.app.FragmentActivity)?.lifecycleScope?.launch(Dispatchers.IO) {
+                    MediaPlayerNative.nativeOpen(items[position])
+                }
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+}
+
+private class MediaViewHolder(view: View) : RecyclerView.ViewHolder(view)

--- a/src/android/app/src/main/java/com/example/mediaplayer/MainActivity.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/MainActivity.kt
@@ -1,0 +1,35 @@
+package com.example.mediaplayer
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.setupActionBarWithNavController
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        val navHost = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        setupActionBarWithNavController(navHost.navController)
+        requestStorage()
+    }
+
+    private fun requestStorage() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
+            != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE), 1)
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        val navHost = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        return navHost.navController.navigateUp() || super.onSupportNavigateUp()
+    }
+}

--- a/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
@@ -1,0 +1,15 @@
+package com.example.mediaplayer
+
+object MediaPlayerNative {
+    init {
+        System.loadLibrary("mediaplayer")
+    }
+
+    external fun nativeOpen(path: String): Boolean
+    external fun nativePlay()
+    external fun nativePause()
+    external fun nativeStop()
+    external fun nativeSeek(position: Double)
+    external fun nativeSetSurface(surface: Any?)
+    external fun nativeListMedia(): Array<String>
+}

--- a/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
@@ -1,0 +1,58 @@
+package com.example.mediaplayer
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class NowPlayingFragment : Fragment(), SurfaceHolder.Callback {
+
+    private var surface: SurfaceView? = null
+    private lateinit var detector: GestureDetector
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_now_playing, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        surface = view.findViewById(R.id.videoSurface)
+        surface?.holder?.addCallback(this)
+        detector = GestureDetector(requireContext(), object : GestureDetector.SimpleOnGestureListener() {
+            override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
+                if (velocityX > 1000) {
+                    lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativeSeek(0.0) }
+                }
+                return true
+            }
+        })
+        view.findViewById<ImageButton>(R.id.playPause).setOnClickListener {
+            lifecycleScope.launch(Dispatchers.IO) {
+                MediaPlayerNative.nativePlay()
+            }
+        }
+        view.setOnTouchListener { _, event -> detector.onTouchEvent(event) }
+    }
+
+    override fun surfaceCreated(holder: SurfaceHolder) {
+        MediaPlayerNative.nativeSetSurface(holder.surface)
+    }
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
+        MediaPlayerNative.nativeSetSurface(null)
+    }
+
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}
+}

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaybackService.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaybackService.kt
@@ -1,0 +1,50 @@
+package com.example.mediaplayer
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.media.session.MediaButtonReceiver
+import androidx.media.app.NotificationCompat as MediaStyle
+import android.support.v4.media.session.MediaSessionCompat
+
+class PlaybackService : Service() {
+    private lateinit var session: MediaSessionCompat
+
+    override fun onCreate() {
+        super.onCreate()
+        session = MediaSessionCompat(this, "player")
+        createChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        MediaButtonReceiver.handleIntent(session, intent)
+        val notif = buildNotification()
+        startForeground(1, notif)
+        return START_STICKY
+    }
+
+    private fun buildNotification(): Notification {
+        return NotificationCompat.Builder(this, "player")
+            .setContentTitle("Playing")
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setStyle(MediaStyle.MediaStyle()
+                .setMediaSession(session.sessionToken))
+            .build()
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= 26) {
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(
+                NotificationChannel("player", "Playback", NotificationManager.IMPORTANCE_LOW)
+            )
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaylistsFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaylistsFragment.kt
@@ -1,0 +1,42 @@
+package com.example.mediaplayer
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+
+class PlaylistsFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_playlists, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val list = view.findViewById<RecyclerView>(R.id.playlists)
+        list.layoutManager = LinearLayoutManager(requireContext())
+        list.adapter = PlaylistAdapter(emptyList())
+    }
+}
+
+private class PlaylistAdapter(private val items: List<String>) :
+    RecyclerView.Adapter<PlaylistViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlaylistViewHolder {
+        val v = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return PlaylistViewHolder(v)
+    }
+
+    override fun onBindViewHolder(holder: PlaylistViewHolder, position: Int) {
+        (holder.itemView as android.widget.TextView).text = items[position]
+    }
+
+    override fun getItemCount(): Int = items.size
+}
+
+private class PlaylistViewHolder(view: View) : RecyclerView.ViewHolder(view)

--- a/src/android/app/src/main/java/com/example/mediaplayer/SettingsActivity.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/SettingsActivity.kt
@@ -1,0 +1,21 @@
+package com.example.mediaplayer
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.PreferenceFragmentCompat
+
+class SettingsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        supportFragmentManager
+            .beginTransaction()
+            .replace(android.R.id.content, SettingsFragment())
+            .commit()
+    }
+}
+
+class SettingsFragment : PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.settings, rootKey)
+    }
+}

--- a/src/android/app/src/main/java/com/example/mediaplayer/VoiceControl.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/VoiceControl.kt
@@ -1,0 +1,14 @@
+package com.example.mediaplayer
+
+import android.app.Activity
+import android.content.Intent
+import android.speech.RecognizerIntent
+
+object VoiceControl {
+    fun startVoiceCommand(activity: Activity, requestCode: Int) {
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+            RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+        activity.startActivityForResult(intent, requestCode)
+    }
+}

--- a/src/android/app/src/main/res/layout/activity_main.xml
+++ b/src/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:navGraph="@navigation/nav_graph"
+        app:defaultNavHost="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/app/src/main/res/layout/fragment_library.xml
+++ b/src/android/app/src/main/res/layout/fragment_library.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/app/src/main/res/layout/fragment_now_playing.xml
+++ b/src/android/app/src/main/res/layout/fragment_now_playing.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <SurfaceView
+        android:id="@+id/videoSurface"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/controls"/>
+
+    <LinearLayout
+        android:id="@+id/controls"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageButton
+            android:id="@+id/playPause"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_media_play"/>
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/app/src/main/res/layout/fragment_playlists.xml
+++ b/src/android/app/src/main/res/layout/fragment_playlists.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/playlists"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/app/src/main/res/navigation/nav_graph.xml
+++ b/src/android/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:startDestination="@id/libraryFragment">
+
+    <fragment
+        android:id="@+id/libraryFragment"
+        android:name="com.example.mediaplayer.LibraryFragment"
+        android:label="Library"/>
+
+    <fragment
+        android:id="@+id/nowPlayingFragment"
+        android:name="com.example.mediaplayer.NowPlayingFragment"
+        android:label="Now Playing"/>
+
+    <fragment
+        android:id="@+id/playlistsFragment"
+        android:name="com.example.mediaplayer.PlaylistsFragment"
+        android:label="Playlists"/>
+
+</navigation>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MediaPlayer</string>
+</resources>

--- a/src/android/app/src/main/res/values/styles.xml
+++ b/src/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.DarkActionBar"/>
+</resources>

--- a/src/android/app/src/main/res/xml/settings.xml
+++ b/src/android/app/src/main/res/xml/settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<preferences xmlns:android="http://schemas.android.com/apk/res/android">
+    <SwitchPreferenceCompat
+        android:key="pref_visualization"
+        android:title="Enable Visualization"
+        android:defaultValue="true" />
+</preferences>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.0.0")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/src/android/jni/MediaPlayerJNI.cpp
+++ b/src/android/jni/MediaPlayerJNI.cpp
@@ -1,0 +1,62 @@
+#include "mediaplayer/MediaPlayer.h"
+#include <jni.h>
+#include <memory>
+
+using mediaplayer::MediaPlayer;
+
+static std::unique_ptr<MediaPlayer> g_player;
+static jobject g_callback = nullptr;
+static JavaVM *g_vm = nullptr;
+
+extern "C" jint JNI_OnLoad(JavaVM *vm, void *) {
+  g_vm = vm;
+  return JNI_VERSION_1_6;
+}
+
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativePlay(JNIEnv *, jclass) {
+  if (g_player)
+    g_player->play();
+}
+
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativePause(JNIEnv *, jclass) {
+  if (g_player)
+    g_player->pause();
+}
+
+extern "C" jboolean Java_com_example_mediaplayer_MediaPlayerNative_nativeOpen(JNIEnv *env, jclass,
+                                                                              jstring path) {
+  if (!g_player)
+    g_player = std::make_unique<MediaPlayer>();
+  const char *cpath = env->GetStringUTFChars(path, nullptr);
+  bool ok = g_player->open(cpath);
+  env->ReleaseStringUTFChars(path, cpath);
+  return ok;
+}
+
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeStop(JNIEnv *, jclass) {
+  if (g_player)
+    g_player->stop();
+}
+
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSeek(JNIEnv *, jclass,
+                                                                          jdouble pos) {
+  if (g_player)
+    g_player->seek(pos);
+}
+
+extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeListMedia(JNIEnv *env,
+                                                                                       jclass) {
+  if (!g_player)
+    g_player = std::make_unique<MediaPlayer>();
+  auto items = g_player->allMedia();
+  jobjectArray arr = env->NewObjectArray(items.size(), env->FindClass("java/lang/String"), nullptr);
+  for (size_t i = 0; i < items.size(); ++i) {
+    env->SetObjectArrayElement(arr, i, env->NewStringUTF(items[i].path.c_str()));
+  }
+  return arr;
+}
+
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSetSurface(JNIEnv *, jclass,
+                                                                                jobject surface) {
+  // TODO connect to video output
+}

--- a/src/android/settings.gradle
+++ b/src/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "MediaPlayerAndroid"
+include(":app")


### PR DESCRIPTION
## Summary
- initialize basic Android Gradle project under `src/android`
- add Kotlin fragments and activity with navigation component
- create JNI bridge to core C++ library
- implement simple `PlaybackService` with MediaSession
- add permission request, gesture stub and voice command helper
- provide minimal Espresso test

## Testing
- `clang-format -i src/android/jni/MediaPlayerJNI.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686aa1a88ffc83318b397bcabf95e811