### PR TITLE
Add GoogleTest framework and sample tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,15 @@ add_subdirectory(src/sync)
 add_subdirectory(src/visualization)
 
 add_subdirectory(src/tools)
+
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+  enable_testing()
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/heads/main.zip
+  )
+  FetchContent_MakeAvailable(googletest)
+  add_subdirectory(tests)
+endif()

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,5 @@ Helpful documents for working with the project:
 - [Merge Strategy](merge_strategy.md)
 - [Git Submodules](submodules.md)
 - [Cloud Sync Server](cloud_sync_server.md)
+- [Performance and Battery Testing](performance_testing.md)
+- [Automated Regression Suite](regression_suite.md)

--- a/docs/building.md
+++ b/docs/building.md
@@ -78,14 +78,12 @@ This produces static libraries for the core engine, media library, subtitle pars
 
 ## Building the test executables
 
-The test programs in `tests/` can also be built with CMake. Configure the project with testing enabled and build the desired targets:
+Unit and integration tests use GoogleTest. Enable them at configure time:
 
 ```bash
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
-    cmake --build . --target test_srtparser format_conversion_test library_playlist_test \
-    library_db_update_test library_playback_update_test library_rating_test \
-    library_search_test library_video_metadata_test subtitle_provider_test \
-    library_recommender_test video_conversion_test
+cmake --build .
+ctest --output-on-failure
 ```
 
 Each test target corresponds to a source file in the `tests/` directory.

--- a/docs/performance_testing.md
+++ b/docs/performance_testing.md
@@ -1,0 +1,36 @@
+# Performance and Battery Testing
+
+This document outlines basic steps for profiling the application and measuring power usage.
+
+## Memory and CPU Profiling
+
+### Linux
+1. Build the project with debug symbols: `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..`
+2. Run the player under `valgrind --tool=massif` to profile heap allocations.
+3. Use `valgrind --tool=callgrind` or `perf record` to capture CPU hotspots.
+4. Visualise the results with `ms_print` for Massif or `kcachegrind` for Callgrind data.
+
+### macOS
+1. Open the Xcode project and choose Product > Profile.
+2. Use the **Instruments** tool to run the **Time Profiler** and **Allocations** templates.
+3. Inspect call stacks to identify heavy functions and leaks.
+
+### Windows
+1. Build with Visual Studio in Release mode with debug info.
+2. Use the **Performance Profiler** (Alt+F2) to collect CPU Usage and Memory Usage traces.
+3. The **Diagnostic Tools** window provides real time allocations and call graphs.
+
+## Battery Consumption
+
+On mobile platforms measure battery drain while playing media for a fixed duration.
+
+### Android
+1. Connect the device via ADB and ensure it is fully charged.
+2. Start playback then run `adb shell dumpsys batterystats --enable full` to reset stats.
+3. After the test duration retrieve stats with `adb shell dumpsys batterystats --charged > stats.txt`.
+4. Review the power usage section for the app's UID.
+
+### iOS
+1. Use **Xcode Instruments** with the **Energy Log** template.
+2. Start recording before launching the app and stop after playback finishes.
+3. Compare the energy impact graph to identify regressions.

--- a/docs/regression_suite.md
+++ b/docs/regression_suite.md
@@ -1,0 +1,20 @@
+# Automated Regression Suite
+
+The project uses GoogleTest for unit and integration tests. When `BUILD_TESTS` is
+enabled CMake builds several test executables under `tests/`. The regression
+suite runs these binaries via `ctest` and can be integrated into CI.
+
+## Running Locally
+
+```bash
+cmake -S . -B build -DBUILD_TESTS=ON
+cmake --build build
+cd build && ctest --output-on-failure
+```
+
+## Continuous Integration
+
+CI jobs should configure the project with `BUILD_TESTS=ON` and execute `ctest`.
+Additional scripts like `tests/end_to_end.py` can be invoked to simulate user
+flows. Failing tests will mark the job failed preventing regressions from
+entering `main`.

--- a/src/desktop/app/main.cpp
+++ b/src/desktop/app/main.cpp
@@ -28,6 +28,7 @@
 #include <QQuickStyle>
 #include <QStandardPaths>
 #include <QtQml/qqml.h>
+#include <chrono>
 #ifdef Q_OS_MAC
 void setupMacIntegration(mediaplayer::MediaPlayerController *controller);
 void connectNowPlayingInfo(mediaplayer::MediaPlayerController *controller);
