### PR TITLE
Enhance iOS search and playback handling

### DIFF
--- a/src/core/include/mediaplayer/MediaPlayer.h
+++ b/src/core/include/mediaplayer/MediaPlayer.h
@@ -97,6 +97,7 @@ public:
   std::vector<MediaMetadata> allMedia() const;
   std::vector<std::string> allPlaylists() const;
   std::vector<MediaMetadata> playlistItems(const std::string &name) const;
+  std::vector<MediaMetadata> searchLibrary(const std::string &query) const;
 
 private:
   void demuxLoop();

--- a/src/core/src/MediaPlayer.cpp
+++ b/src/core/src/MediaPlayer.cpp
@@ -248,6 +248,13 @@ std::vector<MediaMetadata> MediaPlayer::playlistItems(const std::string &name) c
   return {};
 }
 
+std::vector<MediaMetadata> MediaPlayer::searchLibrary(const std::string &query) const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_library)
+    return m_library->search(query);
+  return {};
+}
+
 void MediaPlayer::setAudioOutput(std::unique_ptr<AudioOutput> output) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_output) {

--- a/src/ios/app/LibraryView.swift
+++ b/src/ios/app/LibraryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LibraryView: View {
     @EnvironmentObject var player: MediaPlayerViewModel
+    @State private var searchText: String = ""
 
     var body: some View {
         List(player.library) { item in
@@ -15,5 +16,13 @@ struct LibraryView: View {
             }
         }
         .onAppear { player.loadLibrary() }
+        .searchable(text: $searchText)
+        .onChange(of: searchText) { text in
+            if text.isEmpty {
+                player.loadLibrary()
+            } else {
+                player.search(text)
+            }
+        }
     }
 }

--- a/src/ios/app/MediaPlayerApp.swift
+++ b/src/ios/app/MediaPlayerApp.swift
@@ -13,6 +13,20 @@ struct MediaPlayerApp: App {
         } catch {
             print("AVAudioSession error: \(error)")
         }
+        NotificationCenter.default.addObserver(forName: AVAudioSession.interruptionNotification,
+                                               object: nil, queue: .main) { n in
+            guard let info = n.userInfo,
+                  let value = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+                  let type = AVAudioSession.InterruptionType(rawValue: value) else { return }
+            if type == .began {
+                player.pause()
+            } else if type == .ended {
+                if let optVal = info[AVAudioSessionInterruptionOptionKey] as? UInt,
+                   AVAudioSession.InterruptionOptions(rawValue: optVal).contains(.shouldResume) {
+                    player.play()
+                }
+            }
+        }
     }
 
     var body: some Scene {

--- a/src/ios/app/MediaPlayerBridge.h
+++ b/src/ios/app/MediaPlayerBridge.h
@@ -15,6 +15,7 @@ extern NSString *const MediaPlayerTrackLoadedNotification;
 - (void)seek:(double)position;
 - (NSArray<NSString *> *)listMedia;
 - (NSArray<NSDictionary *> *)allMedia;
+- (NSArray<NSDictionary *> *)search:(NSString *)query;
 - (NSDictionary *)currentMetadata;
 - (void)nextTrack;
 - (void)previousTrack;

--- a/src/ios/app/MediaPlayerBridge.mm
+++ b/src/ios/app/MediaPlayerBridge.mm
@@ -74,6 +74,24 @@ NSString *const MediaPlayerTrackLoadedNotification = @"MediaPlayerTrackLoaded";
   return arr;
 }
 
+- (NSArray<NSDictionary *> *)search:(NSString *)query {
+  if (!_player)
+    _player = std::make_unique<MediaPlayer>();
+  auto items = _player->searchLibrary(query.UTF8String);
+  NSMutableArray<NSDictionary *> *arr = [NSMutableArray arrayWithCapacity:items.size()];
+  for (const auto &m : items) {
+    NSDictionary *info = @{
+      @"path" : [NSString stringWithUTF8String:m.path.c_str()],
+      @"title" : [NSString stringWithUTF8String:m.title.c_str()],
+      @"artist" : [NSString stringWithUTF8String:m.artist.c_str()],
+      @"album" : [NSString stringWithUTF8String:m.album.c_str()],
+      @"duration" : @(m.duration)
+    };
+    [arr addObject:info];
+  }
+  return arr;
+}
+
 - (NSDictionary *)currentMetadata {
   if (!_player)
     return @{};

--- a/src/ios/app/MediaPlayerViewModel.swift
+++ b/src/ios/app/MediaPlayerViewModel.swift
@@ -77,6 +77,15 @@ class MediaPlayerViewModel: ObservableObject {
         }
     }
 
+    func search(_ query: String) {
+        let items = bridge.search(query) as? [[String: Any]] ?? []
+        library = items.map { dict in
+            MediaItem(path: dict["path"] as? String ?? "",
+                      title: dict["title"] as? String ?? "",
+                      artist: dict["artist"] as? String ?? "")
+        }
+    }
+
     func nextTrack() { bridge.nextTrack() }
     func previousTrack() { bridge.previousTrack() }
     func enableShuffle(_ enabled: Bool) {

--- a/tests/ios/MediaPlayerViewModelTests.swift
+++ b/tests/ios/MediaPlayerViewModelTests.swift
@@ -4,8 +4,13 @@ import XCTest
 class DummyBridge: MediaPlayerBridge {
     var playCalled = false
     var shuffleEnabledFlag = false
+    var lastSearchQuery: String?
     override func play() { playCalled = true }
     override func enableShuffle(_ enabled: Bool) { shuffleEnabledFlag = enabled }
+    override func search(_ query: String) -> [NSDictionary] {
+        lastSearchQuery = query
+        return [["path": "p", "title": "t", "artist": "a"]]
+    }
 }
 
 final class MediaPlayerViewModelTests: XCTestCase {
@@ -20,5 +25,13 @@ final class MediaPlayerViewModelTests: XCTestCase {
         let vm = MediaPlayerViewModel(bridge: bridge)
         vm.toggleShuffle()
         XCTAssertTrue(bridge.shuffleEnabledFlag)
+    }
+
+    func testSearchUpdatesLibrary() {
+        let bridge = DummyBridge()
+        let vm = MediaPlayerViewModel(bridge: bridge)
+        vm.search("hello")
+        XCTAssertEqual(bridge.lastSearchQuery, "hello")
+        XCTAssertEqual(vm.library.first?.title, "t")
     }
 }


### PR DESCRIPTION
## Summary
- add MediaPlayer API for library search
- expose search through MediaPlayerBridge
- update ViewModel and LibraryView with search bar
- handle AVAudioSession interruptions
- extend iOS unit tests for search functionality

## Testing
- `clang-format -i src/core/include/mediaplayer/MediaPlayer.h src/core/src/MediaPlayer.cpp src/ios/app/MediaPlayerBridge.mm`
- ❌ `xcodebuild test` *(fails: xcodebuild not available)*

------
https://chatgpt.com/codex/tasks/task_e_686b3083d8bc833194f6012afd10e7f2