### PR TITLE
Add basic Android voice command support

### DIFF
--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -136,7 +136,7 @@
 | 110 | MediaSession & Notification | done | relevant |
 | 111 | Permission Handling | done | relevant |
 | 112 | Gesture Detection | done | relevant |
-| 113 | Voice Control (Android) | done | relevant |
+| 113 | Voice Control (Android) | open | relevant |
 | 114 | Instrumented UI Tests | done | relevant |
 | 115 | Compatibility Testing | open | relevant |
 

--- a/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
+++ b/src/android/app/src/main/java/com/example/mediaplayer/NowPlayingFragment.kt
@@ -1,63 +1,130 @@
-package com.example
-    .mediaplayer
+package com.example.mediaplayer
 
-        import android.os.Bundle import android.view.LayoutInflater
-            import android.view.SurfaceHolder import android.view.SurfaceView
-                import android.view.GestureDetector import android.view.MotionEvent import android
-    .view.View import android.view.ViewGroup import android.widget.ImageButton
-        import android.widget.Toast import com.example.mediaplayer.ShakeDetector import
-            androidx.fragment.app.Fragment import androidx.lifecycle.lifecycleScope
-                import kotlinx.coroutines.Dispatchers import kotlinx.coroutines.launch
+import android.content.Intent
+import android.os.Bundle
+import android.view.GestureDetector
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-    class NowPlayingFragment : Fragment(),
-    SurfaceHolder.Callback {
+class NowPlayingFragment : Fragment(), SurfaceHolder.Callback {
 
-private var surface: SurfaceView? = null
+    private var surface: SurfaceView? = null
     private lateinit var detector: GestureDetector
     private lateinit var shakeDetector: ShakeDetector
+    private lateinit var voiceLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(R.layout.fragment_now_playing, container, false)
-    }
+        savedInstanceState: Bundle?,
+    ): View = inflater.inflate(R.layout.fragment_now_playing, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    surface = view.findViewById(R.id.videoSurface) surface ?.holder
-        ?.addCallback(this) detector =
-             GestureDetector(requireContext(), object : GestureDetector.SimpleOnGestureListener(){
-               override fun onFling(e1 : MotionEvent ?, e2 : MotionEvent ?, velocityX : Float,
-                                    velocityY : Float) :
-                   Boolean{if (velocityX > 1000){lifecycleScope.launch(Dispatchers.IO){
-                       MediaPlayerNative.nativeSeek(0.0)}} return true}
-             }) shakeDetector = ShakeDetector(requireContext()) shakeDetector.onShake =
-    { lifecycleScope.launch(Dispatchers.IO){MediaPlayerNative.nativeEnableShuffle(true)} } view
-             .findViewById<ImageButton>(R.id.playPause)
-             .setOnClickListener {
-      lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativePlay() }
+        surface = view.findViewById<SurfaceView>(R.id.videoSurface).also {
+            it.holder.addCallback(this)
+        }
+
+        voiceLauncher = VoiceControl.registerLauncher(this) { results ->
+            results.firstOrNull()?.let { handleVoiceCommand(it) }
+        }
+
+        detector = GestureDetector(requireContext(), object : GestureDetector.SimpleOnGestureListener() {
+            override fun onFling(
+                e1: MotionEvent?,
+                e2: MotionEvent?,
+                velocityX: Float,
+                velocityY: Float,
+            ): Boolean {
+                if (velocityX > 1000) {
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        MediaPlayerNative.nativeSeek(0.0)
+                    }
+                }
+                return true
+            }
+        })
+
+        shakeDetector = ShakeDetector(requireContext()).also { sd ->
+            sd.onShake = {
+                lifecycleScope.launch(Dispatchers.IO) {
+                    MediaPlayerNative.nativeEnableShuffle(true)
+                }
+            }
+        }
+
+        view.findViewById<ImageButton>(R.id.playPause).setOnClickListener {
+            lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativePlay() }
+        }
+        view.findViewById<ImageButton>(R.id.micButton).setOnClickListener {
+            VoiceControl.startVoiceCommand(voiceLauncher)
+        }
+
+        MediaPlayerNative.nativeSetCallback(object : PlaybackListener {
+            override fun onPlaybackFinished() {
+                lifecycleScope.launch(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "Playback finished", Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            override fun onPositionChanged(pos: Double) {}
+        })
+
+        view.setOnTouchListener { _, event -> detector.onTouchEvent(event) }
     }
-    MediaPlayerNative
-        .nativeSetCallback(object : PlaybackListener{
-            override fun onPlaybackFinished(){lifecycleScope.launch(Dispatchers.Main){
-                Toast.makeText(requireContext(), "Playback finished", Toast.LENGTH_SHORT).show()}}
 
-            override fun onPositionChanged(pos : Double){}}) view.setOnTouchListener {
-      _, event->detector.onTouchEvent(event)
+    private fun handleVoiceCommand(text: String) {
+        val command = text.lowercase()
+        when {
+            command.contains("play") && !command.contains("pause") ->
+                lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativePlay() }
+            command.contains("pause") ->
+                lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativePause() }
+            command.contains("next") ->
+                lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativeNextTrack() }
+            command.contains("previous") || command.contains("back") ->
+                lifecycleScope.launch(Dispatchers.IO) { MediaPlayerNative.nativePreviousTrack() }
+        }
     }
-  }
 
-  override fun onDestroyView(){MediaPlayerNative.nativeSetCallback(null) super.onDestroyView()}
+    override fun onDestroyView() {
+        MediaPlayerNative.nativeSetCallback(null)
+        super.onDestroyView()
+    }
 
-  override fun onResume(){super.onResume() shakeDetector.start()}
+    override fun onResume() {
+        super.onResume()
+        shakeDetector.start()
+    }
 
-  override fun onPause(){shakeDetector.stop() super.onPause()}
+    override fun onPause() {
+        shakeDetector.stop()
+        super.onPause()
+    }
 
-  override fun surfaceCreated(holder : SurfaceHolder){
-      MediaPlayerNative.nativeSetSurface(holder.surface)}
+    override fun surfaceCreated(holder: SurfaceHolder) {
+        MediaPlayerNative.nativeSetSurface(holder.surface)
+    }
 
-  override fun surfaceDestroyed(holder : SurfaceHolder){MediaPlayerNative.nativeSetSurface(null)}
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
+        MediaPlayerNative.nativeSetSurface(null)
+    }
 
-  override fun surfaceChanged(holder : SurfaceHolder, format : Int, width : Int, height : Int) {}
+    override fun surfaceChanged(
+        holder: SurfaceHolder,
+        format: Int,
+        width: Int,
+        height: Int,
+    ) {
+    }
 }

--- a/src/android/app/src/main/res/layout/fragment_now_playing.xml
+++ b/src/android/app/src/main/res/layout/fragment_now_playing.xml
@@ -28,6 +28,12 @@
             android:layout_height="wrap_content"
             android:src="@android:drawable/ic_media_play"/>
 
+        <ImageButton
+            android:id="@+id/micButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@android:drawable/ic_btn_speak_now"/>
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add a microphone button to the Android now playing view
- integrate `VoiceControl` in `NowPlayingFragment`
- handle basic voice commands to control playback
- mark the voice control task as open in `parallel_tasks.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c5f6621fc833192a13445f19376f4