### PR TITLE
Add visualizer sine wave test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,3 +17,14 @@ Additional tests:
 - `gesture` holds Qt tests for `MouseGestureFilter`.
 - `upnp_enum_test.cpp` enumerates DLNA servers on the local network.
 - `sync/test_sync_local.py` exercises mDNS discovery and HTTP sync between two running instances.
+- `visualizer_sine_test.cpp` feeds a 440 Hz sine wave to `BasicVisualizer` and
+  asserts that the generated frequency spectrum contains non-zero values.
+
+To verify the visualizer test manually, build it from the repository root:
+
+```bash
+g++ -std=c++17 tests/visualizer_sine_test.cpp \
+    -Isrc/visualization/include -Isrc/core/include -o visualizer_test
+./visualizer_test
+```
+The program should exit without triggering the assertion.

--- a/tests/visualizer_sine_test.cpp
+++ b/tests/visualizer_sine_test.cpp
@@ -1,0 +1,30 @@
+#include "mediaplayer/BasicVisualizer.h"
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+int main() {
+  const int sampleRate = 44100;
+  const int channels = 1;
+  const int seconds = 1;
+  const double freq = 440.0;
+  const int16_t amplitude = 16000;
+  std::vector<int16_t> pcm(sampleRate * seconds * channels);
+  for (int i = 0; i < static_cast<int>(pcm.size()); ++i) {
+    double t = static_cast<double>(i) / sampleRate;
+    pcm[i] = static_cast<int16_t>(std::sin(2.0 * M_PI * freq * t) * amplitude);
+  }
+
+  mediaplayer::BasicVisualizer vis;
+  vis.onAudioPCM(pcm.data(), pcm.size(), sampleRate, channels);
+  auto spec = vis.spectrum();
+  bool nonZero = false;
+  for (float v : spec) {
+    if (v > 0.0f) {
+      nonZero = true;
+      break;
+    }
+  }
+  assert(nonZero && "Visualizer output is all zeros");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a simple program that feeds a sine wave buffer to `BasicVisualizer`
- document manual visualizer test steps in `tests/README.md`

## Testing
- `clang-format -i tests/visualizer_sine_test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_686f17446ddc8331a367a71b75e8f98c