### PR TITLE
Add unified CMake tests and CI documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,34 @@ jobs:
     env:
       SKIP_OFFLINE_TESTS: 'true'
     steps:
+      # Checkout repository sources
       - uses: actions/checkout@v3
+
+      # Reuse previous build artifacts when possible
       - name: Cache build
         uses: actions/cache@v3
         with:
           path: build
           key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-cmake-
+      # Install CMake
       - uses: actions/setup-cmake@v3
+
+      # Configure the project and enable the test suite
       - name: Configure
-        run: cmake -B build -S .
+        run: cmake -B build -S . -DBUILD_TESTS=ON
+
+      # Build all targets including tests
       - name: Build
         run: cmake --build build --config Release
+
+      # Execute the C++ test suite with CTest
       - name: Run C++ tests
         run: |
           cd build
           ctest --output-on-failure
+
+      # Execute Python unit tests
       - name: Run Python tests
         run: python -m unittest discover -s tests -p '*_test.py'
       - name: Run iOS tests
@@ -46,7 +58,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      # Checkout sources for linting
       - uses: actions/checkout@v3
+
+      # Cache build directory for clang-tidy
       - name: Cache build
         uses: actions/cache@v3
         with:
@@ -54,13 +69,20 @@ jobs:
           key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-cmake-
       - uses: actions/setup-cmake@v3
+      # Generate compile commands for clang-tidy
       - name: Configure
         run: cmake -B build -S . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      # Install formatting tools
       - name: Install clang tools
         run: sudo apt-get update && sudo apt-get install -y clang-tidy clang-format
+
+      # Run clang-tidy static analysis
       - name: clang-tidy
         run: |
           find src -name '*.cpp' -o -name '*.h' | xargs clang-tidy --warnings-as-errors='*' -p build
+
+      # Ensure code is formatted correctly
       - name: clang-format check
         run: |
           find src -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,9 @@ add_subdirectory(src/sync)
 add_subdirectory(src/visualization)
 
 add_subdirectory(src/tools)
+
+option(BUILD_TESTS "Build test programs" OFF)
+if(BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/docs/building.md
+++ b/docs/building.md
@@ -78,27 +78,30 @@ This produces static libraries for the core engine, media library, subtitle pars
 
 ## Building the test executables
 
-The test programs in `tests/` can also be built with CMake. Configure the project with testing enabled and build the desired targets:
+The test programs in `tests/` can also be built with CMake. Configure the project
+with testing enabled to generate a single `test` target which builds all
+executables:
 
 ```bash
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
-    cmake --build . --target test_srtparser format_conversion_test library_playlist_test \
-    library_db_update_test library_playback_update_test library_rating_test \
-    library_search_test library_video_metadata_test subtitle_provider_test \
-    library_recommender_test video_conversion_test
+cmake --build . --target test
 ```
 
-Each test target corresponds to a source file in the `tests/` directory.
+Use CTest to run the entire suite:
+
+```bash
+ctest --output-on-failure
+```
 
 ## Running the tests
 
-After building, run a test binary from the build directory, for example:
+Execute all tests with CTest from the build directory:
 
 ```bash
-./test_srtparser
+ctest --output-on-failure
 ```
 
-Successful execution prints a short confirmation message.
+Each executable prints a short confirmation message on success.
 
 ## Building the conversion utility
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,70 @@
+# Test suite for MediaPlayer
+
+# The tests are simple executables using assert() for validation.
+# Each executable is registered with CTest so `ctest` runs the full suite.
+
+# Subtitles tests
+add_executable(test_srtparser test_srtparser.cpp)
+target_link_libraries(test_srtparser PRIVATE mediaplayer_subtitles)
+add_test(NAME test_srtparser COMMAND test_srtparser)
+
+add_executable(subtitle_provider_test subtitle_provider_test.cpp)
+target_link_libraries(subtitle_provider_test PRIVATE mediaplayer_subtitles)
+add_test(NAME subtitle_provider_test COMMAND subtitle_provider_test)
+
+add_executable(subtitle_decoder_test subtitle_decoder_test.cpp)
+target_link_libraries(subtitle_decoder_test PRIVATE mediaplayer_core)
+add_test(NAME subtitle_decoder_test COMMAND subtitle_decoder_test)
+
+# Format conversion tests
+add_executable(format_conversion_test format_conversion_test.cpp)
+target_link_libraries(format_conversion_test PRIVATE mediaplayer_conversion)
+add_test(NAME format_conversion_test COMMAND format_conversion_test)
+
+add_executable(video_conversion_test video_conversion_test.cpp)
+target_link_libraries(video_conversion_test PRIVATE mediaplayer_conversion)
+add_test(NAME video_conversion_test COMMAND video_conversion_test)
+
+# Media library tests
+set(LIBRARY_TESTS
+    library_playlist_test
+    library_autoplaylist_test
+    library_db_update_test
+    library_playback_update_test
+    library_rating_test
+    library_search_test
+    library_smartplaylist_test
+    library_cleanup_test
+    library_purge_removed_test
+    library_recommender_test
+    library_rescan_update_test
+    library_ftssearch_test
+    library_ignore_nonmedia_test
+    library_invalid_filter_test
+    library_smartquery_test
+    library_video_metadata_test
+    library_video_notag_index_test
+)
+foreach(t ${LIBRARY_TESTS})
+    add_executable(${t} ${t}.cpp)
+    target_link_libraries(${t} PRIVATE mediaplayer_library)
+    add_test(NAME ${t} COMMAND ${t})
+endforeach()
+
+# Networking and sync tests
+add_executable(remote_control_test remote_control_test.cpp)
+target_link_libraries(remote_control_test PRIVATE Qt6::Core Qt6::Network mediaplayer_network)
+add_test(NAME remote_control_test COMMAND remote_control_test)
+
+add_executable(mdns_service_test mdns_service_test.cpp)
+target_link_libraries(mdns_service_test PRIVATE mediaplayer_sync)
+add_test(NAME mdns_service_test COMMAND mdns_service_test)
+
+add_executable(upnp_enum_test upnp_enum_test.cpp)
+target_link_libraries(upnp_enum_test PRIVATE mediaplayer_network)
+add_test(NAME upnp_enum_test COMMAND upnp_enum_test)
+
+# Core stress test
+add_executable(stress_load_test stress_load_test.cpp)
+target_link_libraries(stress_load_test PRIVATE mediaplayer_core)
+add_test(NAME stress_load_test COMMAND stress_load_test)


### PR DESCRIPTION
## Summary
- integrate new `BUILD_TESTS` option in CMake and add `tests/` subdirectory
- create `tests/CMakeLists.txt` to build and register all C++ tests with CTest
- update building guide for unified `test` target
- document CI steps and enable tests in GitHub Actions workflow

## Testing
- `cmake -B build -S . -DBUILD_TESTS=ON` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_686f176f5f5c8331af73145a4e38ef48