### PR TITLE
Implement shuffle gestures and Siri intent handler on iOS

### DIFF
--- a/src/ios/app/IntentHandler.swift
+++ b/src/ios/app/IntentHandler.swift
@@ -1,0 +1,15 @@
+import Intents
+
+class IntentHandler: INExtension, INPlayMediaIntentHandling, INPauseMediaIntentHandling {
+    private let player = MediaPlayerViewModel()
+
+    func handle(intent: INPlayMediaIntent, completion: @escaping (INPlayMediaIntentResponse) -> Void) {
+        player.play()
+        completion(INPlayMediaIntentResponse(code: .success, userActivity: nil))
+    }
+
+    func handle(intent: INPauseMediaIntent, completion: @escaping (INPauseMediaIntentResponse) -> Void) {
+        player.pause()
+        completion(INPauseMediaIntentResponse(code: .success, userActivity: nil))
+    }
+}

--- a/src/ios/app/MediaPlayerApp.swift
+++ b/src/ios/app/MediaPlayerApp.swift
@@ -4,6 +4,7 @@ import AVFoundation
 @main
 struct MediaPlayerApp: App {
     @StateObject private var player = MediaPlayerViewModel()
+    private let shakeDetector = ShakeDetector()
 
     init() {
         do {
@@ -21,6 +22,11 @@ struct MediaPlayerApp: App {
                 .onAppear {
                     player.configureCallbacks()
                     player.setupRemoteCommands()
+                    shakeDetector.onShake = { player.toggleShuffle() }
+                    shakeDetector.start()
+                }
+                .onDisappear {
+                    shakeDetector.stop()
                 }
         }
     }

--- a/src/ios/app/MediaPlayerBridge.h
+++ b/src/ios/app/MediaPlayerBridge.h
@@ -19,6 +19,8 @@ extern NSString *const MediaPlayerTrackLoadedNotification;
 - (void)nextTrack;
 - (void)previousTrack;
 - (void)setCallbacks;
+- (void)enableShuffle:(BOOL)enabled;
+- (BOOL)shuffleEnabled;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ios/app/MediaPlayerBridge.mm
+++ b/src/ios/app/MediaPlayerBridge.mm
@@ -125,4 +125,15 @@ NSString *const MediaPlayerTrackLoadedNotification = @"MediaPlayerTrackLoaded";
   _player->setCallbacks(cbs);
 }
 
+- (void)enableShuffle:(BOOL)enabled {
+  if (_player)
+    _player->enableShuffle(enabled);
+}
+
+- (BOOL)shuffleEnabled {
+  if (_player)
+    return _player->shuffleEnabled();
+  return NO;
+}
+
 @end

--- a/src/ios/app/MediaPlayerViewModel.swift
+++ b/src/ios/app/MediaPlayerViewModel.swift
@@ -18,6 +18,7 @@ class MediaPlayerViewModel: ObservableObject {
     @Published var currentTitle: String = ""
     @Published var currentArtist: String = ""
     @Published var library: [MediaItem] = []
+    @Published var shuffleEnabled: Bool = false
 
     init(bridge: MediaPlayerBridge = MediaPlayerBridge()) {
         self.bridge = bridge
@@ -78,6 +79,14 @@ class MediaPlayerViewModel: ObservableObject {
 
     func nextTrack() { bridge.nextTrack() }
     func previousTrack() { bridge.previousTrack() }
+    func enableShuffle(_ enabled: Bool) {
+        bridge.enableShuffle(enabled)
+        shuffleEnabled = enabled
+    }
+
+    func toggleShuffle() {
+        enableShuffle(!shuffleEnabled)
+    }
 
     private func updateNowPlayingInfo() {
         var info: [String: Any] = [MPMediaItemPropertyTitle: currentTitle,

--- a/src/ios/app/ShakeDetector.swift
+++ b/src/ios/app/ShakeDetector.swift
@@ -1,0 +1,24 @@
+import Foundation
+import CoreMotion
+
+class ShakeDetector {
+    private let motion = CMMotionManager()
+    var onShake: (() -> Void)?
+
+    func start() {
+        guard motion.isAccelerometerAvailable else { return }
+        motion.accelerometerUpdateInterval = 0.2
+        motion.startAccelerometerUpdates(to: .main) { [weak self] data, _ in
+            guard let data = data else { return }
+            let acc = data.acceleration
+            let magnitude = sqrt(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z)
+            if magnitude > 2.7 {
+                self?.onShake?()
+            }
+        }
+    }
+
+    func stop() {
+        motion.stopAccelerometerUpdates()
+    }
+}

--- a/tests/ios/MediaPlayerViewModelTests.swift
+++ b/tests/ios/MediaPlayerViewModelTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 class DummyBridge: MediaPlayerBridge {
     var playCalled = false
+    var shuffleEnabledFlag = false
     override func play() { playCalled = true }
+    override func enableShuffle(_ enabled: Bool) { shuffleEnabledFlag = enabled }
 }
 
 final class MediaPlayerViewModelTests: XCTestCase {
@@ -11,5 +13,12 @@ final class MediaPlayerViewModelTests: XCTestCase {
         let vm = MediaPlayerViewModel(bridge: DummyBridge())
         vm.play()
         XCTAssertTrue(vm.isPlaying)
+    }
+
+    func testToggleShuffleCallsBridge() {
+        let bridge = DummyBridge()
+        let vm = MediaPlayerViewModel(bridge: bridge)
+        vm.toggleShuffle()
+        XCTAssertTrue(bridge.shuffleEnabledFlag)
     }
 }


### PR DESCRIPTION
## Summary
- extend MediaPlayerBridge API with shuffle controls
- implement ShakeDetector and hook it up in MediaPlayerApp for shake-to-shuffle
- expose shuffle APIs through MediaPlayerViewModel
- add basic SiriKit intent handler for play and pause
- cover shuffle toggle in unit tests

## Testing
- `clang-format -i src/ios/app/MediaPlayerBridge.h src/ios/app/MediaPlayerBridge.mm`

------
https://chatgpt.com/codex/tasks/task_e_686b2db5ab788331ac292137cc1fe5ff