@@ -39,11 +40,17 @@ void setupWindowsIntegration();
 #endif
 
 int main(int argc, char *argv[]) {
+  auto start = std::chrono::steady_clock::now();
   QQuickStyle::setStyle("Material");
   QGuiApplication app(argc, argv);
 
   qInfo() << "MediaPlayer core version:"
           << QString::fromStdString(mediaplayer::MediaPlayer::version());
+
+  auto afterApp = std::chrono::steady_clock::now();
+  qInfo() << "Startup time:"
+          << std::chrono::duration_cast<std::chrono::milliseconds>(afterApp - start).count()
+          << "ms";
 
   mediaplayer::SettingsManager settings;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(format_converter_test format_converter_test.cpp)
+    target_link_libraries(format_converter_test PRIVATE mediaplayer_conversion gtest_main)
+
+        add_executable(library_db_test library_db_test.cpp)
+            target_link_libraries(library_db_test PRIVATE mediaplayer_library gtest_main)
+
+                add_executable(visualizer_test visualizer_test.cpp)
+                    target_link_libraries(visualizer_test PRIVATE mediaplayer_core gtest_main)
+
+                        add_executable(playback_integration_test playback_integration_test.cpp)
+                            target_link_libraries(
+                                playback_integration_test PRIVATE mediaplayer_core gtest_main)
+
+                                include(GoogleTest) gtest_discover_tests(format_converter_test)
+                                    gtest_discover_tests(library_db_test)
+                                        gtest_discover_tests(visualizer_test)
+                                            gtest_discover_tests(playback_integration_test)

--- a/tests/end_to_end.py
+++ b/tests/end_to_end.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+from pathlib import Path
+
+BIN_DIR = Path(__file__).resolve().parent
+
+TESTS = [
+    'format_converter_test',
+    'library_db_test',
+    'visualizer_test',
+    'playback_integration_test'
+]
+
+
+def main():
+    for t in TESTS:
+        exe = BIN_DIR / t
+        if not exe.exists():
+            print(f'Skip {t} (not built)')
+            continue
+        print(f'Running {t}...')
+        subprocess.run([str(exe)], check=True)
+    print('End-to-end script finished')
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/format_converter_test.cpp
+++ b/tests/format_converter_test.cpp
@@ -1,0 +1,53 @@
+#include "mediaplayer/FormatConverter.h"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <vector>
+
+using mediaplayer::FormatConverter;
+
+static void createTestWav(const std::string &path) {
+  const int sampleRate = 8000;
+  const int seconds = 1;
+  std::vector<int16_t> samples(sampleRate * seconds, 0);
+  std::ofstream f(path, std::ios::binary);
+  int32_t chunkSize = 36 + samples.size() * sizeof(int16_t);
+  f.write("RIFF", 4);
+  f.write(reinterpret_cast<const char *>(&chunkSize), 4);
+  f.write("WAVEfmt ", 8);
+  int32_t subChunk1 = 16;
+  f.write(reinterpret_cast<const char *>(&subChunk1), 4);
+  int16_t audioFormat = 1;
+  f.write(reinterpret_cast<const char *>(&audioFormat), 2);
+  int16_t channels = 1;
+  f.write(reinterpret_cast<const char *>(&channels), 2);
+  int32_t rate = sampleRate;
+  f.write(reinterpret_cast<const char *>(&rate), 4);
+  int32_t byteRate = rate * channels * 2;
+  f.write(reinterpret_cast<const char *>(&byteRate), 4);
+  int16_t blockAlign = channels * 2;
+  f.write(reinterpret_cast<const char *>(&blockAlign), 2);
+  int16_t bits = 16;
+  f.write(reinterpret_cast<const char *>(&bits), 2);
+  f.write("data", 4);
+  int32_t dataSize = samples.size() * sizeof(int16_t);
+  f.write(reinterpret_cast<const char *>(&dataSize), 4);
+  f.write(reinterpret_cast<const char *>(samples.data()), dataSize);
+}
+
+TEST(FormatConverter, AsyncCancel) {
+  const std::string in = "converter_test.wav";
+  const std::string out = "converter_out.mp3";
+  createTestWav(in);
+  FormatConverter conv;
+  bool doneCalled = false;
+  conv.convertAudioAsync(in, out, {}, {}, [&](bool ok) {
+    doneCalled = true;
+    EXPECT_FALSE(ok);
+  });
+  conv.cancel();
+  conv.wait();
+  EXPECT_TRUE(doneCalled);
+  EXPECT_FALSE(conv.isRunning());
+  std::remove(in.c_str());
+  std::remove(out.c_str());
+}

--- a/tests/library_db_test.cpp
+++ b/tests/library_db_test.cpp
@@ -1,0 +1,19 @@
+#include "mediaplayer/LibraryDB.h"
+#include <gtest/gtest.h>
+
+using mediaplayer::LibraryDB;
+
+TEST(LibraryDB, BasicCrud) {
+  LibraryDB db(":memory:");
+  ASSERT_TRUE(db.open());
+  ASSERT_TRUE(db.addMedia("song.mp3", "Song", "Artist", "Album"));
+  auto all = db.allMedia();
+  EXPECT_EQ(all.size(), 1u);
+  EXPECT_EQ(all[0].title, "Song");
+  ASSERT_TRUE(db.createPlaylist("pl"));
+  ASSERT_TRUE(db.addToPlaylist("pl", "song.mp3"));
+  auto items = db.playlistItems("pl");
+  EXPECT_EQ(items.size(), 1u);
+  EXPECT_EQ(items[0].path, "song.mp3");
+  db.close();
+}

--- a/tests/playback_integration_test.cpp
+++ b/tests/playback_integration_test.cpp
@@ -1,0 +1,53 @@
+#include "mediaplayer/MediaPlayer.h"
+#include "mediaplayer/NullAudioOutput.h"
+#include "mediaplayer/NullVideoOutput.h"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <vector>
+
+using mediaplayer::MediaPlayer;
+using mediaplayer::NullAudioOutput;
+using mediaplayer::NullVideoOutput;
+
+static void createTestWav(const std::string &path) {
+  const int sampleRate = 8000;
+  const int seconds = 1;
+  std::vector<int16_t> samples(sampleRate * seconds, 0);
+  std::ofstream f(path, std::ios::binary);
+  int32_t chunkSize = 36 + samples.size() * sizeof(int16_t);
+  f.write("RIFF", 4);
+  f.write(reinterpret_cast<const char *>(&chunkSize), 4);
+  f.write("WAVEfmt ", 8);
+  int32_t subChunk1 = 16;
+  f.write(reinterpret_cast<const char *>(&subChunk1), 4);
+  int16_t audioFormat = 1;
+  f.write(reinterpret_cast<const char *>(&audioFormat), 2);
+  int16_t channels = 1;
+  f.write(reinterpret_cast<const char *>(&channels), 2);
+  int32_t rate = sampleRate;
+  f.write(reinterpret_cast<const char *>(&rate), 4);
+  int32_t byteRate = rate * channels * 2;
+  f.write(reinterpret_cast<const char *>(&byteRate), 4);
+  int16_t blockAlign = channels * 2;
+  f.write(reinterpret_cast<const char *>(&blockAlign), 2);
+  int16_t bits = 16;
+  f.write(reinterpret_cast<const char *>(&bits), 2);
+  f.write("data", 4);
+  int32_t dataSize = samples.size() * sizeof(int16_t);
+  f.write(reinterpret_cast<const char *>(&dataSize), 4);
+  f.write(reinterpret_cast<const char *>(samples.data()), dataSize);
+}
+
+TEST(MediaPlayerIntegration, OpenAndStop) {
+  const std::string file = "playback_test.wav";
+  createTestWav(file);
+  MediaPlayer player;
+  player.setAudioOutput(std::make_unique<NullAudioOutput>());
+  player.setVideoOutput(std::make_unique<NullVideoOutput>());
+  ASSERT_TRUE(player.open(file));
+  player.play();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  player.stop();
+  EXPECT_FALSE(player.isPlaying());
+  std::remove(file.c_str());
+}

--- a/tests/visualizer_test.cpp
+++ b/tests/visualizer_test.cpp
@@ -1,0 +1,19 @@
+#include "mediaplayer/Visualizer.h"
+#include <gtest/gtest.h>
+
+using mediaplayer::Visualizer;
+
+class DummyVis : public Visualizer {
+public:
+  void onAudioPCM(const int16_t *samples, size_t count, int, int) override {
+    called = count > 0 && samples;
+  }
+  bool called{false};
+};
+
+TEST(Visualizer, CallbackInvoked) {
+  DummyVis vis;
+  int16_t sample[2] = {0, 0};
+  vis.onAudioPCM(sample, 2, 44100, 2);
+  EXPECT_TRUE(vis.called);
+}


### PR DESCRIPTION
## Summary
- integrate GoogleTest via CMake option `BUILD_TESTS`
- add unit tests for `FormatConverter`, `LibraryDB`, `Visualizer` and a playback integration test
- provide simple end-to-end test runner
- log startup time in desktop `main.cpp`
- document profiling, battery testing and regression suite

## Testing
- `cmake -B build -DBUILD_TESTS=ON` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_686f17dfefe08331be8bf6fc322f81ff