### PR TITLE
Add Vosk speech recognition module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ add_subdirectory(src/format_conversion)
 add_subdirectory(src/desktop)
 add_subdirectory(src/desktop/app)
 
+# Voice control via Vosk
+add_subdirectory(src/gesture_voice/vosk)
+
 # Sync module for cross-device playback position sharing
 add_subdirectory(src/sync)
 

--- a/src/gesture_voice/README.md
+++ b/src/gesture_voice/README.md
@@ -1,1 +1,14 @@
 # Gesture & Voice Control
+
+This module integrates the [Vosk](https://alphacephei.com/vosk/) offline speech
+recognition library. The wrapper implementation lives under `vosk/` and expects
+an English model installed locally. To try it out:
+
+1. Download the small English model from the [Vosk models page](https://alphacephei.com/vosk/models) and extract it somewhere, e.g. `models/vosk-model-small-en-us-0.15`.
+2. Pass the absolute model path when constructing `VoskRecognizer` in your
+   application.
+3. Ensure your microphone is accessible. On desktop the wrapper uses Qt
+   Multimedia to capture audio.
+
+Only the model files themselves are required at runtime; they are not stored in
+the repository due to their size.

--- a/src/gesture_voice/vosk/CMakeLists.txt
+++ b/src/gesture_voice/vosk/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(CMAKE_AUTOMOC ON)
+
+add_library(mediaplayer_vosk
+    src/VoskRecognizer.cpp
+    src/VoiceInputQt.cpp
+)
+
+find_package(PkgConfig)
+pkg_check_modules(VOSK REQUIRED IMPORTED_TARGET vosk)
+find_package(Qt6 REQUIRED COMPONENTS Core Multimedia)
+
+target_include_directories(mediaplayer_vosk PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${VOSK_INCLUDE_DIRS}
+)
+
+target_link_libraries(mediaplayer_vosk
+    Qt6::Core
+    Qt6::Multimedia
+    PkgConfig::VOSK
+)
+
+set_target_properties(mediaplayer_vosk PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/src/gesture_voice/vosk/include/mediaplayer/VoiceInputQt.h
+++ b/src/gesture_voice/vosk/include/mediaplayer/VoiceInputQt.h
@@ -1,0 +1,33 @@
+#ifndef MEDIAPLAYER_VOICEINPUTQT_H
+#define MEDIAPLAYER_VOICEINPUTQT_H
+
+#include <QAudioDevice>
+#include <QAudioSource>
+#include <QObject>
+
+namespace mediaplayer {
+
+class VoskRecognizer;
+
+class VoiceInputQt : public QObject {
+  Q_OBJECT
+public:
+  explicit VoiceInputQt(VoskRecognizer *recognizer, QObject *parent = nullptr);
+  ~VoiceInputQt() override;
+
+  void start();
+  void stop();
+
+private slots:
+  void readMore();
+
+private:
+  QAudioDevice m_device;
+  QAudioSource *m_source{nullptr};
+  QIODevice *m_io{nullptr};
+  VoskRecognizer *m_recognizer{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VOICEINPUTQT_H

--- a/src/gesture_voice/vosk/include/mediaplayer/VoskRecognizer.h
+++ b/src/gesture_voice/vosk/include/mediaplayer/VoskRecognizer.h
@@ -1,0 +1,41 @@
+#ifndef MEDIAPLAYER_VOSKRECOGNIZER_H
+#define MEDIAPLAYER_VOSKRECOGNIZER_H
+
+#include <QObject>
+#include <QString>
+#include <atomic>
+#include <string>
+#include <vector>
+
+struct VoskModel;
+struct VoskRecognizer;
+
+namespace mediaplayer {
+
+class VoiceInputQt; // forward declaration
+
+class VoskRecognizer : public QObject {
+  Q_OBJECT
+public:
+  explicit VoskRecognizer(const QString &modelPath, const std::vector<QString> &grammar,
+                          QObject *parent = nullptr);
+  ~VoskRecognizer() override;
+
+  Q_INVOKABLE void startListening();
+  Q_INVOKABLE void stopListening();
+
+  void feedAudio(const int16_t *data, int length);
+
+signals:
+  void commandRecognized(const QString &command);
+
+private:
+  VoskModel *m_model{nullptr};
+  ::VoskRecognizer *m_rec{nullptr};
+  VoiceInputQt *m_input{nullptr};
+  std::atomic<bool> m_active{false};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VOSKRECOGNIZER_H

--- a/src/gesture_voice/vosk/src/VoiceInputQt.cpp
+++ b/src/gesture_voice/vosk/src/VoiceInputQt.cpp
@@ -1,0 +1,43 @@
+#include "mediaplayer/VoiceInputQt.h"
+#include "mediaplayer/VoskRecognizer.h"
+#include <QIODevice>
+#include <QMediaDevices>
+
+using namespace mediaplayer;
+
+VoiceInputQt::VoiceInputQt(VoskRecognizer *recognizer, QObject *parent)
+    : QObject(parent), m_device(QMediaDevices::defaultAudioInput()), m_recognizer(recognizer) {}
+
+VoiceInputQt::~VoiceInputQt() { stop(); }
+
+void VoiceInputQt::start() {
+  if (m_source)
+    return;
+  QAudioFormat fmt;
+  fmt.setSampleRate(16000);
+  fmt.setChannelCount(1);
+  fmt.setSampleFormat(QAudioFormat::Int16);
+  if (m_device.isNull())
+    m_device = QMediaDevices::defaultAudioInput();
+  m_source = new QAudioSource(m_device, fmt, this);
+  m_io = m_source->start();
+  connect(m_io, &QIODevice::readyRead, this, &VoiceInputQt::readMore);
+}
+
+void VoiceInputQt::stop() {
+  if (!m_source)
+    return;
+  disconnect(m_io, nullptr, this, nullptr);
+  m_source->stop();
+  delete m_source;
+  m_source = nullptr;
+  m_io = nullptr;
+}
+
+void VoiceInputQt::readMore() {
+  if (!m_source || !m_recognizer)
+    return;
+  QByteArray data = m_io->readAll();
+  m_recognizer->feedAudio(reinterpret_cast<const int16_t *>(data.constData()),
+                          data.size() / sizeof(int16_t));
+}

--- a/src/gesture_voice/vosk/src/VoskRecognizer.cpp
+++ b/src/gesture_voice/vosk/src/VoskRecognizer.cpp
@@ -1,0 +1,57 @@
+#include "mediaplayer/VoskRecognizer.h"
+#include "mediaplayer/VoiceInputQt.h"
+#include <vosk_api.h>
+
+using namespace mediaplayer;
+
+VoskRecognizer::VoskRecognizer(const QString &modelPath, const std::vector<QString> &grammar,
+                               QObject *parent)
+    : QObject(parent) {
+  vosk_set_log_level(0);
+  m_model = vosk_model_new(modelPath.toUtf8().constData());
+  std::string json = "[";
+  for (size_t i = 0; i < grammar.size(); ++i) {
+    json += '"' + grammar[i].toStdString() + '"';
+    if (i + 1 < grammar.size())
+      json += ',';
+  }
+  json += ']';
+  m_rec = vosk_recognizer_new_grm(m_model, 16000.0f, json.c_str());
+  m_input = new VoiceInputQt(this, this);
+}
+
+VoskRecognizer::~VoskRecognizer() {
+  stopListening();
+  if (m_rec)
+    vosk_recognizer_free(m_rec);
+  if (m_model)
+    vosk_model_free(m_model);
+}
+
+void VoskRecognizer::startListening() {
+  if (m_active.load())
+    return;
+  m_active = true;
+  if (m_input)
+    m_input->start();
+}
+
+void VoskRecognizer::stopListening() {
+  if (!m_active.load())
+    return;
+  m_active = false;
+  if (m_input)
+    m_input->stop();
+}
+
+void VoskRecognizer::feedAudio(const int16_t *data, int length) {
+  if (!m_rec || !m_active.load())
+    return;
+  vosk_recognizer_accept_waveform(m_rec, reinterpret_cast<const char *>(data),
+                                  length * sizeof(int16_t));
+  const char *result = vosk_recognizer_partial_result(m_rec);
+  if (result && *result) {
+    QString res = QString::fromUtf8(result);
+    emit commandRecognized(res);
+  }
+}


### PR DESCRIPTION
## Summary
- add `mediaplayer_vosk` library for offline speech commands
- hook the new module into the root CMakeLists
- implement `VoskRecognizer` and Qt-based audio capture
- document downloading Vosk models for voice control

## Testing
- `clang-format -i src/gesture_voice/vosk/include/mediaplayer/VoskRecognizer.h src/gesture_voice/vosk/include/mediaplayer/VoiceInputQt.h src/gesture_voice/vosk/src/VoskRecognizer.cpp src/gesture_voice/vosk/src/VoiceInputQt.cpp`
- `python tools/generate_parallel_tasks.py > parallel_tasks.tmp && mv parallel_tasks.tmp parallel_tasks.md`

------
https://chatgpt.com/codex/tasks/task_e_686c39802214833180a38c4a7ae13bd3