### PR TITLE
Add iOS project and library integration

### DIFF
--- a/src/ios/MediaPlayerApp.xcodeproj/project.pbxproj
+++ b/src/ios/MediaPlayerApp.xcodeproj/project.pbxproj
@@ -1,0 +1,371 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3A87D423F3F963F534A4D954 /* VoiceControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C6C1ACE906232854E4FD52 /* VoiceControl.swift */; };
+		52273610D5C7F28942D7F1AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCEAD7A90E71FA531D884C65 /* Foundation.framework */; };
+		5CC855AFF19300AC8055FD4F /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C31CF7342AB4C61722A579 /* IntentHandler.swift */; };
+		6825E0897FE5009D8E595F4C /* MediaPlayerBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0B4BF9352862BED1A6490208 /* MediaPlayerBridge.mm */; };
+		69CF428A128FC7D4996BAE3F /* View+OptionalGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BFA5D5AB0EFA08F2330245 /* View+OptionalGesture.swift */; };
+		8BBAF7807E246CCE7126F1AB /* MediaPlayerBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 499BB1E4C81454810BF693CB /* MediaPlayerBridge.h */; };
+		945B0B63ADCCE1B09A3396F7 /* OpenURLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D26AF024CCB5A766009544 /* OpenURLView.swift */; };
+		9FB1EA3FBF9E441527BCA0E5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78C0E3A214E6C8E3FD8AE51 /* ContentView.swift */; };
+		C3A21732C16636A539B083AE /* ShakeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDC4562D07D3105396D3FF7 /* ShakeDetector.swift */; };
+		CECD62E17410569BB5DDB38B /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC81ED3CE823AEA6CE45830 /* LibraryView.swift */; };
+		CF800780930E68863DFA99B2 /* MediaPlayerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66FAF57964544F8422B7639 /* MediaPlayerApp.swift */; };
+		E69FBB62662D0E43EDB4A928 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC679691B1791C8E6C7F3087 /* SettingsView.swift */; };
+		E79BA70BC95500C4FFE1538F /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52321793B760335F76DE89C5 /* NowPlayingView.swift */; };
+		F560B959A4B1D429257A1493 /* MediaPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58524DDFD7927BA0BC66E984 /* MediaPlayerViewModel.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0B4BF9352862BED1A6490208 /* MediaPlayerBridge.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = MediaPlayerBridge.mm; path = src/ios/app/MediaPlayerBridge.mm; sourceTree = "<group>"; };
+		20C6C1ACE906232854E4FD52 /* VoiceControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceControl.swift; path = src/ios/app/VoiceControl.swift; sourceTree = "<group>"; };
+		26BFA5D5AB0EFA08F2330245 /* View+OptionalGesture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "View+OptionalGesture.swift"; path = "src/ios/app/View+OptionalGesture.swift"; sourceTree = "<group>"; };
+		29E9420D3FCC19450C8817B5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = src/ios/app/Info.plist; sourceTree = "<group>"; };
+		499BB1E4C81454810BF693CB /* MediaPlayerBridge.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MediaPlayerBridge.h; path = src/ios/app/MediaPlayerBridge.h; sourceTree = "<group>"; };
+		52321793B760335F76DE89C5 /* NowPlayingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NowPlayingView.swift; path = src/ios/app/NowPlayingView.swift; sourceTree = "<group>"; };
+		56C31CF7342AB4C61722A579 /* IntentHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntentHandler.swift; path = src/ios/app/IntentHandler.swift; sourceTree = "<group>"; };
+		58524DDFD7927BA0BC66E984 /* MediaPlayerViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MediaPlayerViewModel.swift; path = src/ios/app/MediaPlayerViewModel.swift; sourceTree = "<group>"; };
+		6CDC4562D07D3105396D3FF7 /* ShakeDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShakeDetector.swift; path = src/ios/app/ShakeDetector.swift; sourceTree = "<group>"; };
+		9FC81ED3CE823AEA6CE45830 /* LibraryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LibraryView.swift; path = src/ios/app/LibraryView.swift; sourceTree = "<group>"; };
+		A0D26AF024CCB5A766009544 /* OpenURLView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpenURLView.swift; path = src/ios/app/OpenURLView.swift; sourceTree = "<group>"; };
+		AC679691B1791C8E6C7F3087 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsView.swift; path = src/ios/app/SettingsView.swift; sourceTree = "<group>"; };
+		B66FAF57964544F8422B7639 /* MediaPlayerApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MediaPlayerApp.swift; path = src/ios/app/MediaPlayerApp.swift; sourceTree = "<group>"; };
+		BCEAD7A90E71FA531D884C65 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		C78C0E3A214E6C8E3FD8AE51 /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentView.swift; path = src/ios/app/ContentView.swift; sourceTree = "<group>"; };
+		CCD59B8C455AE2C0628BC345 /* MediaPlayerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MediaPlayerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B8C07AB8C369FD01D59B0108 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				52273610D5C7F28942D7F1AF /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1FA25CF244B7062FC77AD1B7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CCD59B8C455AE2C0628BC345 /* MediaPlayerApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		216E804EEF2C873349B0F594 = {
+			isa = PBXGroup;
+			children = (
+				1FA25CF244B7062FC77AD1B7 /* Products */,
+				E0121B05BEC7E42473C90650 /* Frameworks */,
+				C78C0E3A214E6C8E3FD8AE51 /* ContentView.swift */,
+				56C31CF7342AB4C61722A579 /* IntentHandler.swift */,
+				9FC81ED3CE823AEA6CE45830 /* LibraryView.swift */,
+				B66FAF57964544F8422B7639 /* MediaPlayerApp.swift */,
+				58524DDFD7927BA0BC66E984 /* MediaPlayerViewModel.swift */,
+				52321793B760335F76DE89C5 /* NowPlayingView.swift */,
+				A0D26AF024CCB5A766009544 /* OpenURLView.swift */,
+				AC679691B1791C8E6C7F3087 /* SettingsView.swift */,
+				6CDC4562D07D3105396D3FF7 /* ShakeDetector.swift */,
+				26BFA5D5AB0EFA08F2330245 /* View+OptionalGesture.swift */,
+				20C6C1ACE906232854E4FD52 /* VoiceControl.swift */,
+				499BB1E4C81454810BF693CB /* MediaPlayerBridge.h */,
+				0B4BF9352862BED1A6490208 /* MediaPlayerBridge.mm */,
+				29E9420D3FCC19450C8817B5 /* Info.plist */,
+			);
+			sourceTree = "<group>";
+		};
+		BE492702C0A3B10444A005B7 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BCEAD7A90E71FA531D884C65 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		E0121B05BEC7E42473C90650 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BE492702C0A3B10444A005B7 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BCC42F065A80F80B4F1301A5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BBAF7807E246CCE7126F1AB /* MediaPlayerBridge.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		9C7C9D8F834BEDAC5DB3F825 /* MediaPlayerApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B915740EE4FC30D6ACFC5FD7 /* Build configuration list for PBXNativeTarget "MediaPlayerApp" */;
+			buildPhases = (
+				CFC251DF1B1CE916E855C296 /* Sources */,
+				B8C07AB8C369FD01D59B0108 /* Frameworks */,
+				08814C9137A7E9E556783D34 /* Resources */,
+				BCC42F065A80F80B4F1301A5 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MediaPlayerApp;
+			productName = MediaPlayerApp;
+			productReference = CCD59B8C455AE2C0628BC345 /* MediaPlayerApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		85CFCE0F08E36E041B287F1F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+			};
+			buildConfigurationList = 51651A91CA8D71F2A46805E6 /* Build configuration list for PBXProject "MediaPlayerApp" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 216E804EEF2C873349B0F594;
+			productRefGroup = 1FA25CF244B7062FC77AD1B7 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9C7C9D8F834BEDAC5DB3F825 /* MediaPlayerApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		08814C9137A7E9E556783D34 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CFC251DF1B1CE916E855C296 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9FB1EA3FBF9E441527BCA0E5 /* ContentView.swift in Sources */,
+				5CC855AFF19300AC8055FD4F /* IntentHandler.swift in Sources */,
+				CECD62E17410569BB5DDB38B /* LibraryView.swift in Sources */,
+				CF800780930E68863DFA99B2 /* MediaPlayerApp.swift in Sources */,
+				F560B959A4B1D429257A1493 /* MediaPlayerViewModel.swift in Sources */,
+				E79BA70BC95500C4FFE1538F /* NowPlayingView.swift in Sources */,
+				945B0B63ADCCE1B09A3396F7 /* OpenURLView.swift in Sources */,
+				E69FBB62662D0E43EDB4A928 /* SettingsView.swift in Sources */,
+				C3A21732C16636A539B083AE /* ShakeDetector.swift in Sources */,
+				69CF428A128FC7D4996BAE3F /* View+OptionalGesture.swift in Sources */,
+				3A87D423F3F963F534A4D954 /* VoiceControl.swift in Sources */,
+				6825E0897FE5009D8E595F4C /* MediaPlayerBridge.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1B5A22832C9E2101B2FB7B2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		1C58D42EB6831262024DF5F9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../../build/include";
+				INFOPLIST_FILE = src/ios/app/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-lmediaplayer_core";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		41C9F5EB9CFA4AF566E71E2A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/../../build/include";
+				INFOPLIST_FILE = src/ios/app/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-lmediaplayer_core";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DF9A8E3082E1BC3FEC492686 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		51651A91CA8D71F2A46805E6 /* Build configuration list for PBXProject "MediaPlayerApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DF9A8E3082E1BC3FEC492686 /* Debug */,
+				1B5A22832C9E2101B2FB7B2D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B915740EE4FC30D6ACFC5FD7 /* Build configuration list for PBXNativeTarget "MediaPlayerApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41C9F5EB9CFA4AF566E71E2A /* Release */,
+				1C58D42EB6831262024DF5F9 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 85CFCE0F08E36E041B287F1F /* Project object */;
+}

