### PR TITLE
Add performance profiling utilities

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,3 +20,4 @@ Additional tests:
 - `startup_time_test.cpp` measures how quickly the `MediaPlayer` instance can open a file.
 - `format_compatibility.py` runs `format_probe` against media samples to verify various container support.
 - `mobile/android_battery_test.sh` automates battery drain measurement on Android devices.
+- `performance/memory_cpu_profile.sh` profiles memory and CPU usage under Valgrind.

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,9 @@
+# Performance Tests
+
+This directory holds utilities for measuring MediaPlayer's performance. The `memory_cpu_profile.sh` script runs the desktop application under Valgrind's Massif and Callgrind tools to capture memory and CPU usage.
+
+Usage:
+```bash
+./memory_cpu_profile.sh <media_file>
+```
+The resulting `massif.txt` and `callgrind.out` reports can be inspected manually.

--- a/tests/performance/memory_cpu_profile.sh
+++ b/tests/performance/memory_cpu_profile.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run memory and CPU profiling on MediaPlayer.
+# Usage: ./memory_cpu_profile.sh <media_file>
+set -e
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <media_file>" >&2
+  exit 1
+fi
+MEDIA=$1
+ROOT=$(dirname "$(dirname "$0")")
+TOOLS="$ROOT/../tools"
+EXEC=mediaplayer_desktop_app
+if [ ! -x "$EXEC" ]; then
+  echo "$EXEC binary not found. Build the project first." >&2
+  exit 1
+fi
+$TOOLS/memory_profile.sh ./$EXEC "$MEDIA"
+$TOOLS/cpu_profile.sh ./$EXEC "$MEDIA"


### PR DESCRIPTION
## Summary
- create `performance` test directory with scripts
- document performance profiling in `tests/README.md`

## Testing
- `bash tests/performance/memory_cpu_profile.sh` *(fails: binary not built)*

------
https://chatgpt.com/codex/tasks/task_e_687026038ca883319e559c7a3364aa22