### PR TITLE
Integrate Android patches from open PRs

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -2,6 +2,10 @@
 
 This directory contains container definitions and helper scripts for building MediaPlayer.
 
+### Android wrapper utility
+
+`update_android_wrapper.sh` regenerates the Gradle wrapper jar used by the Android project. Run it from the repository root when CI needs a fresh wrapper.
+
 ## Qt build container
 
 `Dockerfile.qt` provides an Ubuntu image with the Qt 6 SDK installed. Use it when you want to compile the desktop application without installing Qt locally.

--- a/devops/update_android_wrapper.sh
+++ b/devops/update_android_wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Regenerate gradle-wrapper.jar for the Android project.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+cd "${PROJECT_ROOT}/src/android"
+# Use the version defined in gradle-wrapper.properties
+gradle wrapper --gradle-version 8.1.1 --distribution-type bin

--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -118,51 +118,79 @@
 | 97 | macOS Bundle | done | package script |
 | 98 | Linux Package/AppImage | done | build script |
 
-
 ## Android App (Kotlin + NDK) ([Tasks.MD](Tasks.MD#android-app-kotlin-ndk))
 
-| #  | Task                                | Status | Notes |
-|---:|-------------------------------------|--------|-------|
-  | 99  | Create Android Studio Project      | done   | relevant |
-  | 100 | NDK Integration                    | done   | relevant |
-  | 101 | Main Activity & Navigation         | done   | relevant |
-  | 102 | Library Fragment (RecyclerView)    | done   | relevant |
-  | 103 | Now Playing Fragment               | done   | relevant |
-  | 104 | Playlists Fragment                 | done   | relevant |
-  | 105 | Settings Activity                  | done   | relevant |
-  | 106 | JNI Bridge Class                   | done   | relevant |
-  | 107 | JNI Implementations                | done   | relevant |
-  | 108 | Thread Management                  | done   | relevant |
-  | 109 | Callbacks from Native              | done   | relevant |
-  | 110 | MediaSession & Notification        | done   | relevant |
-  | 111 | Permission Handling                | done   | relevant |
-  | 112 | Gesture Detection                  | done   | relevant |
-  | 113 | Voice Control (Android)            | done   | relevant |
-  | 114 | Instrumented UI Tests              | open   | relevant |
-  | 115 | Compatibility Testing              | open   | relevant |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 99 | Create Android Studio Project | done | relevant |
+| 100 | NDK Integration | done | relevant |
+| 101 | Main Activity & Navigation | done | relevant |
+| 102 | Library Fragment (RecyclerView) | done | relevant |
+| 103 | Now Playing Fragment | done | relevant |
+| 104 | Playlists Fragment | done | relevant |
+| 105 | Settings Activity | done | relevant |
+| 106 | JNI Bridge Class | done | relevant |
+| 107 | JNI Implementations | done | relevant |
+| 108 | Thread Management | done | relevant |
+| 109 | Callbacks from Native | done | relevant |
+| 110 | MediaSession & Notification | done | relevant |
+| 111 | Permission Handling | done | relevant |
+| 112 | Gesture Detection | done | relevant |
+| 113 | Voice Control (Android) | done | relevant |
+| 114 | Instrumented UI Tests | open | relevant |
+| 115 | Compatibility Testing | open | relevant |
 
 ## iOS App (Swift UI/UIKit + Core bridging) ([Tasks.MD](Tasks.MD#ios-app-swift-uiuikit-core-bridging))
 
