### PR TITLE
Add Kotlin listener and JNI callbacks

### DIFF
--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -132,8 +132,8 @@
   | 105 | Settings Activity                  | done   | relevant |
   | 106 | JNI Bridge Class                   | done   | relevant |
   | 107 | JNI Implementations                | done   | relevant |
-  | 108 | Thread Management                  | open   | relevant |
-  | 109 | Callbacks from Native              | open   | relevant |
+  | 108 | Thread Management                  | done   | relevant |
+  | 109 | Callbacks from Native              | done   | relevant |
   | 110 | MediaSession & Notification        | done   | relevant |
   | 111 | Permission Handling                | done   | relevant |
   | 112 | Gesture Detection                  | done   | relevant |

--- a/src/android/app/src/main/java/com/example/mediaplayer/LibraryFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/LibraryFragment.kt
@@ -46,8 +46,8 @@ private class MediaAdapter(private val items: List<String>) :
         (holder.itemView as android.widget.TextView).text = items[position]
         holder.itemView.setOnClickListener {
             holder.itemView.context.let { ctx ->
-                (ctx as? androidx.fragment.app.FragmentActivity)?.lifecycleScope?.launch(Dispatchers.IO) {
-                    MediaPlayerNative.nativeOpen(items[position])
+                (ctx as? androidx.fragment.app.FragmentActivity)?.lifecycleScope?.launch {
+                    MediaPlayerNative.open(items[position])
                 }
             }
         }

--- a/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
@@ -1,15 +1,22 @@
 package com.example.mediaplayer
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
 object MediaPlayerNative {
     init {
         System.loadLibrary("mediaplayer")
     }
 
     external fun nativeOpen(path: String): Boolean
+    external fun nativeSetListener(listener: PlaybackListener?)
     external fun nativePlay()
     external fun nativePause()
     external fun nativeStop()
     external fun nativeSeek(position: Double)
     external fun nativeSetSurface(surface: Any?)
     external fun nativeListMedia(): Array<String>
+
+    suspend fun open(path: String): Boolean =
+        withContext(Dispatchers.IO) { nativeOpen(path) }
 }

--- a/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
@@ -9,6 +9,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
@@ -43,7 +44,19 @@ class NowPlayingFragment : Fragment(), SurfaceHolder.Callback {
                 MediaPlayerNative.nativePlay()
             }
         }
+        MediaPlayerNative.nativeSetListener(object : PlaybackListener {
+            override fun onFinished() {
+                lifecycleScope.launch(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "Playback finished", Toast.LENGTH_SHORT).show()
+                }
+            }
+        })
         view.setOnTouchListener { _, event -> detector.onTouchEvent(event) }