--- a/src/ios/MediaPlayerApp.xcodeproj/xcshareddata/xcschemes/MediaPlayerApp.xcscheme
+++ b/src/ios/MediaPlayerApp.xcodeproj/xcshareddata/xcschemes/MediaPlayerApp.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9C7C9D8F834BEDAC5DB3F825"
+               BuildableName = "MediaPlayerApp.app"
+               BlueprintName = "MediaPlayerApp"
+               ReferencedContainer = "container:MediaPlayerApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C7C9D8F834BEDAC5DB3F825"
+            BuildableName = "MediaPlayerApp.app"
+            BlueprintName = "MediaPlayerApp"
+            ReferencedContainer = "container:MediaPlayerApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C7C9D8F834BEDAC5DB3F825"
+            BuildableName = "MediaPlayerApp.app"
+            BlueprintName = "MediaPlayerApp"
+            ReferencedContainer = "container:MediaPlayerApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C7C9D8F834BEDAC5DB3F825"
+            BuildableName = "MediaPlayerApp.app"
+            BlueprintName = "MediaPlayerApp"
+            ReferencedContainer = "container:MediaPlayerApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/ios/README.md
+++ b/src/ios/README.md
@@ -36,5 +36,14 @@ The **Settings** tab now includes toggles for swipe gestures and the
 to issue voice commands such as "play", "pause" or "next". The Now Playing
 screen includes a microphone button that activates recognition and dispatches
 the recognized text to `MediaPlayerViewModel.handleVoiceCommand(_:)`.
