### PR TITLE
Add Vosk recognizer scaffolding and tests

### DIFF
--- a/src/desktop/app/CMakeLists.txt
+++ b/src/desktop/app/CMakeLists.txt
@@ -13,6 +13,9 @@ add_executable(mediaplayer_desktop_app
     SmartPlaylistManager.cpp
     VideoItem.cpp
     MouseGestureFilter.cpp
+    MicrophoneInput.cpp
+    ../gesture_voice/VoskRecognizer.cpp
+    ../gesture_voice/VoiceCommandProcessor.cpp
     windows/WinIntegration.cpp
     windows/Hotkeys.cpp
     macos/MacIntegration.mm
@@ -61,6 +64,7 @@ target_include_directories(mediaplayer_desktop_app PRIVATE
     ${CMAKE_SOURCE_DIR}/src/core/include
     ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/src/desktop
+    ${CMAKE_SOURCE_DIR}/src/gesture_voice
 )
 
 file(COPY qml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/desktop/app/MicrophoneInput.cpp
+++ b/src/desktop/app/MicrophoneInput.cpp
@@ -1,0 +1,32 @@
+#include "MicrophoneInput.h"
+#include <QAudioDevice>
+#include <QIODevice>
+#include <QMediaDevices>
+
+using namespace mediaplayer;
+
+MicrophoneInput::MicrophoneInput(QObject *parent) : QObject(parent) {
+  m_device = QMediaDevices::defaultAudioInput();
+  m_format.setSampleRate(16000);
+  m_format.setChannelCount(1);
+  m_format.setSampleFormat(QAudioFormat::Int16);
+}
+
+void MicrophoneInput::start() {
+  stop();
+  m_source = new QAudioSource(m_device, m_format, this);
+  QIODevice *io = m_source->start();
+  connect(io, &QIODevice::readyRead, this, [this, io]() {
+    QByteArray data = io->readAll();
+    if (!data.isEmpty())
+      emit audioDataReady(data);
+  });
+}
+
+void MicrophoneInput::stop() {
+  if (m_source) {
+    m_source->stop();
+    m_source->deleteLater();
+    m_source = nullptr;
+  }
+}

--- a/src/desktop/app/MicrophoneInput.h
+++ b/src/desktop/app/MicrophoneInput.h
@@ -1,0 +1,30 @@
+#ifndef MEDIAPLAYER_MICROPHONEINPUT_H
+#define MEDIAPLAYER_MICROPHONEINPUT_H
+
+#include <QAudioDevice>
+#include <QAudioFormat>
+#include <QAudioSource>
+#include <QObject>
+
+namespace mediaplayer {
+
+class MicrophoneInput : public QObject {
+  Q_OBJECT
+
+public:
+  explicit MicrophoneInput(QObject *parent = nullptr);
+  Q_INVOKABLE void start();
+  Q_INVOKABLE void stop();
+
+signals:
+  void audioDataReady(const QByteArray &data);
+
+private:
+  QAudioFormat m_format;
+  QAudioDevice m_device;
+  QAudioSource *m_source{nullptr};
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_MICROPHONEINPUT_H

--- a/src/desktop/app/app.qrc
+++ b/src/desktop/app/app.qrc
@@ -7,6 +7,9 @@
         <file>resources/icons/stop.svg</file>
         <file>resources/icons/shuffle.svg</file>
 </qresource>
+    <qresource prefix="/gesture_voice">
+        <file alias="commands.json">../gesture_voice/commands.json</file>
+    </qresource>
     <qresource prefix="/qml">
         <file>qml/PlaylistItemsDialog.qml</file>
         <file>qml/PlaylistItemsView.qml</file>

--- a/src/desktop/app/qml/Main.qml
+++ b/src/desktop/app/qml/Main.qml
@@ -138,6 +138,18 @@ ApplicationWindow {
                 icon.source: "qrc:/icons/next.svg"
                 onClicked: player.seek(player.position + 10)
             }
+            ToolButton {
+                text: "🎤"
+                onClicked: {
+                    if (voiceRecognizer.running) {
+                        microphoneInput.stop()
+                        voiceRecognizer.stop()
+                    } else {
+                        voiceRecognizer.start()
+                        microphoneInput.start()
+                    }
+                }
+            }
             Label { text: Math.floor(player.position) }
             Slider {
                 id: seekSlider
@@ -149,6 +161,17 @@ ApplicationWindow {
             }
             Label { text: Math.floor(player.duration) }
             Slider { from: 0; to: 1; value: 1; onValueChanged: player.setVolume(value) }
+        } 
+    }
+    Rectangle {
+        anchors.fill: parent
+        color: "#80000000"
+        visible: voiceRecognizer.running
+        z: 10
+        Text {
+            anchors.centerIn: parent
+            text: qsTr("Listening...")
+            color: "white"
         }
     }
 }

--- a/src/gesture_voice/README.md
+++ b/src/gesture_voice/README.md
@@ -1,1 +1,24 @@
 # Gesture & Voice Control
+
+This module contains helpers used by all platforms to recognize and handle
+simple voice commands. Vosk is used for offline speech recognition.
+
+## Command grammar
+
+`commands.json` lists the phrases that the recognizer will listen for. The file
+is loaded by `VoskRecognizer` and passed to Vosk as a grammar to improve
+accuracy. To extend the grammar, add new phrases to the `phrases` array. Example:
+
+```json
+{
+  "phrases": [
+    "play",
+    "pause",
+    "next track",
+    "previous track"
+  ]
+}
+```
+
+After editing the JSON file rebuild the application so the recognizer reloads
+the grammar.

--- a/src/gesture_voice/VoiceCommandProcessor.cpp
+++ b/src/gesture_voice/VoiceCommandProcessor.cpp
@@ -1,0 +1,36 @@
+#include "VoiceCommandProcessor.h"
+#include "desktop/app/MediaPlayerController.h"
+
+using namespace mediaplayer;
+
+VoiceCommandProcessor::VoiceCommandProcessor(MediaPlayerController *ctrl, QObject *parent)
+    : QObject(parent), m_ctrl(ctrl) {}
+
+void VoiceCommandProcessor::processText(const QString &text) {
+  QString cmd = text.toLower();
+  if (cmd.contains("play") && !cmd.contains("pause")) {
+    m_ctrl->play();
+    return;
+  }
+  if (cmd.contains("pause") || cmd.contains("stop")) {
+    m_ctrl->pause();
+    return;
+  }
+  if (cmd.contains("next")) {
+    m_ctrl->nextTrack();
+    return;
+  }
+  if (cmd.contains("previous") || cmd.contains("back")) {
+    m_ctrl->previousTrack();
+    return;
+  }
+  if (cmd.contains("volume up")) {
+    m_ctrl->setVolume(std::min(1.0, m_ctrl->volume() + 0.1));
+    return;
+  }
+  if (cmd.contains("volume down")) {
+    m_ctrl->setVolume(std::max(0.0, m_ctrl->volume() - 0.1));
+    return;
+  }
+  emit commandUnknown(text);
+}

--- a/src/gesture_voice/VoiceCommandProcessor.h
+++ b/src/gesture_voice/VoiceCommandProcessor.h
@@ -1,0 +1,27 @@
+#ifndef MEDIAPLAYER_VOICECOMMANDPROCESSOR_H
+#define MEDIAPLAYER_VOICECOMMANDPROCESSOR_H
+
+#include <QObject>
+
+namespace mediaplayer {
+class MediaPlayerController;
+
+class VoiceCommandProcessor : public QObject {
+  Q_OBJECT
+
+public:
+  explicit VoiceCommandProcessor(MediaPlayerController *ctrl, QObject *parent = nullptr);
+
+public slots:
+  void processText(const QString &text);
+
+signals:
+  void commandUnknown(const QString &text);
+
+private:
+  MediaPlayerController *m_ctrl;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VOICECOMMANDPROCESSOR_H

--- a/src/gesture_voice/VoskRecognizer.cpp
+++ b/src/gesture_voice/VoskRecognizer.cpp
@@ -1,0 +1,68 @@
+#include "VoskRecognizer.h"
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+#include <vosk_api.h>
+
+using namespace mediaplayer;
+
+struct VoskRecognizer::Impl {
+  VoskModel *model{nullptr};
+  VoskRecognizer *rec{nullptr};
+  QByteArray grammar;
+  bool running{false};
+};
+
+VoskRecognizer::VoskRecognizer(QObject *parent) : QObject(parent), m(new Impl) { loadGrammar(); }
+
+void VoskRecognizer::loadGrammar() {
+  QFile f(":/gesture_voice/commands.json");
+  if (!f.open(QIODevice::ReadOnly))
+    return;
+  m->grammar = f.readAll();
+}
+
+bool VoskRecognizer::loadModel(const QString &modelPath) {
+  if (m->model)
+    vosk_model_free(m->model);
+  m->model = vosk_model_new(modelPath.toUtf8().constData());
+  return m->model != nullptr;
+}
+
+bool VoskRecognizer::start() {
+  if (!m->model)
+    return false;
+  if (m->rec)
+    vosk_recognizer_free(m->rec);
+  const char *grammarStr = m->grammar.isEmpty() ? nullptr : m->grammar.constData();
+  m->rec = vosk_recognizer_new_grm(m->model, 16000.0f, grammarStr);
+  m->running = m->rec != nullptr;
+  if (m->running)
+    emit runningChanged(true);
+  return m->running;
+}
+
+void VoskRecognizer::stop() {
+  if (m->rec) {
+    vosk_recognizer_free(m->rec);
+    m->rec = nullptr;
+    m->running = false;
+    emit runningChanged(false);
+  }
+}
+
+void VoskRecognizer::feedAudio(const QByteArray &data) {
+  if (!m->rec)
+    return;
+  int r = vosk_recognizer_accept_waveform(m->rec, (const char *)data.constData(), data.size());
+  if (r) {
+    const char *json = vosk_recognizer_result(m->rec);
+    QJsonDocument doc = QJsonDocument::fromJson(QByteArray(json));
+    QString text = doc.object().value("text").toString();
+    if (!text.isEmpty())
+      emit textRecognized(text);
+  }
+}
+
+bool VoskRecognizer::isRunning() const { return m->running; }

--- a/src/gesture_voice/VoskRecognizer.h
+++ b/src/gesture_voice/VoskRecognizer.h
@@ -1,0 +1,34 @@
+#ifndef MEDIAPLAYER_VOSKRECOGNIZER_H
+#define MEDIAPLAYER_VOSKRECOGNIZER_H
+
+#include <QObject>
+#include <memory>
+
+namespace mediaplayer {
+
+class VoskRecognizer : public QObject {
+  Q_OBJECT
+
+public:
+  explicit VoskRecognizer(QObject *parent = nullptr);
+  Q_INVOKABLE bool loadModel(const QString &modelPath);
+  Q_INVOKABLE bool start();
+  Q_INVOKABLE void stop();
+  Q_INVOKABLE void feedAudio(const QByteArray &data);
+  Q_PROPERTY(bool running READ isRunning NOTIFY runningChanged)
+  bool isRunning() const;
+
+signals:
+  void textRecognized(const QString &text);
+  void error(const QString &message);
+  void runningChanged(bool running);
+
+private:
+  void loadGrammar();
+  struct Impl;
+  std::unique_ptr<Impl> m;
+};
+
+} // namespace mediaplayer
+
+#endif // MEDIAPLAYER_VOSKRECOGNIZER_H

--- a/src/gesture_voice/commands.json
+++ b/src/gesture_voice/commands.json
@@ -1,0 +1,14 @@
+{
+  "phrases": [
+    "play",
+    "pause",
+    "stop",
+    "next track",
+    "previous track",
+    "volume up",
+    "volume down",
+    "mute",
+    "shuffle on",
+    "shuffle off"
+  ]
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,3 +9,9 @@ shows the AI recommendation hook. `stress_load_test.cpp` spawns
 multiple `MediaPlayer` instances to stress test core playback.
 `library_ftssearch_test.cpp` checks full text search queries using SQLite's
 FTS5 module.
+
+Additional tests:
+
+- `voice_sim` contains a Python script that feeds prerecorded audio to the Vosk
+  recognizer and prints the resulting player action.
+- `gesture` holds Qt tests for `MouseGestureFilter`.

--- a/tests/gesture/MouseGestureFilterTest.cpp
+++ b/tests/gesture/MouseGestureFilterTest.cpp
@@ -1,0 +1,27 @@
+#include "desktop/app/MouseGestureFilter.h"
+#include "desktop/app/MediaPlayerController.h"
+#include <QtTest/QtTest>
+
+using namespace mediaplayer;
+
+class MouseGestureFilterTest : public QObject {
+  Q_OBJECT
+private slots:
+  void swipeLeftTriggersNext();
+};
+
+void MouseGestureFilterTest::swipeLeftTriggersNext() {
+  MediaPlayerController ctrl;
+  MouseGestureFilter filter(&ctrl);
+  QSignalSpy spy(&ctrl, &MediaPlayerController::nextTrack);
+  QMouseEvent press(QEvent::MouseButtonPress, QPoint(0, 0), Qt::RightButton, Qt::RightButton,
+                    Qt::NoModifier);
+  filter.eventFilter(nullptr, &press);
+  QMouseEvent release(QEvent::MouseButtonRelease, QPoint(-100, 0), Qt::RightButton, Qt::RightButton,
+                      Qt::NoModifier);
+  filter.eventFilter(nullptr, &release);
+  QCOMPARE(spy.count(), 1);
+}
+
+QTEST_MAIN(MouseGestureFilterTest)
+#include "MouseGestureFilterTest.moc"

--- a/tests/gesture/README.md
+++ b/tests/gesture/README.md
@@ -1,0 +1,11 @@
+# Gesture Tests
+
+Qt based tests to verify mouse gesture recognition. Build and run with:
+
+```bash
+qmake && make
+./MouseGestureFilterTest
+```
+
+The tests synthesize mouse events to ensure `MouseGestureFilter` triggers the
+expected player actions.

--- a/tests/voice_sim/README.md
+++ b/tests/voice_sim/README.md
@@ -1,0 +1,11 @@
+# Voice Simulation Test
+
+This script uses the `vosk` Python package to recognize voice commands from
+pre-recorded WAV files. Usage:
+
+```bash
+python3 run.py ../../src/gesture_voice/commands.json /path/to/vosk-model path/to/audio.wav
+```
+
+The script prints the recognized text and the player action that would be
+triggered. Provide your own Vosk model and sample recordings.

--- a/tests/voice_sim/run.py
+++ b/tests/voice_sim/run.py
@@ -1,0 +1,39 @@
+import json
+import sys
+from vosk import Model, KaldiRecognizer
+import wave
+
+COMMANDS_PATH = sys.argv[1]
+MODEL_PATH = sys.argv[2]
+AUDIO_PATH = sys.argv[3]
+
+with open(COMMANDS_PATH) as f:
+    grammar = json.load(f)["phrases"]
+
+model = Model(MODEL_PATH)
+rec = KaldiRecognizer(model, 16000, json.dumps(grammar))
+wf = wave.open(AUDIO_PATH, "rb")
+
+while True:
+    data = wf.readframes(4000)
+    if len(data) == 0:
+        break
+    if rec.AcceptWaveform(data):
+        pass
+
+result = json.loads(rec.FinalResult())
+text = result.get("text", "")
+print("Recognized:", text)
+
+mapping = {
+    "play": "play",
+    "pause": "pause",
+    "next track": "nextTrack",
+    "previous track": "previousTrack",
+}
+for phrase, action in mapping.items():
+    if phrase in text:
+        print("Action:", action)
+        break
+else:
+    print("Action: none")


### PR DESCRIPTION
## Summary
- define voice command grammar JSON
- implement `VoskRecognizer`, `MicrophoneInput` and `VoiceCommandProcessor`
- wire up desktop UI with new voice features
- show simple indicator while listening
- add example grammar to documentation
- provide Python voice simulation test and Qt gesture test scaffolding

## Testing
- `pip install vosk --user`


------
https://chatgpt.com/codex/tasks/task_e_686c3a32c1ec8331be569ff8137f6798