### PR TITLE
Add Android build Dockerfile & update tasks

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,0 +1,24 @@
+FROM openjdk:17-slim
+
+ENV ANDROID_HOME=/sdk
+ENV PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/33.0.2:$ANDROID_HOME/ndk/23.2.8568313"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p $ANDROID_HOME/cmdline-tools && \
+    cd /tmp && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O cmdline-tools.zip && \
+    unzip -q cmdline-tools.zip && \
+    rm cmdline-tools.zip && \
+    mv cmdline-tools $ANDROID_HOME/cmdline-tools/latest && \
+    yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_HOME \
+        "platform-tools" \
+        "platforms;android-33" \
+        "build-tools;33.0.2" \
+        "ndk;23.2.8568313"
+
+WORKDIR /app
+COPY . /app
+
+CMD ["/bin/bash"]

--- a/devops/README.md
+++ b/devops/README.md
@@ -38,3 +38,19 @@ docker run --rm -it \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     mediaplayer-qt /build/mediaplayer_desktop_app
 ```
+
+## Android build container
+
+`Dockerfile.android` installs the Android SDK and NDK so the app can be built without a local Android Studio install.
+
+### Build the image
+
+```bash
+docker build -f Dockerfile.android -t mediaplayer-android .
+```
+
+Run the container to access the SDK tools or execute Gradle builds:
+
+```bash
+docker run --rm -it mediaplayer-android
+```

--- a/parallel_tasks.md
+++ b/parallel_tasks.md
@@ -138,7 +138,7 @@
 | 112 | Gesture Detection | done | relevant |
 | 113 | Voice Control (Android) | done | implemented in `VoiceControl.kt` |
 | 114 | Instrumented UI Tests | done | relevant |
-| 115 | Compatibility Testing | open | relevant |
+| 115 | Compatibility Testing | done | see `.github/workflows/android.yml` |
 
 ## iOS App (Swift UI/UIKit + Core bridging) ([Tasks.MD](Tasks.MD#ios-app-swift-uiuikit-core-bridging))
 


### PR DESCRIPTION
## Summary
- mark Android compatibility testing task as done
- add `Dockerfile.android` for Android SDK/NDK build environment
- document how to build `Dockerfile.android`
- regenerate `parallel_tasks.md`

## Testing
- `python tools/generate_parallel_tasks.py > parallel_tasks.tmp && mv parallel_tasks.tmp parallel_tasks.md`

------
https://chatgpt.com/codex/tasks/task_e_686d9f22cc248331848abec56bc42f57