### PR TITLE
Add optional QML test to regression suite

### DIFF
--- a/docs/regression_suite.md
+++ b/docs/regression_suite.md
@@ -22,6 +22,7 @@ preventing regressions from entering `main`.
 ### UI Responsiveness
 
 The Qt test harness `tests/ui_responsiveness.qml` simulates a large library scan
-while checking that the main window continues to process events. Run it manually
-with `qmltestrunner` or integrate into CI using the same command. A short guide
-is provided in `docs/ui_responsiveness_test.md`.
+while checking that the main window continues to process events. If
+`qmltestrunner` is installed, `tests/run_regression_suite.sh` will automatically
+execute the QML test. Otherwise it can be run manually with the same command.
+A short guide is provided in `docs/ui_responsiveness_test.md`.

--- a/tests/run_regression_suite.sh
+++ b/tests/run_regression_suite.sh
@@ -14,5 +14,11 @@ popd >/dev/null
 
 python -m unittest discover -s "$ROOT_DIR/tests" -p "*_test.py"
 
+if command -v qmltestrunner >/dev/null 2>&1; then
+    qmltestrunner "$ROOT_DIR/tests/ui_responsiveness.qml"
+else
+    echo "Warning: qmltestrunner not found; skipping UI responsiveness test" >&2
+fi
+
 python "$SCRIPT_DIR/end_to_end.py"
 


### PR DESCRIPTION
## Summary
- extend `tests/run_regression_suite.sh` with an optional `qmltestrunner` call
- update regression suite docs to mention the new step

## Testing
- `command -v qmltestrunner || echo "not found"`
- `tests/run_regression_suite.sh 2>&1 | head -n 20` *(fails: couldn't find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_687175adcb208331b98e2913469ec2ae