-Ensure the app Info.plist declares the `NSSpeechRecognitionUsageDescription`
-key so iOS prompts the user for permission to use speech recognition.
+
+The app requires the following keys in **Info.plist** so iOS prompts the user
+for access to speech and Siri functionality:
+
+```
+NSSpeechRecognitionUsageDescription
+NSSiriUsageDescription
+```
+
+`devops/build_ios.sh` builds the project from the command line using
+`xcodebuild`.

--- a/src/ios/app/Info.plist
+++ b/src/ios/app/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Speech recognition is used for voice commands.</string>
+    <key>NSSiriUsageDescription</key>
+    <string>Siri is used to control playback.</string>
+</dict>
+</plist>

--- a/src/ios/app/MediaPlayerBridge.h
+++ b/src/ios/app/MediaPlayerBridge.h
@@ -20,6 +20,7 @@ extern NSString *const MediaPlayerTrackLoadedNotification;
 - (void)nextTrack;
 - (void)previousTrack;
 - (void)setCallbacks;
+- (void)setLibraryPath:(NSString *)path;
 - (void)enableShuffle:(BOOL)enabled;
 - (BOOL)shuffleEnabled;
 @end

--- a/src/ios/app/MediaPlayerBridge.mm
+++ b/src/ios/app/MediaPlayerBridge.mm
@@ -1,4 +1,5 @@
 #import "MediaPlayerBridge.h"
+#include "mediaplayer/LibraryDB.h"
 #include "mediaplayer/MediaPlayer.h"
 #include <memory>
 
