### PR TITLE
Add Espresso library playback test

### DIFF
--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -13,6 +13,7 @@ android {
         targetSdk 34
         versionCode 1
         versionName "0.1"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         externalNativeBuild {
             cmake {
@@ -52,4 +53,11 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.7.4'
     implementation 'androidx.navigation:navigation-ui-ktx:2.7.4'
     implementation 'androidx.media:media:1.6.0'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test:core-ktx:1.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.5.1'
 }

--- a/src/android/app/src/androidTest/java/com/example/mediaplayer/LibraryPlaybackTest.kt
+++ b/src/android/app/src/androidTest/java/com/example/mediaplayer/LibraryPlaybackTest.kt
@@ -1,0 +1,40 @@
+package com.example.mediaplayer
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryPlaybackTest {
+    @get:Rule
+    val rule = ActivityTestRule(MainActivity::class.java)
+
+    @Test
+    fun clickLibraryItemShowsPlayingNotification() {
+        // Click the first item in the library list
+        onView(withId(R.id.list)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+        )
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val hasPlaying = manager.activeNotifications.any {
+            it.notification.extras.getString(Notification.EXTRA_TITLE) == "Playing"
+        }
+        assertTrue("Playback notification missing", hasPlaying)
+    }
+}


### PR DESCRIPTION
## Summary
- add `LibraryPlaybackTest` Espresso test
- add test runner and dependencies to the Android Gradle module

## Testing
- `gradle wrapper`
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af404779c8331908a5cdc5eb0d5c8