### PR TITLE
Document Gradle wrapper regeneration

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -2,6 +2,10 @@
 
 This directory contains container definitions and helper scripts for building MediaPlayer.
 
+### Android wrapper utility
+
+`update_android_wrapper.sh` regenerates the Gradle wrapper jar used by the Android project. Run it from the repository root when CI needs a fresh wrapper.
+
 ## Qt build container
 
 `Dockerfile.qt` provides an Ubuntu image with the Qt 6 SDK installed. Use it when you want to compile the desktop application without installing Qt locally.

--- a/devops/update_android_wrapper.sh
+++ b/devops/update_android_wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Regenerate gradle-wrapper.jar for the Android project.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+cd "${PROJECT_ROOT}/src/android"
+# Use the version defined in gradle-wrapper.properties
+gradle wrapper --gradle-version 8.1.1 --distribution-type bin

--- a/src/android/README.md
+++ b/src/android/README.md
@@ -13,6 +13,14 @@ Supported ABIs are `arm64-v8a`, `armeabi-v7a` and `x86_64`.
 
 Run instrumented tests with `./gradlew connectedAndroidTest`.
 
-The binary `gradle-wrapper.jar` is not included in the repository. If the
-wrapper fails to run, install Gradle locally and execute `gradle wrapper` in
-this directory to regenerate the jar.
+The binary `gradle-wrapper.jar` is intentionally omitted from version control.
+If `./gradlew` fails because the jar is missing, run the following command in
+this directory to download it again:
+
+```bash
+gradle wrapper --gradle-version 8.1.1 --distribution-type bin
+```
+
+The command recreates `gradle/wrapper/gradle-wrapper.jar` so the wrapper script
+can be used normally. CI environments can invoke the helper script
+`devops/update_android_wrapper.sh` to automate this step.


### PR DESCRIPTION
## Summary
- clarify how to recreate `gradle-wrapper.jar` in the Android README
- add helper script for CI to regenerate the wrapper
- mention script in devops docs

## Testing
- `./devops/update_android_wrapper.sh` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af41bd90483319f8734625bae7c66