### PR TITLE
Update iOS tasks and add AI tagging toggle

### DIFF
--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -144,8 +144,8 @@
 
 | # | Task | Status | Notes |
 |-:|------|--------|-------|
-| 116 | Create Xcode Project | open | relevant |
-| 117 | Include Core Engine | open | relevant |
+| 116 | Create Xcode Project | done | relevant |
+| 117 | Include Core Engine | done | relevant |
 | 118 | Main UI (SwiftUI ContentView) | done | relevant |
 | 119 | Library List View | done | relevant |
 | 120 | Now Playing View | done | relevant |

--- a/src/ios/app/Info.plist
+++ b/src/ios/app/Info.plist
@@ -13,5 +13,7 @@
         <string>INPlayMediaIntent</string>
         <string>INPauseMediaIntent</string>
     </array>
+    <key>EnableAITagging</key>
+    <false/>
 </dict>
 </plist>

--- a/src/ios/app/MediaPlayerViewModel.swift
+++ b/src/ios/app/MediaPlayerViewModel.swift
@@ -21,6 +21,11 @@ class MediaPlayerViewModel: ObservableObject {
     @Published var currentArtist: String = ""
     @Published var library: [MediaItem] = []
     @Published var shuffleEnabled: Bool = false
+    @Published var aiTaggingEnabled: Bool = UserDefaults.standard.bool(forKey: "enableAITagging") {
+        didSet {
+            UserDefaults.standard.set(aiTaggingEnabled, forKey: "enableAITagging")
+        }
+    }
     @Published var currentDuration: Double = 0
     @Published var artwork: UIImage? = nil
 
@@ -28,6 +33,7 @@ class MediaPlayerViewModel: ObservableObject {
         self.bridge = bridge
         self.nowPlayingCenter = nowPlaying
         shuffleEnabled = bridge.shuffleEnabled()
+        aiTaggingEnabled = UserDefaults.standard.bool(forKey: "enableAITagging")
         observers.append(NotificationCenter.default.addObserver(forName: .trackFinished, object: nil, queue: .main) { _ in
             self.isPlaying = false
         })

--- a/src/ios/app/SettingsView.swift
+++ b/src/ios/app/SettingsView.swift
@@ -4,12 +4,14 @@ struct SettingsView: View {
     @AppStorage("darkMode") var darkMode: Bool = false
     @AppStorage("enableShake") var enableShake: Bool = true
     @AppStorage("enableSwipe") var enableSwipe: Bool = true
+    @AppStorage("enableAITagging") var enableAITagging: Bool = false
 
     var body: some View {
         Form {
             Toggle("Dark Mode", isOn: $darkMode)
             Toggle("Shake to Shuffle", isOn: $enableShake)
             Toggle("Swipe Gestures", isOn: $enableSwipe)
+            Toggle("AI Tagging", isOn: $enableAITagging)
         }
     }
 }


### PR DESCRIPTION
## Summary
- mark iOS project setup tasks 116 and 117 as done
- allow AI tagging toggle in the Settings view
- persist AI tagging setting in `MediaPlayerViewModel`
- store default AI tagging value in `Info.plist`

## Testing
- `python3 tools/generate_parallel_tasks.py > parallel_tasks.tmp && mv parallel_tasks.tmp parallel_tasks.md`

------
https://chatgpt.com/codex/tasks/task_e_686c06ed944c8331a36ff700cde7ddf9