-| #   | Task                              | Status | Notes |
-|----:|-----------------------------------|--------|-------|
-| 116 | Create Xcode Project             | open   | relevant |
-| 117 | Include Core Engine              | open   | relevant |
-| 118 | Main UI (SwiftUI ContentView)    | open   | relevant |
-| 119 | Library List View                | open   | relevant |
-| 120 | Now Playing View                 | open   | relevant |
-| 121 | Navigation and Tab Bar           | open   | relevant |
-| 122 | Settings UI                      | open   | relevant |
-| 123 | Bridging Header and Wrapper      | open   | relevant |
-| 124 | Expose to Swift                  | open   | relevant |
-| 125 | Callbacks from Core              | open   | relevant |
-| 126 | Data Flow                        | open   | relevant |
-| 127 | AVAudioSession Handling          | open   | relevant |
-| 128 | Remote Command Center            | open   | relevant |
-| 129 | Gesture Support                  | open   | relevant |
-| 130 | Siri / Voice                     | open   | relevant |
-| 131 | Unit Tests (Swift)               | open   | relevant |
-| 132 | UI Tests (XCTest/UIAutomation)   | open   | relevant |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 116 | Create Xcode Project | open | relevant |
+| 117 | Include Core Engine | open | relevant |
+| 118 | Main UI (SwiftUI ContentView) | open | relevant |
+| 119 | Library List View | open | relevant |
+| 120 | Now Playing View | open | relevant |
+| 121 | Navigation and Tab Bar | open | relevant |
+| 122 | Settings UI | open | relevant |
+| 123 | Bridging Header and Wrapper | open | relevant |
+| 124 | Expose to Swift | open | relevant |
+| 125 | Callbacks from Core | open | relevant |
+| 126 | Data Flow | open | relevant |
+| 127 | AVAudioSession Handling | open | relevant |
+| 128 | Remote Command Center | open | relevant |
+| 129 | Gesture Support | open | relevant |
+| 130 | Siri / Voice | open | relevant |
+| 131 | Unit Tests (Swift) | open | relevant |
+| 132 | UI Tests (XCTest/UIAutomation) | open | relevant |
 
+## Gesture & Voice Control Module ([Tasks.MD](Tasks.MD#gesture-voice-control-module))
+
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 133 | Desktop Mouse Gestures | open |  |
+| 134 | Mobile Touch Gestures | open |  |
+| 135 | Shake to Shuffle (Mobile) | open |  |
+| 136 | Custom Gesture Mapping UI | open |  |
+| 137 | Integrate Vosk Speech Library (C++ or Python) | open |  |
+| 138 | Voice Command Grammar | open |  |
+| 139 | Microphone Capture (Desktop) | open |  |
+| 140 | Voice Input (Mobile) | open |  |
+| 141 | Voice Command Processing | open |  |
+| 142 | Feedback & Error Handling | open |  |
+| 143 | Simulate Voice Commands | open |  |
+| 144 | Gesture Unit Tests | open |  |
+
+## AI Tagging Service (AI Metadata Module) ([Tasks.MD](Tasks.MD#ai-tagging-service-ai-metadata-module))
+
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 145 | Choose AI Framework | open |  |
+| 146 | Environment for AI | open |  |
+| 147 | Music Genre Classification | open |  |
+| 148 | Audio Fingerprinting (Song ID) | open |  |
+| 149 | Speech-to-Text (for Videos) | open |  |
+| 150 | Mood Detection | open |  |
+| 151 | Object & Scene Recognition | open |  |
+| 152 | Face Recognition (Optional) | open |  |
 | 153 | Video Scene Segmentation | open | relevant |
 | 154 | Service API | open | relevant |
 | 155 | Asynchronous Tagging | open | relevant |
@@ -173,48 +201,48 @@
 
 ## Streaming & Networking Module ([Tasks.MD](Tasks.MD#streaming-networking-module))
 
