### PR TITLE
Add iOS SwiftUI skeleton and Obj-C++ bridge

### DIFF
--- a/src/ios/README.md
+++ b/src/ios/README.md
@@ -1,1 +1,21 @@
 # iOS App
+
+This directory contains the native iOS implementation written in Swift
+with a small Objective-C++ bridge to the core C++ engine. The Xcode
+project should add the files under `app/` and link against the
+`mediaplayer_core` static library built by CMake for the `arm64` iOS
+platform.
+
+## Building
+
+1. Open `MediaPlayerApp.xcodeproj` (create a new SwiftUI app targeting
+iOS 14 or later).
+2. Add the `mediaplayer_core` library output from the CMake build to the
+project (either via "Add Files" or as a framework).
+3. Include `MediaPlayer-Bridging-Header.h` in the project settings under
+`Objective‑C Bridging Header`.
+4. Ensure the `MediaPlayerBridge.mm` file is compiled as Objective-C++ by
+setting its file type to `Objective-C++ Source`.
+
+The SwiftUI views demonstrate basic playback control and can be expanded
+with library browsing and settings screens as tasks are completed.

--- a/src/ios/app/ContentView.swift
+++ b/src/ios/app/ContentView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var player: MediaPlayerViewModel
+
+    var body: some View {
+        VStack {
+            Text("Position: \(player.position, specifier: "%.1f")")
+            HStack {
+                Button("Play") { player.play() }
+                Button("Pause") { player.pause() }
+            }
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView().environmentObject(MediaPlayerViewModel())
+    }
+}

--- a/src/ios/app/MediaPlayer-Bridging-Header.h
+++ b/src/ios/app/MediaPlayer-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "MediaPlayerBridge.h"

--- a/src/ios/app/MediaPlayerApp.swift
+++ b/src/ios/app/MediaPlayerApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct MediaPlayerApp: App {
+    @StateObject private var player = MediaPlayerViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(player)
+                .onAppear { player.configureCallbacks() }
+        }
+    }
+}

--- a/src/ios/app/MediaPlayerBridge.h
+++ b/src/ios/app/MediaPlayerBridge.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const MediaPlayerTrackFinishedNotification;
+extern NSString *const MediaPlayerPositionChangedNotification;
+
+@interface MediaPlayerBridge : NSObject
+- (instancetype)init;
+- (BOOL)open:(NSString *)path;
+- (void)play;
+- (void)pause;
+- (void)stop;
+- (void)seek:(double)position;
+- (NSArray<NSString *> *)listMedia;
+- (void)setCallbacks;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/app/MediaPlayerBridge.mm
+++ b/src/ios/app/MediaPlayerBridge.mm
@@ -1,0 +1,75 @@
+#import "MediaPlayerBridge.h"
+#include "mediaplayer/MediaPlayer.h"
+#include <memory>
+
+using namespace mediaplayer;
+
+NSString *const MediaPlayerTrackFinishedNotification = @"MediaPlayerTrackFinished";
+NSString *const MediaPlayerPositionChangedNotification = @"MediaPlayerPositionChanged";
+
+@interface MediaPlayerBridge () {
+  std::unique_ptr<MediaPlayer> _player;
+}
+@end
+
+@implementation MediaPlayerBridge
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _player = std::make_unique<MediaPlayer>();
+  }
+  return self;
+}
+
+- (BOOL)open:(NSString *)path {
+  if (!_player)
+    _player = std::make_unique<MediaPlayer>();
+  return _player->open(path.UTF8String);
+}
+
+- (void)play {
+  if (_player)
+    _player->play();
+}
+- (void)pause {
+  if (_player)
+    _player->pause();
+}
+- (void)stop {
+  if (_player)
+    _player->stop();
+}
+- (void)seek:(double)position {
+  if (_player)
+    _player->seek(position);
+}
+
+- (NSArray<NSString *> *)listMedia {
+  if (!_player)
+    _player = std::make_unique<MediaPlayer>();
+  auto items = _player->allMedia();
+  NSMutableArray<NSString *> *arr = [NSMutableArray arrayWithCapacity:items.size()];
+  for (const auto &m : items) {
+    [arr addObject:[NSString stringWithUTF8String:m.path.c_str()]];
+  }
+  return arr;
+}
+
+- (void)setCallbacks {
+  if (!_player)
+    _player = std::make_unique<MediaPlayer>();
+  PlaybackCallbacks cbs;
+  cbs.onFinished = []() {
+    [[NSNotificationCenter defaultCenter] postNotificationName:MediaPlayerTrackFinishedNotification
+                                                        object:nil];
+  };
+  cbs.onPosition = [](double pos) {
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:MediaPlayerPositionChangedNotification
+                      object:nil
+                    userInfo:@{@"position" : @(pos)}];
+  };
+  _player->setCallbacks(cbs);
+}
+
+@end

--- a/src/ios/app/MediaPlayerViewModel.swift
+++ b/src/ios/app/MediaPlayerViewModel.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Combine
+
+class MediaPlayerViewModel: ObservableObject {
+    private let bridge = MediaPlayerBridge()
+    private var observers: [NSObjectProtocol] = []
+
+    @Published var isPlaying: Bool = false
+    @Published var position: Double = 0
+
+    init() {
+        observers.append(NotificationCenter.default.addObserver(forName: .trackFinished, object: nil, queue: .main) { _ in
+            self.isPlaying = false
+        })
+        observers.append(NotificationCenter.default.addObserver(forName: .positionChanged, object: nil, queue: .main) { n in
+            if let pos = n.userInfo?["position"] as? Double {
+                self.position = pos
+            }
+        })
+    }
+
+    deinit {
+        for o in observers { NotificationCenter.default.removeObserver(o) }
+    }
+
+    func configureCallbacks() {
+        bridge.setCallbacks()
+    }
+
+    func open(_ path: String) -> Bool {
+        bridge.open(path)
+    }
+
+    func play() {
+        bridge.play()
+        isPlaying = true
+    }
+
+    func pause() {
+        bridge.pause()
+        isPlaying = false
+    }
+
+    func stop() {
+        bridge.stop()
+        isPlaying = false
+    }
+
+    func seek(to pos: Double) {
+        bridge.seek(pos)
+    }
+}
+
+extension Notification.Name {
+    static let trackFinished = Notification.Name("MediaPlayerTrackFinished")
+    static let positionChanged = Notification.Name("MediaPlayerPositionChanged")
+}


### PR DESCRIPTION
## Summary
- implement Objective-C++ bridge exposing `MediaPlayer` to Swift
- add minimal SwiftUI app with view model and content view
- document iOS build instructions

## Testing
- `clang-format -i src/ios/app/MediaPlayerBridge.h src/ios/app/MediaPlayerBridge.mm`

------
https://chatgpt.com/codex/tasks/task_e_686b284a77e08331a134d8e2c916c8b7