### PR TITLE
Implement voice control for iOS and add build script

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -6,6 +6,12 @@ This directory contains container definitions and helper scripts for building Me
 
 `update_android_wrapper.sh` regenerates the Gradle wrapper jar used by the Android project. Run it from the repository root when CI needs a fresh wrapper.
 
+### iOS build helper
+
+`build_ios.sh` invokes `xcodebuild` to compile the iOS application. It expects
+an Xcode project at `src/ios/MediaPlayerApp.xcodeproj` and requires the Xcode
+command line tools to be installed.
+
 ## Qt build container
 
 `Dockerfile.qt` provides an Ubuntu image with the Qt 6 SDK installed. Use it when you want to compile the desktop application without installing Qt locally.

--- a/devops/build_ios.sh
+++ b/devops/build_ios.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Build the iOS application using xcodebuild.
+# Requires Xcode command line tools installed.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+
+PROJECT="$PROJECT_ROOT/src/ios/MediaPlayerApp.xcodeproj"
+SCHEME="MediaPlayerApp"
+
+if [ ! -d "$PROJECT" ]; then
+  echo "Xcode project not found: $PROJECT" >&2
+  exit 1
+fi
+
+xcodebuild -project "$PROJECT" \
+           -scheme "$SCHEME" \
+           -configuration Release \
+           -destination 'generic/platform=iOS' \
+           build

--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -158,7 +158,7 @@
 | 127 | AVAudioSession Handling | done | relevant |
 | 128 | Remote Command Center | done | relevant |
 | 129 | Gesture Support | done | relevant |
-| 130 | Siri / Voice | open | relevant |
+| 130 | Siri / Voice | done | speech recognition button added in iOS app |
 | 131 | Unit Tests (Swift) | done | relevant |
 | 132 | UI Tests (XCTest/UIAutomation) | done | relevant |
 
@@ -221,7 +221,7 @@
 | 170 | Dockerfile for Core/C++ | done | Dockerfile.core added |
 | 171 | Dockerfile for Qt | done | Dockerfile.qt added |
 | 172 | Android Build Environment | open | relevant |
-| 173 | iOS Build Setup | open | relevant |
+| 173 | iOS Build Setup | done | build script added in devops |
 | 174 | GitHub Actions CI Workflow | done | relevant |
 | 175 | Automated Tests in CI | open | relevant |
 | 176 | Static Analysis & Lint | open | relevant |

--- a/src/ios/README.md
+++ b/src/ios/README.md
@@ -19,3 +19,12 @@ setting its file type to `Objective-C++ Source`.
 
 The SwiftUI views demonstrate basic playback control and can be expanded
 with library browsing and settings screens as tasks are completed.
+
+### Voice Control
+
+`VoiceControl.swift` implements a minimal wrapper around `SFSpeechRecognizer`
+to issue voice commands such as "play", "pause" or "next". The Now Playing
+screen includes a microphone button that activates recognition and dispatches
+the recognized text to `MediaPlayerViewModel.handleVoiceCommand(_:)`.
+Ensure the app Info.plist declares the `NSSpeechRecognitionUsageDescription`
+key so iOS prompts the user for permission to use speech recognition.

--- a/src/ios/app/MediaPlayerViewModel.swift
+++ b/src/ios/app/MediaPlayerViewModel.swift
@@ -111,6 +111,31 @@ class MediaPlayerViewModel: ObservableObject {
         cc.nextTrackCommand.addTarget { _ in self.nextTrack(); return .success }
         cc.previousTrackCommand.addTarget { _ in self.previousTrack(); return .success }
     }
+
+    func handleVoiceCommand(_ text: String) {
+        let command = text.lowercased()
+        if command.contains("play") && !command.contains("pause") {
+            play()
+            return
+        }
+        if command.contains("pause") {
+            pause()
+            return
+        }
+        if command.contains("next") {
+            nextTrack()
+            return
+        }
+        if command.contains("previous") || command.contains("back") {
+            previousTrack()
+            return
+        }
+        search(command)
+        if let first = library.first {
+            _ = open(first.path)
+            play()
+        }
+    }
 }
 
 extension Notification.Name {

--- a/src/ios/app/NowPlayingView.swift
+++ b/src/ios/app/NowPlayingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct NowPlayingView: View {
     @EnvironmentObject var player: MediaPlayerViewModel
+    @StateObject private var voice = VoiceControl()
 
     var body: some View {
         VStack {
@@ -13,11 +14,15 @@ struct NowPlayingView: View {
                     player.isPlaying ? player.pause() : player.play()
                 }
                 Button("Next") { player.nextTrack() }
+                Button(action: { voice.start() }) {
+                    Image(systemName: "mic.fill")
+                }
             }
         }
         .gesture(DragGesture().onEnded { value in
             if value.translation.width < -50 { player.nextTrack() }
             if value.translation.width > 50 { player.previousTrack() }
         })
+        .onAppear { voice.onCommand = { player.handleVoiceCommand($0) } }
     }
 }

--- a/src/ios/app/VoiceControl.swift
+++ b/src/ios/app/VoiceControl.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Speech
+import AVFoundation
+
+class VoiceControl: NSObject {
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private let recognizer = SFSpeechRecognizer()
+
+    var onCommand: ((String) -> Void)?
+
+    func start() {
+        SFSpeechRecognizer.requestAuthorization { auth in
+            guard auth == .authorized else { return }
+            DispatchQueue.main.async {
+                self.beginRecognition()
+            }
+        }
+    }
+
+    private func beginRecognition() {
+        stop()
+        request = SFSpeechAudioBufferRecognitionRequest()
+        guard let request = request else { return }
+        let node = audioEngine.inputNode
+        let format = node.outputFormat(forBus: 0)
+        node.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            request.append(buffer)
+        }
+        task = recognizer?.recognitionTask(with: request) { result, error in
+            if let text = result?.bestTranscription.formattedString {
+                self.onCommand?(text)
+            }
+            if result?.isFinal == true || error != nil {
+                self.stop()
+            }
+        }
+        audioEngine.prepare()
+        try? audioEngine.start()
+    }
+
+    func stop() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        task?.cancel()
+        request = nil
+        task = nil
+    }
+}


### PR DESCRIPTION
## Summary
- implement `VoiceControl` using `SFSpeechRecognizer`
- integrate voice commands in Now Playing view
- expose `handleVoiceCommand` in the iOS view model
- document new feature in iOS README
- add `build_ios.sh` helper and document it
- mark related tasks complete in `parallel_tasks.md`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686b377724b483319e5f26b6fe490845