### PR TITLE
Add playback integration test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,7 @@ playlist management in the SQLite library. `library_smartplaylist_test.cpp`
 demonstrates smart playlist creation and `library_recommender_test.cpp`
 shows the AI recommendation hook. `stress_load_test.cpp` spawns
 multiple `MediaPlayer` instances to stress test core playback.
+`playback_integration_test.cpp` confirms basic playback state transitions.
 `library_ftssearch_test.cpp` checks full text search queries using SQLite's
 FTS5 module.
 

--- a/tests/playback_integration_test.cpp
+++ b/tests/playback_integration_test.cpp
@@ -1,0 +1,74 @@
+#include "mediaplayer/MediaPlayer.h"
+#include "mediaplayer/NullAudioOutput.h"
+#include "mediaplayer/NullVideoOutput.h"
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace mediaplayer;
+
+static void createTestWav(const std::string &path) {
+  const int sampleRate = 44100;
+  const int seconds = 1;
+  const int16_t amplitude = 1000;
+  std::vector<int16_t> samples(sampleRate * seconds);
+  for (int i = 0; i < sampleRate * seconds; ++i) {
+    samples[i] = (i % 100 < 50 ? amplitude : -amplitude);
+  }
+  std::ofstream f(path, std::ios::binary);
+  int32_t chunkSize = 36 + samples.size() * sizeof(int16_t);
+  f.write("RIFF", 4);
+  f.write(reinterpret_cast<const char *>(&chunkSize), 4);
+  f.write("WAVEfmt ", 8);
+  int32_t subChunk1 = 16;
+  int16_t audioFormat = 1;
+  int16_t numChannels = 1;
+  int32_t byteRate = sampleRate * numChannels * sizeof(int16_t);
+  int16_t blockAlign = numChannels * sizeof(int16_t);
+  int16_t bitsPerSample = 16;
+  f.write(reinterpret_cast<const char *>(&subChunk1), 4);
+  f.write(reinterpret_cast<const char *>(&audioFormat), 2);
+  f.write(reinterpret_cast<const char *>(&numChannels), 2);
+  f.write(reinterpret_cast<const char *>(&sampleRate), 4);
+  f.write(reinterpret_cast<const char *>(&byteRate), 4);
+  f.write(reinterpret_cast<const char *>(&blockAlign), 2);
+  f.write(reinterpret_cast<const char *>(&bitsPerSample), 2);
+  f.write("data", 4);
+  int32_t dataSize = samples.size() * sizeof(int16_t);
+  f.write(reinterpret_cast<const char *>(&dataSize), 4);
+  f.write(reinterpret_cast<const char *>(samples.data()), dataSize);
+}
+
+int main() {
+  const std::string path = "tests/sample_media/sample.wav";
+  if (!std::filesystem::exists(path))
+    createTestWav(path);
+
+  MediaPlayer player;
+  player.setAudioOutput(std::make_unique<NullAudioOutput>());
+  player.setVideoOutput(std::make_unique<NullVideoOutput>());
+
+  enum class State { Stopped, Playing, Ended } state = State::Stopped;
+  PlaybackCallbacks cb;
+  cb.onPlay = [&]() { state = State::Playing; };
+  cb.onFinished = [&]() { state = State::Ended; };
+  player.setCallbacks(cb);
+
+  assert(player.open(path));
+  player.play();
+
+  auto start = std::chrono::steady_clock::now();
+  while (state != State::Ended &&
+         std::chrono::steady_clock::now() - start < std::chrono::seconds(5)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  player.stop();
+  assert(state == State::Ended);
+  std::cout << "Playback integration test passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a playback integration test that verifies Stopped->Playing->Ended transitions
- generate a sample WAV on demand if none exists
- document the new test in `tests/README.md`

## Testing
- `clang-format -i tests/playback_integration_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686f174a60948331907576acfe919f5d