### PR TITLE
Add GoogleTest core unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,8 @@ add_subdirectory(src/sync)
 add_subdirectory(src/visualization)
 
 add_subdirectory(src/tools)
+
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/docs/building.md
+++ b/docs/building.md
@@ -24,7 +24,7 @@ sudo apt-get install -y build-essential cmake git \
     libcurl4-openssl-dev \
     nlohmann-json3-dev \
     libsqlite3-dev libtag1-dev libpulse-dev libpulse-simple-dev \
-    libprojectM-dev
+    libprojectM-dev libgtest-dev
 ```
 
 
@@ -89,6 +89,14 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
 ```
 
 Each test target corresponds to a source file in the `tests/` directory.
+
+The GoogleTest-based suite can be built and run with:
+
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
+cmake --build . --target core_unit_tests
+./core_unit_tests
+```
 
 ## Running the tests
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_package(GTest REQUIRED)
+
+add_executable(core_unit_tests
+    core_unit_tests.cpp)
+
+target_link_libraries(core_unit_tests
+    GTest::gtest_main
+    mediaplayer_core
+    mediaplayer_conversion)
+
+set_target_properties(core_unit_tests PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON)

--- a/tests/core_unit_tests.cpp
+++ b/tests/core_unit_tests.cpp
@@ -1,0 +1,91 @@
+#include "mediaplayer/AudioConverter.h"
+#include "mediaplayer/MediaPlayer.h"
+#include "mediaplayer/NullAudioOutput.h"
+#include "mediaplayer/NullVideoOutput.h"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <thread>
+
+using namespace mediaplayer;
+
+static void createTestWav(const std::string &path) {
+  const int sampleRate = 44100;
+  const int seconds = 1;
+  const int16_t amplitude = 1000;
+  std::vector<int16_t> samples(sampleRate * seconds);
+  for (int i = 0; i < sampleRate * seconds; ++i) {
+    samples[i] = (i % 100 < 50 ? amplitude : -amplitude);
+  }
+  std::ofstream f(path, std::ios::binary);
+  int32_t chunkSize = 36 + samples.size() * sizeof(int16_t);
+  f.write("RIFF", 4);
+  f.write(reinterpret_cast<const char *>(&chunkSize), 4);
+  f.write("WAVEfmt ", 8);
+  int32_t subChunk1 = 16;
+  int16_t audioFormat = 1;
+  int16_t numChannels = 1;
+  int32_t byteRate = sampleRate * numChannels * sizeof(int16_t);
+  int16_t blockAlign = numChannels * sizeof(int16_t);
+  int16_t bitsPerSample = 16;
+  f.write(reinterpret_cast<const char *>(&subChunk1), 4);
+  f.write(reinterpret_cast<const char *>(&audioFormat), 2);
+  f.write(reinterpret_cast<const char *>(&numChannels), 2);
+  f.write(reinterpret_cast<const char *>(&sampleRate), 4);
+  f.write(reinterpret_cast<const char *>(&byteRate), 4);
+  f.write(reinterpret_cast<const char *>(&blockAlign), 2);
+  f.write(reinterpret_cast<const char *>(&bitsPerSample), 2);
+  f.write("data", 4);
+  int32_t dataSize = samples.size() * sizeof(int16_t);
+  f.write(reinterpret_cast<const char *>(&dataSize), 4);
+  f.write(reinterpret_cast<const char *>(samples.data()), dataSize);
+}
+
+class MediaPlayerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    wavPath = "test_input.wav";
+    mp3Path = "test_output.mp3";
+    createTestWav(wavPath);
+    player.setAudioOutput(std::make_unique<NullAudioOutput>());
+    player.setVideoOutput(std::make_unique<NullVideoOutput>());
+    ASSERT_TRUE(player.open(wavPath));
+  }
+
+  void TearDown() override {
+    player.stop();
+    std::remove(wavPath.c_str());
+    std::remove(mp3Path.c_str());
+  }
+
+  MediaPlayer player;
+  std::string wavPath;
+  std::string mp3Path;
+};
+
+TEST_F(MediaPlayerTest, OpenFileReadsDuration) {
+  EXPECT_NEAR(player.metadata().duration, 1.0, 0.1);
+}
+
+TEST_F(MediaPlayerTest, PauseStopsPositionAdvance) {
+  player.play();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  player.pause();
+  double pos = player.position();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_NEAR(player.position(), pos, 0.05);
+}
+
+TEST_F(MediaPlayerTest, FormatConversionWorks) {
+  AudioConverter conv;
+  AudioEncodeOptions opts;
+  opts.bitrate = 64000;
+  bool ok = conv.convert(wavPath, mp3Path, opts);
+  EXPECT_TRUE(ok);
+  std::ifstream f(mp3Path, std::ios::binary);
+  EXPECT_TRUE(f.good());
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- install gtest in docs and add BUILD_TESTS option
- add test target `core_unit_tests`
- document building the new suite

## Testing
- `cmake .. -DBUILD_TESTS=ON` *(fails: could not complete configuration due to missing Qt6 components)*

------
https://chatgpt.com/codex/tasks/task_e_686f1736be0083318bef9c9f274ef867