### PR TITLE
Measure desktop startup time

### DIFF
--- a/src/desktop/app/template/main.cpp
+++ b/src/desktop/app/template/main.cpp
@@ -1,12 +1,20 @@
+#include <QDebug>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <chrono>
 
 int main(int argc, char *argv[]) {
+  auto startupBegin = std::chrono::steady_clock::now();
   QGuiApplication app(argc, argv);
   QQmlApplicationEngine engine;
   const QUrl url = QUrl::fromLocalFile("qml/Main.qml");
   engine.load(url);
   if (engine.rootObjects().isEmpty())
     return -1;
+  auto startupEnd = std::chrono::steady_clock::now();
+  double startupSeconds = std::chrono::duration<double>(startupEnd - startupBegin).count();
+  qInfo() << "Startup completed in" << startupSeconds << "seconds";
+  if (!qEnvironmentVariableIsEmpty("MEASURE_STARTUP"))
+    return 0;
   return app.exec();
 }

--- a/tools/startup_time.sh
+++ b/tools/startup_time.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Build and measure startup time of the desktop app
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+BUILD_DIR="${REPO_ROOT}/build_startup"
+
+cmake -S "$REPO_ROOT" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release >/dev/null
+cmake --build "$BUILD_DIR" --target mediaplayer_desktop_app >/dev/null
+
+OUTPUT=$(MEASURE_STARTUP=1 "$BUILD_DIR/mediaplayer_desktop_app" 2>&1)
+SECONDS_VAL=$(echo "$OUTPUT" | grep -Eo '[0-9]+(\.[0-9]+)?(?= seconds)' | head -n1)
+echo "$OUTPUT" | grep 'Startup completed' || true
+if [ -n "$SECONDS_VAL" ]; then
+    if awk -v s="$SECONDS_VAL" 'BEGIN{exit s<2?0:1}'; then
+        echo "Startup time ${SECONDS_VAL}s (PASS)"
+    else
+        echo "Startup time ${SECONDS_VAL}s exceeds threshold" >&2
+        exit 1
+    fi
+else
+    echo "Failed to measure startup time" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- instrument desktop main.cpp with startup timing
- add similar timestamp logic to template main.cpp
- add `tools/startup_time.sh` to build and check startup time under 2 seconds

## Testing
- `bash tools/startup_time.sh` *(fails: Qt not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f175677d88331aad0b440e28b7e46