@@ -10,6 +11,7 @@ NSString *const MediaPlayerTrackLoadedNotification = @"MediaPlayerTrackLoaded";
 
 @interface MediaPlayerBridge () {
   std::unique_ptr<MediaPlayer> _player;
+  std::unique_ptr<LibraryDB> _library;
 }
 @end
 
@@ -141,6 +143,15 @@ NSString *const MediaPlayerTrackLoadedNotification = @"MediaPlayerTrackLoaded";
                                                       userInfo:info];
   };
   _player->setCallbacks(cbs);
+}
+
+- (void)setLibraryPath:(NSString *)path {
+  _library = std::make_unique<LibraryDB>(path.UTF8String);
+  if (_library->open()) {
+    if (!_player)
+      _player = std::make_unique<MediaPlayer>();
+    _player->setLibrary(_library.get());
+  }
 }
 
 - (void)enableShuffle:(BOOL)enabled {

--- a/tests/ios/MediaPlayerViewModelTests.swift
+++ b/tests/ios/MediaPlayerViewModelTests.swift
@@ -4,34 +4,57 @@ import XCTest
 class DummyBridge: MediaPlayerBridge {
     var playCalled = false
     var shuffleEnabledFlag = false
+    var shuffleEnabledReturn = false
     var lastSearchQuery: String?
     override func play() { playCalled = true }
     override func enableShuffle(_ enabled: Bool) { shuffleEnabledFlag = enabled }
+    override func shuffleEnabled() -> Bool { shuffleEnabledReturn }
     override func search(_ query: String) -> [NSDictionary] {
         lastSearchQuery = query
         return [["path": "p", "title": "t", "artist": "a"]]
     }
 }
 
+class MockNowPlayingInfoCenter: MPNowPlayingInfoCenter {
+    var updated = false
+    override var nowPlayingInfo: [String : Any]? {
+        didSet { updated = true }
+    }
+}
+
 final class MediaPlayerViewModelTests: XCTestCase {
     func testPlaySetsState() {
-        let vm = MediaPlayerViewModel(bridge: DummyBridge())
+        let vm = MediaPlayerViewModel(bridge: DummyBridge(), nowPlaying: MockNowPlayingInfoCenter())
         vm.play()
         XCTAssertTrue(vm.isPlaying)
     }
 
     func testToggleShuffleCallsBridge() {
         let bridge = DummyBridge()
-        let vm = MediaPlayerViewModel(bridge: bridge)
+        let vm = MediaPlayerViewModel(bridge: bridge, nowPlaying: MockNowPlayingInfoCenter())
         vm.toggleShuffle()
         XCTAssertTrue(bridge.shuffleEnabledFlag)
     }
 
     func testSearchUpdatesLibrary() {
         let bridge = DummyBridge()
-        let vm = MediaPlayerViewModel(bridge: bridge)
+        let vm = MediaPlayerViewModel(bridge: bridge, nowPlaying: MockNowPlayingInfoCenter())
         vm.search("hello")
         XCTAssertEqual(bridge.lastSearchQuery, "hello")
         XCTAssertEqual(vm.library.first?.title, "t")
+    }
+
+    func testPositionNotificationUpdatesNowPlaying() {
+        let nowPlaying = MockNowPlayingInfoCenter()
+        let vm = MediaPlayerViewModel(bridge: DummyBridge(), nowPlaying: nowPlaying)
+        NotificationCenter.default.post(name: .positionChanged, object: nil, userInfo: ["position": 10.0])
+        XCTAssertTrue(nowPlaying.updated)
+    }
+
+    func testInitReadsShuffleState() {
+        let bridge = DummyBridge()
+        bridge.shuffleEnabledReturn = true
+        let vm = MediaPlayerViewModel(bridge: bridge, nowPlaying: MockNowPlayingInfoCenter())
+        XCTAssertTrue(vm.shuffleEnabled)
     }
 }


### PR DESCRIPTION
## Summary
- create SwiftUI Xcode project with build scheme
- add Info.plist with speech and Siri permissions
- expose `setLibraryPath` in MediaPlayerBridge
- use library path and update Now Playing info from ViewModel
- mention Info.plist keys in README
- extend unit tests for shuffle state and Now Playing updates

## Testing
- `ruby generate_xcodeproj.rb` (to create project)


------
https://chatgpt.com/codex/tasks/task_e_686b403e382883319e80fb61dc4e54bc