### PR TITLE
Fix Android app CMake to include JNI

### DIFF
--- a/src/android/app/CMakeLists.txt
+++ b/src/android/app/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mediaplayer_android)
 add_library(mediaplayer SHARED
     ../../core/src/AudioDecoder.cpp
     ../../core/src/VideoDecoder.cpp
+    ../jni/MediaPlayerJNI.cpp
 )
 
 # Simplified: link to core library if built separately


### PR DESCRIPTION
## Summary
- build mediaplayer JNI glue when compiling the Android library
- confirm mediaplayer links to the core library

## Testing
- `gradle -p app :app:externalNativeBuildDebug --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af3f073488331969dd3c6780fba1c