-| #   | Task                               | Status | Notes |
-|----:|------------------------------------|--------|-------|
-| 160 | Open URL UI                        | open   | relevant |
-| 161 | YouTube DL Integration             | done   | `YouTubeDL` helper in network module |
-| 162 | Local DLNA/UPnP Support            | open   | relevant |
-| 163 | HTTP Server for Remote Control    | open   | relevant |
-| 164 | Discovery (mDNS)                  | open   | relevant |
-| 165 | Announcement & Discovery Handlers | open   | relevant |
-| 166 | Device Info Exchange              | open   | relevant |
-| 167 | Sync Playback Position            | open   | relevant |
-| 168 | Cloud Sync Option                 | open   | relevant |
-| 169 | Testing Sync                      | open   | relevant |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 160 | Open URL UI | open | relevant |
+| 161 | YouTube DL Integration | done | `YouTubeDL` helper in network module |
+| 162 | Local DLNA/UPnP Support | open | relevant |
+| 163 | HTTP Server for Remote Control | open | relevant |
+| 164 | Discovery (mDNS) | open | relevant |
+| 165 | Announcement & Discovery Handlers | open | relevant |
+| 166 | Device Info Exchange | open | relevant |
+| 167 | Sync Playback Position | open | relevant |
+| 168 | Cloud Sync Option | open | relevant |
+| 169 | Testing Sync | open | relevant |
 
 ## DevOps & Infrastructure ([Tasks.MD](Tasks.MD#devops-infrastructure))
 
-| #   | Task                              | Status | Notes |
-|----:|-----------------------------------|--------|-------|
-| 170 | Dockerfile for Core/C++           | done   | Dockerfile.core added |
-| 171 | Dockerfile for Qt                 | done   | Dockerfile.qt added |
-| 172 | Android Build Environment        | open   | relevant |
-| 173 | iOS Build Setup                  | open   | relevant |
-| 174 | GitHub Actions CI Workflow       | done   | relevant |
-| 175 | Automated Tests in CI            | open   | relevant |
-| 176 | Static Analysis & Lint           | open   | relevant |
-| 177 | Code Formatting                  | done   | relevant |
-| 178 | Git Submodules for Libraries     | open   | relevant |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 170 | Dockerfile for Core/C++ | done | Dockerfile.core added |
+| 171 | Dockerfile for Qt | done | Dockerfile.qt added |
+| 172 | Android Build Environment | open | relevant |
+| 173 | iOS Build Setup | open | relevant |
+| 174 | GitHub Actions CI Workflow | done | relevant |
+| 175 | Automated Tests in CI | open | relevant |
+| 176 | Static Analysis & Lint | open | relevant |
+| 177 | Code Formatting | done | relevant |
+| 178 | Git Submodules for Libraries | open | relevant |
 | 179 | Issue Templates and Contribution Guide | open | relevant |
-| 180 | Merge Strategy for AI Agents     | open   | relevant |
+| 180 | Merge Strategy for AI Agents | open | relevant |
 
 ## Testing & Quality Assurance ([Tasks.MD](Tasks.MD#testing-quality-assurance))
 
-| #   | Task                              | Status | Notes |
-|----:|-----------------------------------|--------|-------|
-| 181 | Core Unit Tests Setup            | open   | relevant |
-| 182 | Library Module Tests             | open   | relevant |
-| 183 | Visualization Tests              | open   | relevant |
-| 184 | Playback Integration Test        | open   | relevant |
-| 185 | End-to-End Script                | open   | relevant |
-| 186 | Startup Time Test                | open   | relevant |
-| 187 | Memory/CPU Profiling             | open   | relevant |
-| 188 | Battery Test (Mobile)            | open   | relevant |
-| 189 | Formats Compatibility Test       | open   | relevant |
-| 190 | UI Responsiveness Test           | open   | relevant |
-| 191 | Automate Regression Suite       | open   | relevant |
+| # | Task | Status | Notes |
+|-:|------|--------|-------|
+| 181 | Core Unit Tests Setup | open | relevant |
+| 182 | Library Module Tests | open | relevant |
+| 183 | Visualization Tests | open | relevant |
+| 184 | Playback Integration Test | open | relevant |
+| 185 | End-to-End Script | open | relevant |
+| 186 | Startup Time Test | open | relevant |
+| 187 | Memory/CPU Profiling | open | relevant |
+| 188 | Battery Test (Mobile) | open | relevant |
+| 189 | Formats Compatibility Test | open | relevant |
+| 190 | UI Responsiveness Test | open | relevant |
+| 191 | Automate Regression Suite | open | relevant |
 