+    }
+
+    override fun onDestroyView() {
+        MediaPlayerNative.nativeSetListener(null)
+        super.onDestroyView()
     }
 
     override fun surfaceCreated(holder: SurfaceHolder) {

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt
@@ -1,0 +1,11 @@
+package com.example.mediaplayer
+
+interface PlaybackListener {
+    fun onPlay() {}
+    fun onPause() {}
+    fun onStop() {}
+    fun onFinished() {}
+    fun onTrackLoaded(path: String) {}
+    fun onPosition(position: Double) {}
+    fun onError(message: String) {}
+}

--- a/src/android/jni/MediaPlayerJNI.cpp
+++ b/src/android/jni/MediaPlayerJNI.cpp
@@ -3,12 +3,73 @@
 #include <android/native_window_jni.h>
 #include <jni.h>
 #include <memory>
+#include <string>
 
 using mediaplayer::MediaPlayer;
 
 static std::unique_ptr<MediaPlayer> g_player;
 static jobject g_callback = nullptr;
 static JavaVM *g_vm = nullptr;
+
+static JNIEnv *getEnv() {
+  JNIEnv *env = nullptr;
+  if (g_vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+    g_vm->AttachCurrentThread(&env, nullptr);
+  }
+  return env;
+}
+
+static void callVoid(const char *name) {
+  if (!g_callback)
+    return;
+  JNIEnv *env = getEnv();
+  jclass cls = env->GetObjectClass(g_callback);
+  jmethodID mid = env->GetMethodID(cls, name, "()V");
+  if (mid)
+    env->CallVoidMethod(g_callback, mid);
+  env->DeleteLocalRef(cls);
+}
+
+static void callDouble(const char *name, double value) {
+  if (!g_callback)
+    return;
+  JNIEnv *env = getEnv();
+  jclass cls = env->GetObjectClass(g_callback);
+  jmethodID mid = env->GetMethodID(cls, name, "(D)V");
+  if (mid)
+    env->CallVoidMethod(g_callback, mid, value);
+  env->DeleteLocalRef(cls);
+}
+
+static void callString(const char *name, const std::string &str) {
+  if (!g_callback)
+    return;
+  JNIEnv *env = getEnv();
+  jclass cls = env->GetObjectClass(g_callback);
+  jmethodID mid = env->GetMethodID(cls, name, "(Ljava/lang/String;)V");
+  if (mid) {
+    jstring jstr = env->NewStringUTF(str.c_str());
+    env->CallVoidMethod(g_callback, mid, jstr);
+    env->DeleteLocalRef(jstr);
+  }
+  env->DeleteLocalRef(cls);
+}
+
+static void updateCallbacks() {
+  if (!g_player)
+    return;
+  mediaplayer::PlaybackCallbacks cb{};
+  cb.onPlay = []() { callVoid("onPlay"); };
+  cb.onPause = []() { callVoid("onPause"); };
+  cb.onStop = []() { callVoid("onStop"); };
+  cb.onFinished = []() { callVoid("onFinished"); };
+  cb.onTrackLoaded = [](const mediaplayer::MediaMetadata &m) {
+    callString("onTrackLoaded", m.path);
+  };
+  cb.onPosition = [](double p) { callDouble("onPosition", p); };
+  cb.onError = [](const std::string &msg) { callString("onError", msg); };
+  g_player->setCallbacks(std::move(cb));
+}
 
 extern "C" jint JNI_OnLoad(JavaVM *vm, void *) {
   g_vm = vm;
@@ -25,7 +86,23 @@ extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativePause(JNIEn
     g_player->pause();
 }
 
-extern "C" jboolean Java_com_example_mediaplayer_MediaPlayerNative_nativeOpen(JNIEnv *env, jclass) {
+extern "C" jboolean Java_com_example_mediaplayer_MediaPlayerNative_nativeOpen(JNIEnv *env, jclass,
+                                                                              jstring path) {
+  if (!g_player)
+    g_player = std::make_unique<MediaPlayer>();
+  const char *cpath = env->GetStringUTFChars(path, nullptr);
+  updateCallbacks();
+  bool ok = g_player->open(cpath);
+  env->ReleaseStringUTFChars(path, cpath);
+  return ok ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C" void
+Java_com_example_mediaplayer_MediaPlayerNative_nativeSetListener(JNIEnv *env, jclass, jobject cb) {
+  if (g_callback)
+    env->DeleteGlobalRef(g_callback);
+  g_callback = cb ? env->NewGlobalRef(cb) : nullptr;
+  updateCallbacks();
 }
 
 extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeStop(JNIEnv *, jclass) {
@@ -33,12 +110,14 @@ extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeStop(JNIEnv
     g_player->stop();
 }
 
-extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSeek(JNIEnv *, jclass, jdouble pos) {
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSeek(JNIEnv *, jclass,
+                                                                          jdouble pos) {
   if (g_player)
     g_player->seek(pos);
 }
 
-extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeListMedia(JNIEnv *env, jclass) {
+extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeListMedia(JNIEnv *env,
+                                                                                       jclass) {
   if (!g_player)
     g_player = std::make_unique<MediaPlayer>();
   auto items = g_player->allMedia();
@@ -49,7 +128,8 @@ extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeLis
   return arr;
 }
 
-extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSetSurface(JNIEnv *env, jclass, jobject surface) {
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSetSurface(JNIEnv *env, jclass,
+                                                                                jobject surface) {
   if (!g_player)
     g_player = std::make_unique<MediaPlayer>();
 


### PR DESCRIPTION
## Summary
- add `PlaybackListener` interface for Kotlin callbacks
- invoke callbacks from native layer using `CallVoidMethod`
- run blocking open on `Dispatchers.IO`
- show playback completion toast
- mark completed tasks in `parallel_tasks.md`

## Testing
- `clang-format -i src/android/jni/MediaPlayerJNI.cpp`
- `g++ -I/usr/lib/jvm/default-java/include -I/usr/lib/jvm/default-java/include/linux -Isrc/core/include -Isrc/android -Isrc -fsyntax-only src/android/jni/MediaPlayerJNI.cpp` *(fails: libavcodec/avcodec.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686af3fb1a1c8331bea190e89e71bb07