### PR TITLE
Add regression suite script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,8 @@ jobs:
         run: cmake -B build -S .
       - name: Build
         run: cmake --build build --config Release
-      - name: Run C++ tests
-        run: |
-          cd build
-          ctest --output-on-failure
-      - name: Run Python tests
-        run: python -m unittest discover -s tests -p '*_test.py'
+      - name: Regression suite
+        run: bash tests/run_regression_suite.sh
       - name: Run iOS tests
         if: matrix.os == 'macos-latest'
         run: xcodebuild test -scheme MediaPlayer -destination 'platform=iOS Simulator,name=iPhone 14'

--- a/docs/regression_suite.md
+++ b/docs/regression_suite.md
@@ -6,18 +6,18 @@ suite runs these binaries via `ctest` and can be integrated into CI.
 
 ## Running Locally
 
+The helper script `tests/run_regression_suite.sh` builds the project with
+tests enabled and executes the full suite of checks.
+
 ```bash
-cmake -S . -B build -DBUILD_TESTS=ON
-cmake --build build
-cd build && ctest --output-on-failure
+./tests/run_regression_suite.sh
 ```
 
 ## Continuous Integration
 
-CI jobs should configure the project with `BUILD_TESTS=ON` and execute `ctest`.
-Additional scripts like `tests/end_to_end.py` can be invoked to simulate user
-flows. Failing tests will mark the job failed preventing regressions from
-entering `main`.
+CI jobs should run `tests/run_regression_suite.sh` to build the project with
+tests enabled and execute all checks. Failing tests will mark the job failed
+preventing regressions from entering `main`.
 
 ### UI Responsiveness
 

--- a/tests/run_regression_suite.sh
+++ b/tests/run_regression_suite.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${ROOT_DIR}/build"
+
+cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DBUILD_TESTS=ON "$@"
+cmake --build "$BUILD_DIR"
+
+pushd "$BUILD_DIR" >/dev/null
+ctest --output-on-failure
+popd >/dev/null
+
+python -m unittest discover -s "$ROOT_DIR/tests" -p "*_test.py"
+
+python "$SCRIPT_DIR/end_to_end.py"
+


### PR DESCRIPTION
## Summary
- add `run_regression_suite.sh` to build & run tests
- document how to run the regression suite
- use the script in CI

## Testing
- `bash tests/run_regression_suite.sh --help` *(fails: CMakeLists not found)*

------
https://chatgpt.com/codex/tasks/task_e_687061a3852883318167668d7e7bd9a2