--- a/src/android/README.md
+++ b/src/android/README.md
@@ -13,6 +13,14 @@ Supported ABIs are `arm64-v8a`, `armeabi-v7a` and `x86_64`.
 
 Run instrumented tests with `./gradlew connectedAndroidTest`.
 
-The binary `gradle-wrapper.jar` is not included in the repository. If the
-wrapper fails to run, install Gradle locally and execute `gradle wrapper` in
-this directory to regenerate the jar.
+The binary `gradle-wrapper.jar` is intentionally omitted from version control.
+If `./gradlew` fails because the jar is missing, run the following command in
+this directory to download it again:
+
+```bash
+gradle wrapper --gradle-version 8.1.1 --distribution-type bin
+```
+
+The command recreates `gradle/wrapper/gradle-wrapper.jar` so the wrapper script
+can be used normally. CI environments can invoke the helper script
+`devops/update_android_wrapper.sh` to automate this step.

--- a/src/android/app/CMakeLists.txt
+++ b/src/android/app/CMakeLists.txt
@@ -4,6 +4,7 @@ project(mediaplayer_android)
 add_library(mediaplayer SHARED
     ../../core/src/AudioDecoder.cpp
     ../../core/src/VideoDecoder.cpp
+    ../jni/MediaPlayerJNI.cpp
 )
 
 # Simplified: link to core library if built separately

