### PR TITLE
Add playback listener callbacks for Android

### DIFF
--- a/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
@@ -12,4 +12,10 @@ object MediaPlayerNative {
     external fun nativeSeek(position: Double)
     external fun nativeSetSurface(surface: Any?)
     external fun nativeListMedia(): Array<String>
+
+    external fun nativeSetListener(listener: PlaybackListener?)
+
+    fun setPlaybackListener(listener: PlaybackListener?) {
+        nativeSetListener(listener)
+    }
 }

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt
@@ -1,0 +1,10 @@
+package com.example.mediaplayer
+
+/** Listener for playback events coming from native code. */
+interface PlaybackListener {
+    /** Called when playback of the current track finished. */
+    fun onFinished()
+
+    /** Called periodically with the current playback position in seconds. */
+    fun onPosition(position: Double)
+}


### PR DESCRIPTION
## Summary
- add `PlaybackListener` Kotlin interface for receiving playback events
- expose `setPlaybackListener` in `MediaPlayerNative`
- store listener as a global reference in JNI
- call `onFinished` and `onPosition` from `PlaybackCallbacks`

## Testing
- `clang-format -i src/android/jni/MediaPlayerJNI.cpp`
- `clang-format -i src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt`
- `clang-format -i src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt`

------
https://chatgpt.com/codex/tasks/task_e_686af41911888331b7442501c284e398