### PR TITLE
Implement MediaSession playback controls

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,14 @@
         android:label="MediaPlayer"
         android:allowBackup="true"
         android:theme="@style/Theme.App">
+        <service
+            android:name=".PlaybackService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </service>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaybackService.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaybackService.kt
@@ -11,30 +11,94 @@ import androidx.core.app.NotificationCompat
 import androidx.media.session.MediaButtonReceiver
 import androidx.media.app.NotificationCompat as MediaStyle
 import androidx.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class PlaybackService : Service() {
     private lateinit var session: MediaSessionCompat
+    private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
         session = MediaSessionCompat(this, "player")
+        session.setCallback(object : MediaSessionCompat.Callback() {
+            override fun onPlay() {
+                scope.launch { MediaPlayerNative.nativePlay() }
+                updateState(PlaybackStateCompat.STATE_PLAYING)
+            }
+
+            override fun onPause() {
+                scope.launch { MediaPlayerNative.nativePause() }
+                updateState(PlaybackStateCompat.STATE_PAUSED)
+            }
+        })
         createChannel()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         MediaButtonReceiver.handleIntent(session, intent)
-        val notif = buildNotification()
-        startForeground(1, notif)
+        session.isActive = true
+        updateNotification()
         return START_STICKY
     }
 
-    private fun buildNotification(): Notification {
+    private fun buildNotification(state: Int): Notification {
+        val action = if (state == PlaybackStateCompat.STATE_PLAYING) {
+            NotificationCompat.Action(
+                android.R.drawable.ic_media_pause,
+                "Pause",
+                MediaButtonReceiver.buildMediaButtonPendingIntent(
+                    this,
+                    PlaybackStateCompat.ACTION_PAUSE
+                )
+            )
+        } else {
+            NotificationCompat.Action(
+                android.R.drawable.ic_media_play,
+                "Play",
+                MediaButtonReceiver.buildMediaButtonPendingIntent(
+                    this,
+                    PlaybackStateCompat.ACTION_PLAY
+                )
+            )
+        }
+
         return NotificationCompat.Builder(this, "player")
             .setContentTitle("Playing")
             .setSmallIcon(android.R.drawable.ic_media_play)
-            .setStyle(MediaStyle.MediaStyle()
-                .setMediaSession(session.sessionToken))
+            .addAction(action)
+            .setStyle(
+                MediaStyle.MediaStyle()
+                    .setMediaSession(session.sessionToken)
+                    .setShowActionsInCompactView(0)
+            )
+            .setOngoing(state == PlaybackStateCompat.STATE_PLAYING)
             .build()
+    }
+
+    private fun updateNotification() {
+        val state = session.controller.playbackState?.state
+            ?: PlaybackStateCompat.STATE_NONE
+        val notif = buildNotification(state)
+        if (state == PlaybackStateCompat.STATE_PLAYING) {
+            startForeground(1, notif)
+        } else {
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.notify(1, notif)
+        }
+    }
+
+    private fun updateState(state: Int) {
+        val playbackState = PlaybackStateCompat.Builder()
+            .setActions(
+                PlaybackStateCompat.ACTION_PLAY or PlaybackStateCompat.ACTION_PAUSE
+            )
+            .setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 1.0f)
+            .build()
+        session.setPlaybackState(playbackState)
+        updateNotification()
     }
 
     private fun createChannel() {


### PR DESCRIPTION
## Summary
- implement play/pause callbacks in `PlaybackService`
- update `PlaybackStateCompat` and notification when state changes
- register `PlaybackService` in the Android manifest

## Testing
- `./gradlew --version` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686af4255c048331b5070742af979350