--- a/src/android/app/src/androidTest/java/com/example/mediaplayer/PlaybackTest.kt
+++ b/src/android/app/src/androidTest/java/com/example/mediaplayer/PlaybackTest.kt
@@ -2,7 +2,15 @@ package com.example.mediaplayer
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.rule.GrantPermissionRule
+import com.example.mediaplayer.PlaybackService
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -10,11 +18,23 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PlaybackTest {
     @get:Rule
-    val rule = ActivityTestRule(MainActivity::class.java)
+    val intentsRule = IntentsTestRule(MainActivity::class.java)
+
+    @get:Rule
+    val permissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(android.Manifest.permission.READ_EXTERNAL_STORAGE)
 
     @Test
     fun startPlayback() {
         // Simple smoke test ensuring activity launches
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    @Test
+    fun tapLibraryItemStartsService() {
+        onView(withId(R.id.list)).perform(
+            actionOnItemAtPosition<androidx.recyclerview.widget.RecyclerView.ViewHolder>(0, click())
+        )
+        intended(hasComponent(PlaybackService::class.java.name))
     }
 }

--- a/src/android/app/src/main/java/com/example/mediaplayer/LibraryFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/LibraryFragment.kt
@@ -46,8 +46,8 @@ private class MediaAdapter(private val items: List<String>) :
         (holder.itemView as android.widget.TextView).text = items[position]
         holder.itemView.setOnClickListener {
             holder.itemView.context.let { ctx ->
-                (ctx as? androidx.fragment.app.FragmentActivity)?.lifecycleScope?.launch {
-                    MediaPlayerNative.open(items[position])
+                (ctx as? androidx.fragment.app.FragmentActivity)?.lifecycleScope?.launch(Dispatchers.IO) {
+                    MediaPlayerNative.nativeOpen(items[position])
                 }
             }
         }

--- a/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/MediaPlayerNative.kt
@@ -1,15 +1,12 @@
 package com.example.mediaplayer
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-
 object MediaPlayerNative {
     init {
         System.loadLibrary("mediaplayer")
     }
 
     external fun nativeOpen(path: String): Boolean
-    external fun nativeSetListener(listener: PlaybackListener?)
+    external fun nativeSetCallback(listener: PlaybackListener?)
     external fun nativePlay()
     external fun nativePause()
     external fun nativeStop()
@@ -17,6 +14,5 @@ object MediaPlayerNative {
     external fun nativeSetSurface(surface: Any?)
     external fun nativeListMedia(): Array<String>
 
-    suspend fun open(path: String): Boolean =
-        withContext(Dispatchers.IO) { nativeOpen(path) }
+    // Calls that may block should be dispatched on Dispatchers.IO by the caller.
 }

--- a/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
@@ -44,18 +44,20 @@ class NowPlayingFragment : Fragment(), SurfaceHolder.Callback {
                 MediaPlayerNative.nativePlay()
             }
         }
-        MediaPlayerNative.nativeSetListener(object : PlaybackListener {
-            override fun onFinished() {
+        MediaPlayerNative.nativeSetCallback(object : PlaybackListener {
+            override fun onPlaybackFinished() {
                 lifecycleScope.launch(Dispatchers.Main) {
                     Toast.makeText(requireContext(), "Playback finished", Toast.LENGTH_SHORT).show()
                 }
             }
+
+            override fun onPositionChanged(pos: Double) {}
         })
         view.setOnTouchListener { _, event -> detector.onTouchEvent(event) }
     }
 
     override fun onDestroyView() {
-        MediaPlayerNative.nativeSetListener(null)
+        MediaPlayerNative.nativeSetCallback(null)
         super.onDestroyView()
     }
 

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaybackListener.kt
@@ -1,11 +1,9 @@
 package com.example.mediaplayer
 
+/**
+ * Listener interface for playback events coming from the native player.
+ */
 interface PlaybackListener {
-    fun onPlay() {}
-    fun onPause() {}
-    fun onStop() {}
-    fun onFinished() {}
-    fun onTrackLoaded(path: String) {}
-    fun onPosition(position: Double) {}
-    fun onError(message: String) {}
+    fun onPlaybackFinished()
+    fun onPositionChanged(pos: Double)
 }

--- a/src/android/app/src/main/java/com/example/mediaplayer/PlaybackService.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/PlaybackService.kt
@@ -11,30 +11,94 @@ import androidx.core.app.NotificationCompat
 import androidx.media.session.MediaButtonReceiver
 import androidx.media.app.NotificationCompat as MediaStyle
 import androidx.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class PlaybackService : Service() {
     private lateinit var session: MediaSessionCompat
+    private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
         session = MediaSessionCompat(this, "player")
+        session.setCallback(object : MediaSessionCompat.Callback() {
+            override fun onPlay() {
+                scope.launch { MediaPlayerNative.nativePlay() }
+                updateState(PlaybackStateCompat.STATE_PLAYING)
+            }
+
+            override fun onPause() {
+                scope.launch { MediaPlayerNative.nativePause() }
+                updateState(PlaybackStateCompat.STATE_PAUSED)
+            }
+        })
         createChannel()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         MediaButtonReceiver.handleIntent(session, intent)
-        val notif = buildNotification()
-        startForeground(1, notif)
+        session.isActive = true
+        updateNotification()
         return START_STICKY
     }
 
-    private fun buildNotification(): Notification {
+    private fun buildNotification(state: Int): Notification {
+        val action = if (state == PlaybackStateCompat.STATE_PLAYING) {
+            NotificationCompat.Action(
+                android.R.drawable.ic_media_pause,
+                "Pause",
+                MediaButtonReceiver.buildMediaButtonPendingIntent(
+                    this,
+                    PlaybackStateCompat.ACTION_PAUSE
+                )
+            )
+        } else {
+            NotificationCompat.Action(
+                android.R.drawable.ic_media_play,
+                "Play",
+                MediaButtonReceiver.buildMediaButtonPendingIntent(
+                    this,
+                    PlaybackStateCompat.ACTION_PLAY
+                )
+            )
+        }
+
         return NotificationCompat.Builder(this, "player")
             .setContentTitle("Playing")
             .setSmallIcon(android.R.drawable.ic_media_play)
-            .setStyle(MediaStyle.MediaStyle()
-                .setMediaSession(session.sessionToken))
+            .addAction(action)
+            .setStyle(
+                MediaStyle.MediaStyle()
+                    .setMediaSession(session.sessionToken)
+                    .setShowActionsInCompactView(0)
+            )
+            .setOngoing(state == PlaybackStateCompat.STATE_PLAYING)
             .build()
+    }
+
+    private fun updateNotification() {
+        val state = session.controller.playbackState?.state
+            ?: PlaybackStateCompat.STATE_NONE
+        val notif = buildNotification(state)
+        if (state == PlaybackStateCompat.STATE_PLAYING) {
+            startForeground(1, notif)
+        } else {
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.notify(1, notif)
+        }
+    }
+
+    private fun updateState(state: Int) {
+        val playbackState = PlaybackStateCompat.Builder()
+            .setActions(
+                PlaybackStateCompat.ACTION_PLAY or PlaybackStateCompat.ACTION_PAUSE
+            )
+            .setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 1.0f)
+            .build()
+        session.setPlaybackState(playbackState)
+        updateNotification()
     }
 
     private fun createChannel() {

--- a/src/android/app/src/main/java/com/example/mediaplayer/VoiceControl.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/VoiceControl.kt
@@ -3,12 +3,54 @@ package com.example.mediaplayer
 import android.app.Activity
 import android.content.Intent
 import android.speech.RecognizerIntent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
 
 object VoiceControl {
-    fun startVoiceCommand(activity: Activity, requestCode: Int) {
-        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
-        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-            RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-        activity.startActivityForResult(intent, requestCode)
+
+    fun registerLauncher(
+        activity: ComponentActivity,
+        callback: (List<String>) -> Unit
+    ): ActivityResultLauncher<Intent> =
+        activity.registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            val results = if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                    .orEmpty()
+            } else {
+                emptyList()
+            }
+            callback(results)
+        }
+
+    fun registerLauncher(
+        fragment: Fragment,
+        callback: (List<String>) -> Unit
+    ): ActivityResultLauncher<Intent> =
+        fragment.registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            val results = if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                    .orEmpty()
+            } else {
+                emptyList()
+            }
+            callback(results)
+        }
+
+    private fun createSpeechIntent(): Intent =
+        Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+            )
+        }
+
+    fun startVoiceCommand(launcher: ActivityResultLauncher<Intent>) {
+        launcher.launch(createSpeechIntent())
     }
 }

--- a/tools/generate_parallel_tasks.py
+++ b/tools/generate_parallel_tasks.py
@@ -7,7 +7,7 @@ def parse_existing(path: Path):
     statuses = {}
     if not path.exists():
         return statuses
-    pattern = re.compile(r"^\|\s*\d+\s*\|\s*(.*?)\s*\|\s*(\w+)\s*\|\s*(.*?)\s*\|")
+    pattern = re.compile(r"^\s*\|\s*\d+\s*\|\s*(.*?)\s*\|\s*(\w+)\s*\|\s*(.*?)\s*\|")
     with path.open(encoding="utf-8") as f:
         for line in f:
             m = pattern.match(line)


### PR DESCRIPTION
## Summary
- support Activity Result API for voice control
- document Gradle wrapper update script
- add CMake entry for JNI source and new wrapper script
- improve PlaybackService with MediaSession actions
- expose native callbacks with `nativeSetCallback`
- update library fragment and tests accordingly
- regenerate parallel task table

## Testing
- `python3 tools/generate_parallel_tasks.py > parallel_tasks.tmp && mv parallel_tasks.tmp parallel_tasks.md`


------
https://chatgpt.com/codex/tasks/task_e_686afb4998b0833181a7de8b99a542ab