### PR TITLE
Update voice control to ActivityResult API

### DIFF
--- a/src/android/app/src/main/java/com/example/mediaplayer/VoiceControl.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/VoiceControl.kt
@@ -3,12 +3,57 @@ package com.example.mediaplayer
 import android.app.Activity
 import android.content.Intent
 import android.speech.RecognizerIntent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
 
 object VoiceControl {
-    fun startVoiceCommand(activity: Activity, requestCode: Int) {
-        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
-        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-            RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-        activity.startActivityForResult(intent, requestCode)
+
+    fun registerLauncher(
+        activity: ComponentActivity,
+        callback: (List<String>) -> Unit
+    ): ActivityResultLauncher<Intent> {
+        return activity.registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            val results = if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                    .orEmpty()
+            } else {
+                emptyList()
+            }
+            callback(results)
+        }
+    }
+
+    fun registerLauncher(
+        fragment: Fragment,
+        callback: (List<String>) -> Unit
+    ): ActivityResultLauncher<Intent> {
+        return fragment.registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            val results = if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                    .orEmpty()
+            } else {
+                emptyList()
+            }
+            callback(results)
+        }
+    }
+
+    private fun createSpeechIntent(): Intent {
+        return Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+            )
+        }
+    }
+
+    fun startVoiceCommand(launcher: ActivityResultLauncher<Intent>) {
+        launcher.launch(createSpeechIntent())
     }
 }


### PR DESCRIPTION
## Summary
- refactor `VoiceControl.kt` to use `ActivityResultLauncher`
- add helpers for registering launchers from `Activity` or `Fragment`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686af3e966648331b4c6adc570672332