### PR TITLE
Add async job processing to AI tagging API

### DIFF
--- a/src/ai_tagging/python/service_api.py
+++ b/src/ai_tagging/python/service_api.py
@@ -1,7 +1,11 @@
 import tempfile
 import os
+from itertools import count
+from typing import Dict, Any
+
 from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import JSONResponse
+
 from genre_classifier import classify_genre
 from mood_detector import detect_mood
 from speech_to_text import transcribe_audio
@@ -9,8 +13,23 @@ from object_scene_detector import detect_objects
 from face_recognition import recognize_faces
 from scene_segmentation import segment_scenes
 from fingerprinter import fingerprint
+from tag_worker import TagWorker
 
 app = FastAPI()
+worker = TagWorker()
+_results: Dict[int, Any] = {}
+_job_ids = count(1)
+
+
+def _enqueue_job(path: str, handler) -> int:
+    job_id = next(_job_ids)
+
+    def _callback(result):
+        _results[job_id] = result
+        os.unlink(path)
+
+    worker.enqueue(path, handler, _callback)
+    return job_id
 
 
 def _save_upload(upload: UploadFile) -> str:
@@ -21,30 +40,43 @@ def _save_upload(upload: UploadFile) -> str:
     return path
 
 
-@app.post("/tag/audio")
-async def tag_audio(file: UploadFile = File(...)):
-    path = _save_upload(file)
-    tags = {
+def _audio_handler(path: str) -> Dict[str, Any]:
+    return {
         "genre": classify_genre(path),
         "mood": detect_mood(path),
         "fingerprint": fingerprint(path),
         "transcript": transcribe_audio(path),
     }
-    os.unlink(path)
-    return JSONResponse(tags)
 
 
-@app.post("/tag/video")
-async def tag_video(file: UploadFile = File(...)):
+@app.post("/tag/audio")
+async def tag_audio(file: UploadFile = File(...)):
     path = _save_upload(file)
-    tags = {
+    job_id = _enqueue_job(path, _audio_handler)
+    return {"job_id": job_id}
+
+
+def _video_handler(path: str) -> Dict[str, Any]:
+    return {
         "objects": detect_objects(path),
         "faces": recognize_faces(path),
         "scenes": segment_scenes(path),
         "transcript": transcribe_audio(path),
     }
-    os.unlink(path)
-    return JSONResponse(tags)
+
+
+@app.post("/tag/video")
+async def tag_video(file: UploadFile = File(...)):
+    path = _save_upload(file)
+    job_id = _enqueue_job(path, _video_handler)
+    return {"job_id": job_id}
+
+
+@app.get("/result/{job_id}")
+async def get_result(job_id: int):
+    if job_id in _results:
+        return JSONResponse(_results.pop(job_id))
+    return JSONResponse({"status": "pending"})
 
 
 if __name__ == "__main__":

--- a/src/ai_tagging/python/tag_worker.py
+++ b/src/ai_tagging/python/tag_worker.py
@@ -1,23 +1,29 @@
 import asyncio
+import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Any
-from collections import deque
+
 
 
 class TagWorker:
-    def __init__(self, loop: asyncio.AbstractEventLoop | None = None):
+    """Process tagging jobs concurrently using a worker pool."""
+
+    def __init__(self, *, max_workers: int | None = None, loop: asyncio.AbstractEventLoop | None = None):
         self.loop = loop or asyncio.get_event_loop()
-        self.queue: deque[tuple[str, Callable[[Any], None], Callable[[str], Any]]] = deque()
-        self.running = False
+        self.max_workers = max_workers or os.cpu_count() or 1
+        self.queue: asyncio.Queue[tuple[str, Callable[[str], Any], Callable[[Any], None]]] = asyncio.Queue()
+        self.executor = ThreadPoolExecutor(max_workers=self.max_workers)
+        self.workers = [self.loop.create_task(self._worker()) for _ in range(self.max_workers)]
 
-    def enqueue(self, path: str, handler: Callable[[str], Any], callback: Callable[[Any], None]):
-        self.queue.append((path, callback, handler))
-        if not self.running:
-            self.loop.create_task(self._run())
-            self.running = True
+    def enqueue(self, path: str, handler: Callable[[str], Any], callback: Callable[[Any], None]) -> None:
+        """Add a job to the queue."""
+        self.queue.put_nowait((path, handler, callback))
 
-    async def _run(self):
-        while self.queue:
-            path, callback, handler = self.queue.popleft()
-            result = await self.loop.run_in_executor(None, handler, path)
-            callback(result)
-        self.running = False
+    async def _worker(self) -> None:
+        while True:
+            path, handler, callback = await self.queue.get()
+            try:
+                result = await self.loop.run_in_executor(self.executor, handler, path)
+                callback(result)
+            finally:
+                self.queue.task_done()

--- a/tests/ai_tagging_test.py
+++ b/tests/ai_tagging_test.py
@@ -18,16 +18,27 @@ def profile(func, path):
     print(result)
 
 
+def wait_result(job_id):
+    while True:
+        resp = requests.get(f'http://localhost:8000/result/{job_id}')
+        data = resp.json()
+        if data.get('status') != 'pending':
+            return data
+        time.sleep(0.5)
+
+
 def main():
     def call_audio(_):
         with open(AUDIO, 'rb') as f:
             resp = requests.post('http://localhost:8000/tag/audio', files={'file': f})
-        return resp.json()
+        job_id = resp.json()['job_id']
+        return wait_result(job_id)
 
     def call_video(_):
         with open(VIDEO, 'rb') as f:
             resp = requests.post('http://localhost:8000/tag/video', files={'file': f})
-        return resp.json()
+        job_id = resp.json()['job_id']
+        return wait_result(job_id)
 
     profile(call_audio, AUDIO)
     profile(call_video, VIDEO)


### PR DESCRIPTION
## Summary
- queue tagging requests via TagWorker and provide `/result/{job_id}` endpoint
- document asynchronous endpoints and worker behavior
- update test script for new API usage
- improve TagWorker concurrency with a thread pool

## Testing
- `python -m py_compile src/ai_tagging/python/service_api.py src/ai_tagging/python/tag_worker.py tests/ai_tagging_test.py`


------
https://chatgpt.com/codex/tasks/task_e_686d470d6d548331957c17c7e302f556