### PR TITLE
Implement nativeOpen JNI method

### DIFF
--- a/src/android/jni/MediaPlayerJNI.cpp
+++ b/src/android/jni/MediaPlayerJNI.cpp
@@ -25,7 +25,16 @@ extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativePause(JNIEn
     g_player->pause();
 }
 
-extern "C" jboolean Java_com_example_mediaplayer_MediaPlayerNative_nativeOpen(JNIEnv *env, jclass) {
+extern "C" jboolean Java_com_example_mediaplayer_MediaPlayerNative_nativeOpen(JNIEnv *env, jclass,
+                                                                              jstring path) {
+  const char *cpath = env->GetStringUTFChars(path, nullptr);
+  std::string pathStr = cpath ? cpath : "";
+  if (cpath)
+    env->ReleaseStringUTFChars(path, cpath);
+  if (!g_player)
+    g_player = std::make_unique<MediaPlayer>();
+  bool result = g_player->open(pathStr);
+  return result ? JNI_TRUE : JNI_FALSE;
 }
 
 extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeStop(JNIEnv *, jclass) {
@@ -33,12 +42,14 @@ extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeStop(JNIEnv
     g_player->stop();
 }
 
-extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSeek(JNIEnv *, jclass, jdouble pos) {
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSeek(JNIEnv *, jclass,
+                                                                          jdouble pos) {
   if (g_player)
     g_player->seek(pos);
 }
 
-extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeListMedia(JNIEnv *env, jclass) {
+extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeListMedia(JNIEnv *env,
+                                                                                       jclass) {
   if (!g_player)
     g_player = std::make_unique<MediaPlayer>();
   auto items = g_player->allMedia();
@@ -49,7 +60,8 @@ extern "C" jobjectArray Java_com_example_mediaplayer_MediaPlayerNative_nativeLis
   return arr;
 }
 
-extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSetSurface(JNIEnv *env, jclass, jobject surface) {
+extern "C" void Java_com_example_mediaplayer_MediaPlayerNative_nativeSetSurface(JNIEnv *env, jclass,
+                                                                                jobject surface) {
   if (!g_player)
     g_player = std::make_unique<MediaPlayer>();
 


### PR DESCRIPTION
## Summary
- add missing `path` parameter to nativeOpen
- convert jstring to `std::string` and call `MediaPlayer::open`
- return JNI boolean result

## Testing
- `clang-format -i src/android/jni/MediaPlayerJNI.cpp`


------
https://chatgpt.com/codex/tasks/task_e_686af3e62f388331a5764b3bb0a05022